### PR TITLE
feat: allows ignoring templates

### DIFF
--- a/.ailloy/ailloy.yaml
+++ b/.ailloy/ailloy.yaml
@@ -1,0 +1,5 @@
+templates:
+  ignore:
+    - ci.yml
+    - release.yml
+    - security.yml

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,6 +32,7 @@ type TemplateConfig struct {
 	AutoUpdate      bool              `yaml:"auto_update"`
 	Repositories    []string          `yaml:"repositories"`
 	Variables       map[string]string `yaml:"variables"`
+	Ignore          []string          `yaml:"ignore"` // Patterns to exclude from template list
 }
 
 // WorkflowConfig holds workflow definitions


### PR DESCRIPTION
Adds functionality to ignore templates based on filename, template name, or full path. This allows users to exclude certain templates, such as CI/CD workflows, from the list of available options.

A new `ignore` field has been added to the `TemplateConfig` struct to store the patterns to be ignored. The `isIgnored` function checks if a template should be ignored based on these patterns.

The config is loaded to get ignore patterns.

## Description

Brief description of changes.

## Related Issue

Fixes #(issue number)

## Testing

Describe how you tested these changes.

## UAT

Describe how we can test your changes.

## Checklist

- [ ] I have read the CONTRIBUTING guidelines
- [ ] My code follows the project style
- [ ] I have added tests (if applicable)
- [ ] I have updated documentation (if applicable)
- [ ] My commits have DCO sign-off (`git commit -s`)
