### PR TITLE
fix: use --json flag in gh commands to avoid projects classic deprecation

### DIFF
--- a/.claude/commands/open-pr.md
+++ b/.claude/commands/open-pr.md
@@ -18,7 +18,7 @@ When this command is used, Claude will:
 
 1. **Enter Plan Mode** to outline the PR creation/update process
 
-2. **Check for existing PR** on the current branch using `gh pr view`
+2. **Check for existing PR** on the current branch using `gh pr view --json number,title,url,state`
 
 3. **If PR already exists**:
    - Use `/update-pr` to update the existing PR description

--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -18,7 +18,7 @@ Fetch a GitHub issue and begin implementation.
 
 When this command is used, Claude will:
 
-1. **Fetch the issue details** using `gh issue view <issue-number>`
+1. **Fetch the issue details** using `gh issue view <issue-number> --json title,body,author,state,labels,assignees,milestone,number,url,comments`
 
 2. **Create a todo list** with tasks derived from the issue requirements
 
@@ -40,14 +40,16 @@ When this command is used, Claude will:
 
 ### Fetching Issue Details
 
+**IMPORTANT:** Always use `--json` to avoid GitHub Projects (classic) deprecation errors.
+
 ```bash
-gh issue view <URL or issue-number>
+gh issue view <URL or issue-number> --json title,body,author,state,labels,assignees,milestone,number,url,comments
 ```
 
 Examples:
 
-- `gh issue view https://github.com/your-org/your-repo/issues/1234`
-- `gh issue view 1234` (when in the repository directory)
+- `gh issue view 1234 --json title,body,author,state,labels,assignees,milestone,number,url,comments`
+- `gh issue view https://github.com/your-org/your-repo/issues/1234 --json title,body,author,state,labels,assignees,milestone,number,url,comments`
 
 ## Notes
 

--- a/.claude/commands/update-pr.md
+++ b/.claude/commands/update-pr.md
@@ -14,7 +14,7 @@ When this command is used, Claude will:
 
 1. **Enter Plan Mode** to outline the PR update process
 
-2. **Verify PR exists** for the current branch using `gh pr view`
+2. **Verify PR exists** for the current branch using `gh pr view --json number,title,url,state`
 
 3. **Generate updated description** using `/pr-description` command
    - Analyzes current branch changes against main

--- a/ailloy/commands/open-pr.md
+++ b/ailloy/commands/open-pr.md
@@ -16,7 +16,7 @@ When this command is used, Claude will:
 
 1. **Enter Plan Mode** to outline the PR creation/update process
 
-2. **Check for existing PR** on the current branch using `gh pr view`
+2. **Check for existing PR** on the current branch using `gh pr view --json number,title,url,state`
 
 3. **If PR already exists**:
    - Use `/update-pr` to update the existing PR description

--- a/ailloy/commands/start-issue.md
+++ b/ailloy/commands/start-issue.md
@@ -15,7 +15,7 @@ Refer to the full template documentation for detailed instructions.
 
 When this command is used, Claude will:
 
-1. **Fetch the issue details** using `gh issue view <issue-number>`
+1. **Fetch the issue details** using `gh issue view <issue-number> --json title,body,author,state,labels,assignees,milestone,number,url,comments`
 
 2. **Create a todo list** with tasks derived from the issue requirements
 
@@ -36,8 +36,10 @@ When this command is used, Claude will:
 
 ## GitHub CLI Commands
 
+**IMPORTANT:** Always use `--json` to avoid GitHub Projects (classic) deprecation errors.
+
 ```bash
-gh issue view <URL or issue-number>
+gh issue view <URL or issue-number> --json title,body,author,state,labels,assignees,milestone,number,url,comments
 ```
 
 

--- a/ailloy/commands/update-pr.md
+++ b/ailloy/commands/update-pr.md
@@ -13,7 +13,7 @@ When this command is used, Claude will:
 
 1. **Enter Plan Mode** to outline the PR update process
 
-2. **Verify PR exists** for the current branch using `gh pr view`
+2. **Verify PR exists** for the current branch using `gh pr view --json number,title,url,state`
 
 3. **Generate updated description** using `/pr-description` command
    - Analyzes current branch changes against main

--- a/pkg/templates/claude/commands/open-pr.md
+++ b/pkg/templates/claude/commands/open-pr.md
@@ -18,7 +18,7 @@ When this command is used, Claude will:
 
 1. **Enter Plan Mode** to outline the PR creation/update process
 
-2. **Check for existing PR** on the current branch using `gh pr view`
+2. **Check for existing PR** on the current branch using `gh pr view --json number,title,url,state`
 
 3. **If PR already exists**:
    - Use `/update-pr` to update the existing PR description

--- a/pkg/templates/claude/commands/start-issue.md
+++ b/pkg/templates/claude/commands/start-issue.md
@@ -18,7 +18,7 @@ Fetch a GitHub issue and begin implementation.
 
 When this command is used, Claude will:
 
-1. **Fetch the issue details** using `gh issue view <issue-number>`
+1. **Fetch the issue details** using `gh issue view <issue-number> --json title,body,author,state,labels,assignees,milestone,number,url,comments`
 
 2. **Create a todo list** with tasks derived from the issue requirements
 
@@ -40,14 +40,16 @@ When this command is used, Claude will:
 
 ### Fetching Issue Details
 
+**IMPORTANT:** Always use `--json` to avoid GitHub Projects (classic) deprecation errors.
+
 ```bash
-gh issue view <URL or issue-number>
+gh issue view <URL or issue-number> --json title,body,author,state,labels,assignees,milestone,number,url,comments
 ```
 
 Examples:
 
-- `gh issue view https://github.com/your-org/your-repo/issues/1234`
-- `gh issue view 1234` (when in the repository directory)
+- `gh issue view 1234 --json title,body,author,state,labels,assignees,milestone,number,url,comments`
+- `gh issue view https://github.com/your-org/your-repo/issues/1234 --json title,body,author,state,labels,assignees,milestone,number,url,comments`
 
 ## Notes
 

--- a/pkg/templates/claude/commands/update-pr.md
+++ b/pkg/templates/claude/commands/update-pr.md
@@ -14,7 +14,7 @@ When this command is used, Claude will:
 
 1. **Enter Plan Mode** to outline the PR update process
 
-2. **Verify PR exists** for the current branch using `gh pr view`
+2. **Verify PR exists** for the current branch using `gh pr view --json number,title,url,state`
 
 3. **Generate updated description** using `/pr-description` command
    - Analyzes current branch changes against main


### PR DESCRIPTION
## Summary

Replace plain `gh issue view` and `gh pr view` calls with `--json` variants across all command templates to avoid GitHub's Projects (classic) deprecation error.

The default `gh issue view` and `gh pr view` commands (without `--json`) internally query `projectCards` — a classic Projects field — which triggers:
```
GraphQL: Projects (classic) is being deprecated in favor of the new Projects experience
```

## Changes

- **start-issue.md**: Use `gh issue view --json title,body,author,state,labels,assignees,milestone,number,url,comments` instead of plain `gh issue view`
- **open-pr.md**: Use `gh pr view --json number,title,url,state` instead of plain `gh pr view`
- **update-pr.md**: Use `gh pr view --json number,title,url,state` instead of plain `gh pr view`
- All changes applied across 3 template directories: `.claude/commands/`, `pkg/templates/claude/commands/`, `ailloy/commands/`

## UAT

1. Run `gh issue view 15 --json title,body,author,state,labels,assignees,milestone,number,url,comments` — should return JSON without error
2. Run `gh pr view --json number,title,url,state` — should return JSON (or "no PR found", not deprecation error)
3. Run `go test ./...` — all tests pass
4. Run `go build ./...` — builds successfully