### PR TITLE
chore: remove automatic claude.md file creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Like in metallurgy—where combining two elements yields a stronger alloy—Aill
 
 Ailloy helps you:
 
-- **Initialize AI-ready projects**: Set up `CLAUDE.md` configuration and template structure
+- **Initialize AI-ready projects**: Set up command template structure for AI-assisted workflows
 - **Customize templates**: Configure team-specific defaults for consistent workflows
 - **Manage AI templates**: Access pre-built templates for common development tasks
 - **Standardize AI workflows**: Use consistent patterns for GitHub issues, PRs, and development tasks
@@ -234,7 +234,7 @@ When both global and project configurations exist:
 
 **Alpha Stage**: Ailloy is an early-stage tool focused on Claude Code integration. The CLI provides:
 
-- ✅ Project initialization with `CLAUDE.md` setup
+- ✅ Project initialization with command template setup
 - ✅ Template management and viewing
 - ✅ Template customization with team-specific variables
 - ✅ YAML configuration system with global and project scopes

--- a/internal/commands/init.go
+++ b/internal/commands/init.go
@@ -75,50 +75,6 @@ func initProject() error {
 	}
 	fmt.Println()
 
-	// Create CLAUDE.md configuration file
-	claudePath := "CLAUDE.md"
-	claudeContent := `# Claude Code Configuration
-
-This project is set up with Ailloy templates for AI-assisted development workflows.
-
-## Available Commands
-
-The following command templates are available in the ` + "`.claude/commands/`" + ` directory:
-
-- **create-issue**: Generate well-formatted GitHub issues with proper structure
-- **start-issue**: Fetch GitHub issue details and begin implementation
-- **open-pr**: Create pull requests with structured descriptions
-- **pr-description**: Generate comprehensive PR descriptions
-- **pr-comments**: Respond to PR review comments efficiently
-- **pr-review**: Conduct comprehensive code reviews with silent/interactive modes
-- **update-pr**: Update existing pull requests
-
-## Usage
-
-To use a command template:
-
-1. Open the template file from the ` + "`.claude/commands/`" + ` directory
-2. Copy the template content into your Claude Code conversation
-3. Use the command syntax specified in the template
-
-## Project Setup
-
-This project was initialized with Ailloy to provide structured AI workflows for:
-- GitHub issue management
-- Pull request workflows
-- Development task automation
-
-For more information about Ailloy, visit: https://github.com/nimble-giant/ailloy
-`
-
-	fmt.Println(styles.InfoStyle.Render("📝 Creating CLAUDE.md configuration..."))
-	//#nosec G306 -- CLAUDE.md needs to be readable by IDE/tools
-	if err := os.WriteFile(claudePath, []byte(claudeContent), 0644); err != nil {
-		return fmt.Errorf("failed to create CLAUDE.md file: %w", err)
-	}
-	fmt.Println(styles.SuccessStyle.Render("✅ Created configuration: ") + styles.CodeStyle.Render(claudePath))
-	fmt.Println()
-
 	// Copy template files from embedded templates
 	if err := copyTemplateFiles(); err != nil {
 		return fmt.Errorf("failed to copy template files: %w", err)
@@ -131,13 +87,20 @@ For more information about Ailloy, visit: https://github.com/nimble-giant/ailloy
 	fmt.Println()
 	
 	// Summary box
-	summary := styles.SuccessBoxStyle.Render(
-		styles.SuccessStyle.Render("🎉 Setup Complete!\n\n") +
-		styles.FoxBullet("Claude Code configuration: ") + styles.CodeStyle.Render("CLAUDE.md") + "\n" +
+	summaryContent := styles.SuccessStyle.Render("🎉 Setup Complete!\n\n") +
 		styles.FoxBullet("Command templates: ") + styles.CodeStyle.Render(".claude/commands/") + "\n" +
-		styles.FoxBullet("Ready for AI-powered development! 🚀"),
-	)
-	
+		styles.FoxBullet("Ready for AI-powered development! 🚀")
+
+	// Check if CLAUDE.md exists and suggest creating one if not
+	if _, err := os.Stat("CLAUDE.md"); os.IsNotExist(err) {
+		summaryContent += "\n\n" +
+			styles.InfoStyle.Render("💡 Tip: ") +
+			"No " + styles.CodeStyle.Render("CLAUDE.md") + " detected. " +
+			"Run " + styles.CodeStyle.Render("/init") + " in Claude Code to create one."
+	}
+
+	summary := styles.SuccessBoxStyle.Render(summaryContent)
+
 	fmt.Println(summary)
 	
 	return nil


### PR DESCRIPTION
## Description

Removes automatic `CLAUDE.md` file creation from the CLI `init` command and instead suggests users create it within Claude Code. This change shifts the responsibility of generating the configuration file to Claude Code itself, where it can be more intelligently created based on the project context.

The init command now:
- Skips creating `CLAUDE.md` automatically
- Checks if `CLAUDE.md` exists and displays a helpful tip if it doesn't
- Directs users to run `/init` in Claude Code to generate the configuration file

Updated documentation to reflect that project initialization sets up command template structure rather than explicitly creating `CLAUDE.md`.

## Related Issue

N/A

## Testing

Verified that:
- The init command completes successfully without creating `CLAUDE.md`
- The summary message displays the helpful tip when `CLAUDE.md` is not present
- The summary message does not display the tip when `CLAUDE.md` already exists
- All existing template copying functionality remains intact

## UAT

1. Run `ailloy init` in a new project directory
2. Verify that `.claude/commands/` directory is created with templates
3. Verify that `CLAUDE.md` is NOT created
4. Verify that the success message includes a tip about running `/init` in Claude Code
5. Create a `CLAUDE.md` file manually and run `ailloy init` again
6. Verify that the tip no longer appears in the success message

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [x] I have updated documentation (if applicable)
- [x] My commits have DCO sign-off (`git commit -s`)

https://claude.ai/code/session_01QLj8DqD9cWA8739saxZXRV