### PR TITLE
feat: add forge command for dry-run template rendering

### DIFF
--- a/internal/commands/forge.go
+++ b/internal/commands/forge.go
@@ -1,0 +1,176 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/nimble-giant/ailloy/pkg/config"
+	"github.com/nimble-giant/ailloy/pkg/styles"
+	embeddedtemplates "github.com/nimble-giant/ailloy/pkg/templates"
+	"github.com/spf13/cobra"
+)
+
+var forgeCmd = &cobra.Command{
+	Use:     "forge",
+	Aliases: []string{"template"},
+	Short:   "Dry-run render of mold templates",
+	Long: `Render all templates in the current mold with flux values and print the result (alias: template).
+
+This is the "what would cast produce?" preview, analogous to helm template.
+By default, rendered output is printed to stdout. Use --output to write files to a directory.`,
+	RunE: runForge,
+}
+
+var (
+	forgeOutputDir string
+	forgeSetValues []string
+)
+
+func init() {
+	rootCmd.AddCommand(forgeCmd)
+
+	forgeCmd.Flags().StringVarP(&forgeOutputDir, "output", "o", "", "write rendered files to this directory instead of stdout")
+	forgeCmd.Flags().StringArrayVar(&forgeSetValues, "set", nil, "set flux values (key=value)")
+}
+
+// loadForgeConfig loads the layered config identical to cast, then applies --set overrides.
+func loadForgeConfig(setValues []string) (*config.Config, error) {
+	cfg, err := config.LoadConfig(false)
+	if err != nil {
+		cfg = &config.Config{
+			Templates: config.TemplateConfig{
+				Variables: make(map[string]string),
+			},
+		}
+	}
+
+	globalCfg, err := config.LoadConfig(true)
+	if err == nil && globalCfg.Templates.Variables != nil {
+		for key, value := range globalCfg.Templates.Variables {
+			if _, exists := cfg.Templates.Variables[key]; !exists {
+				cfg.Templates.Variables[key] = value
+			}
+		}
+	}
+
+	config.MergeModelVariables(cfg)
+
+	// Apply --set overrides (highest precedence)
+	for _, kv := range setValues {
+		key, value, ok := strings.Cut(kv, "=")
+		if !ok {
+			return nil, fmt.Errorf("invalid --set value %q: expected key=value", kv)
+		}
+		cfg.Templates.Variables[key] = value
+	}
+
+	return cfg, nil
+}
+
+// renderFile processes a single template and returns the rendered content.
+func renderFile(name string, content []byte, cfg *config.Config) (string, error) {
+	rendered, err := config.ProcessTemplate(string(content), cfg.Templates.Variables, &cfg.Models)
+	if err != nil {
+		return "", fmt.Errorf("template %s: %w", name, err)
+	}
+	return rendered, nil
+}
+
+type renderedFile struct {
+	destPath string // relative output path (e.g. ".claude/commands/brainstorm.md")
+	content  string
+}
+
+func runForge(cmd *cobra.Command, args []string) error {
+	cfg, err := loadForgeConfig(forgeSetValues)
+	if err != nil {
+		return err
+	}
+
+	manifest, err := embeddedtemplates.LoadManifest()
+	if err != nil {
+		return fmt.Errorf("failed to load mold manifest: %w", err)
+	}
+
+	var files []renderedFile
+
+	// Render command templates
+	for _, name := range manifest.Commands {
+		content, err := embeddedtemplates.GetTemplate(name)
+		if err != nil {
+			return fmt.Errorf("reading command template %s: %w", name, err)
+		}
+		rendered, err := renderFile(name, content, cfg)
+		if err != nil {
+			return err
+		}
+		files = append(files, renderedFile{
+			destPath: filepath.Join(".claude", "commands", name),
+			content:  rendered,
+		})
+	}
+
+	// Render skill templates
+	for _, name := range manifest.Skills {
+		content, err := embeddedtemplates.GetSkill(name)
+		if err != nil {
+			return fmt.Errorf("reading skill template %s: %w", name, err)
+		}
+		rendered, err := renderFile(name, content, cfg)
+		if err != nil {
+			return err
+		}
+		files = append(files, renderedFile{
+			destPath: filepath.Join(".claude", "skills", name),
+			content:  rendered,
+		})
+	}
+
+	// Workflow templates are not Go-templated, include as-is
+	for _, name := range manifest.Workflows {
+		content, err := embeddedtemplates.GetWorkflowTemplate(name)
+		if err != nil {
+			return fmt.Errorf("reading workflow template %s: %w", name, err)
+		}
+		files = append(files, renderedFile{
+			destPath: filepath.Join(".github", "workflows", name),
+			content:  string(content),
+		})
+	}
+
+	if forgeOutputDir != "" {
+		return writeForgeFiles(files, forgeOutputDir)
+	}
+	return printForgeFiles(files)
+}
+
+func printForgeFiles(files []renderedFile) error {
+	for i, f := range files {
+		fmt.Println(styles.AccentStyle.Render("--- " + f.destPath + " ---"))
+		fmt.Print(f.content)
+		if !strings.HasSuffix(f.content, "\n") {
+			fmt.Println()
+		}
+		if i < len(files)-1 {
+			fmt.Println()
+		}
+	}
+	return nil
+}
+
+func writeForgeFiles(files []renderedFile, outputDir string) error {
+	for _, f := range files {
+		dest := filepath.Join(outputDir, f.destPath)
+		if err := os.MkdirAll(filepath.Dir(dest), 0750); err != nil { // #nosec G301 -- Output directories need group read access
+			return fmt.Errorf("creating directory for %s: %w", f.destPath, err)
+		}
+		//#nosec G306 -- Rendered templates need to be readable
+		if err := os.WriteFile(dest, []byte(f.content), 0644); err != nil {
+			return fmt.Errorf("writing %s: %w", f.destPath, err)
+		}
+		fmt.Println(styles.SuccessStyle.Render("wrote ") + styles.CodeStyle.Render(dest))
+	}
+	return nil
+}


### PR DESCRIPTION
## Description

Adds `ailloy forge` (alias: `template`), a dry-run rendering command analogous to `helm template`. It renders all mold templates (commands, skills, workflows) with resolved flux values and prints to stdout, or writes to a directory via `--output`. Supports `--set key=value` for inline overrides and reads the same layered config as `cast`.

## Related Issue

Fixes #42

## Testing

- `go vet ./...` — clean
- `go build ./...` — clean
- `go test ./...` — all packages pass
- Manual: `ailloy forge`, `ailloy template`, `ailloy forge --output /tmp/out`, `ailloy forge --set organization=acme`

## UAT

Run `ailloy forge` in a project to preview what `cast` would produce. Verify `--output <dir>` writes the expected file tree. Use `--set key=value` to override flux variables without editing config.

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [x] I have updated documentation (if applicable)
- [x] My commits have DCO sign-off (`git commit -s`)