### PR TITLE
feat(config): define semantic model layer for priority, status, and iteration

### DIFF
--- a/internal/commands/customize.go
+++ b/internal/commands/customize.go
@@ -104,7 +104,47 @@ func listTemplateVariables(cfg *config.Config) error {
 	}
 
 	fmt.Println(table.Render())
+
+	// Show models section if any are enabled
+	if hasEnabledModels(cfg) {
+		fmt.Println()
+		fmt.Println(styles.AccentStyle.Render("Semantic Models:"))
+		fmt.Println()
+
+		printModelSummary("Status", &cfg.Models.Status)
+		printModelSummary("Priority", &cfg.Models.Priority)
+		printModelSummary("Iteration", &cfg.Models.Iteration)
+	}
+
 	return nil
+}
+
+func hasEnabledModels(cfg *config.Config) bool {
+	return cfg.Models.Status.Enabled || cfg.Models.Priority.Enabled || cfg.Models.Iteration.Enabled
+}
+
+func printModelSummary(name string, model *config.ModelConfig) {
+	if !model.Enabled {
+		fmt.Println(styles.SubtleStyle.Render("  " + name + ": disabled"))
+		return
+	}
+
+	status := styles.SuccessStyle.Render("enabled")
+	mapping := ""
+	if model.FieldMapping != "" {
+		mapping = " -> " + styles.CodeStyle.Render(model.FieldMapping)
+	}
+	fmt.Println("  " + styles.AccentStyle.Render(name) + ": " + status + mapping)
+
+	if len(model.Options) > 0 {
+		for concept, opt := range model.Options {
+			line := "    " + styles.SubtleStyle.Render(concept) + ": " + styles.CodeStyle.Render(opt.Label)
+			if opt.ID != "" {
+				line += styles.SubtleStyle.Render(" (" + opt.ID + ")")
+			}
+			fmt.Println(line)
+		}
+	}
 }
 
 func deleteTemplateVariable(cfg *config.Config, key string) error {

--- a/internal/commands/init.go
+++ b/internal/commands/init.go
@@ -154,6 +154,9 @@ func copyTemplateFiles() error {
 		}
 	}
 
+	// Merge model-derived variables into template variables
+	config.MergeModelVariables(cfg)
+
 	// Define template files to copy
 	templates := []string{
 		"brainstorm.md",
@@ -253,6 +256,9 @@ func copySkillFiles() error {
 			}
 		}
 	}
+
+	// Merge model-derived variables into template variables
+	config.MergeModelVariables(cfg)
 
 	// Define skill files to copy
 	skills := []string{


### PR DESCRIPTION
## Summary

- Introduces `ModelOption`, `ModelConfig`, and `Models` structs to `pkg/config/config.go` that define Priority (P0-P3), Status (Ready/In Progress/In Review/Done), and Iteration as first-class ailloy concepts with optional field mapping to GitHub Project custom fields
- Adds backward compatibility bridge (`ModelsToVariables`, `MergeModelVariables`) so model-derived values automatically populate flat template variables without breaking existing templates
- Updates `ailloy customize --list` to display a "Semantic Models" section showing enabled/disabled state, field mappings, and option labels
- Adds 7 new unit tests covering model defaults, YAML round-trip, backward compat merging, and disabled model behavior

Closes #25

## Test plan

- [x] All 30 config package tests pass (`go test ./pkg/config/ -v`)
- [x] Full test suite passes (`go test ./...`)
- [x] `go vet ./...` clean
- [x] `go build` succeeds
- [x] Manual: create `ailloy.yaml` with `models:` section and verify `ailloy customize --list` output
- [x] Manual: verify existing configs without `models:` key still load correctly with defaults filled in