### PR TITLE
refactor: domain terminology and configuration overhaul (#41)

### DIFF
--- a/internal/commands/cast_integration_test.go
+++ b/internal/commands/cast_integration_test.go
@@ -97,10 +97,10 @@ func TestIntegration_CopyTemplateFiles_WithVariableSubstitution(t *testing.T) {
 	}
 	defer func() { _ = os.Chdir(origDir) }()
 
-	// Create config with variables
+	// Create config with flux variables
 	cfg := &config.Config{
 		Templates: config.TemplateConfig{
-			Variables: map[string]string{
+			Flux: map[string]string{
 				"organization":  "test-org",
 				"default_board": "TestBoard",
 			},
@@ -191,12 +191,12 @@ func TestIntegration_TemplateFilesMatchEmbedded(t *testing.T) {
 		}
 
 		// Process embedded content through the same template engine
-		// (with default models and no variables, matching what copyTemplateFiles does)
-		defaultModels := config.DefaultModels()
+		// (with default ore and no flux, matching what copyTemplateFiles does)
+		defaultOre := config.DefaultOre()
 		expectedContent, err := config.ProcessTemplate(
 			string(embeddedContent),
 			make(map[string]string),
-			&defaultModels,
+			&defaultOre,
 		)
 		if err != nil {
 			t.Errorf("failed to process embedded template %s: %v", tmplName, err)
@@ -230,11 +230,11 @@ func TestIntegration_TemplateFilesMatchEmbedded(t *testing.T) {
 		}
 
 		// Process embedded content through the same template engine
-		defaultModels := config.DefaultModels()
+		defaultOre := config.DefaultOre()
 		expectedContent, err := config.ProcessTemplate(
 			string(embeddedContent),
 			make(map[string]string),
-			&defaultModels,
+			&defaultOre,
 		)
 		if err != nil {
 			t.Errorf("failed to process embedded skill %s: %v", skillName, err)

--- a/internal/commands/forge.go
+++ b/internal/commands/forge.go
@@ -41,21 +41,21 @@ func loadForgeConfig(setValues []string) (*config.Config, error) {
 	if err != nil {
 		cfg = &config.Config{
 			Templates: config.TemplateConfig{
-				Variables: make(map[string]string),
+				Flux: make(map[string]string),
 			},
 		}
 	}
 
 	globalCfg, err := config.LoadConfig(true)
-	if err == nil && globalCfg.Templates.Variables != nil {
-		for key, value := range globalCfg.Templates.Variables {
-			if _, exists := cfg.Templates.Variables[key]; !exists {
-				cfg.Templates.Variables[key] = value
+	if err == nil && globalCfg.Templates.Flux != nil {
+		for key, value := range globalCfg.Templates.Flux {
+			if _, exists := cfg.Templates.Flux[key]; !exists {
+				cfg.Templates.Flux[key] = value
 			}
 		}
 	}
 
-	config.MergeModelVariables(cfg)
+	config.MergeOreFlux(cfg)
 
 	// Apply --set overrides (highest precedence)
 	for _, kv := range setValues {
@@ -63,7 +63,7 @@ func loadForgeConfig(setValues []string) (*config.Config, error) {
 		if !ok {
 			return nil, fmt.Errorf("invalid --set value %q: expected key=value", kv)
 		}
-		cfg.Templates.Variables[key] = value
+		cfg.Templates.Flux[key] = value
 	}
 
 	return cfg, nil
@@ -71,7 +71,7 @@ func loadForgeConfig(setValues []string) (*config.Config, error) {
 
 // renderFile processes a single template and returns the rendered content.
 func renderFile(name string, content []byte, cfg *config.Config) (string, error) {
-	rendered, err := config.ProcessTemplate(string(content), cfg.Templates.Variables, &cfg.Models)
+	rendered, err := config.ProcessTemplate(string(content), cfg.Templates.Flux, &cfg.Ore)
 	if err != nil {
 		return "", fmt.Errorf("template %s: %w", name, err)
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -69,8 +69,8 @@ func TestLoadConfig_MissingFile(t *testing.T) {
 	if cfg == nil {
 		t.Fatal("expected non-nil config")
 	}
-	if cfg.Templates.Variables == nil {
-		t.Error("expected Variables map to be initialized")
+	if cfg.Templates.Flux == nil {
+		t.Error("expected Flux map to be initialized")
 	}
 }
 
@@ -92,7 +92,7 @@ func TestLoadConfig_ValidYAML(t *testing.T) {
   description: A test project
 templates:
   default_provider: claude
-  variables:
+  flux:
     org: myorg
     board: Engineering
 user:
@@ -122,11 +122,11 @@ providers:
 	if cfg.Templates.DefaultProvider != "claude" {
 		t.Errorf("expected default provider 'claude', got '%s'", cfg.Templates.DefaultProvider)
 	}
-	if cfg.Templates.Variables["org"] != "myorg" {
-		t.Errorf("expected variable org=myorg, got '%s'", cfg.Templates.Variables["org"])
+	if cfg.Templates.Flux["org"] != "myorg" {
+		t.Errorf("expected flux org=myorg, got '%s'", cfg.Templates.Flux["org"])
 	}
-	if cfg.Templates.Variables["board"] != "Engineering" {
-		t.Errorf("expected variable board=Engineering, got '%s'", cfg.Templates.Variables["board"])
+	if cfg.Templates.Flux["board"] != "Engineering" {
+		t.Errorf("expected flux board=Engineering, got '%s'", cfg.Templates.Flux["board"])
 	}
 	if cfg.User.Name != "Test User" {
 		t.Errorf("expected user name 'Test User', got '%s'", cfg.User.Name)
@@ -164,7 +164,7 @@ func TestLoadConfig_InvalidYAML(t *testing.T) {
 	}
 }
 
-func TestLoadConfig_NilVariablesInitialized(t *testing.T) {
+func TestLoadConfig_NilFluxInitialized(t *testing.T) {
 	tmpDir := t.TempDir()
 	origDir, _ := os.Getwd()
 	if err := os.Chdir(tmpDir); err != nil {
@@ -177,7 +177,7 @@ func TestLoadConfig_NilVariablesInitialized(t *testing.T) {
 		t.Fatalf("failed to create config dir: %v", err)
 	}
 
-	// YAML without variables section
+	// YAML without flux section
 	yamlContent := `project:
   name: test
 `
@@ -190,8 +190,8 @@ func TestLoadConfig_NilVariablesInitialized(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cfg.Templates.Variables == nil {
-		t.Error("expected Variables map to be initialized even when not in YAML")
+	if cfg.Templates.Flux == nil {
+		t.Error("expected Flux map to be initialized even when not in YAML")
 	}
 }
 
@@ -210,7 +210,7 @@ func TestSaveConfig(t *testing.T) {
 		},
 		Templates: TemplateConfig{
 			DefaultProvider: "claude",
-			Variables: map[string]string{
+			Flux: map[string]string{
 				"key1": "value1",
 				"key2": "value2",
 			},
@@ -241,11 +241,11 @@ func TestSaveConfig(t *testing.T) {
 	if loaded.Project.Name != "saved-project" {
 		t.Errorf("expected project name 'saved-project', got '%s'", loaded.Project.Name)
 	}
-	if loaded.Templates.Variables["key1"] != "value1" {
-		t.Errorf("expected variable key1=value1, got '%s'", loaded.Templates.Variables["key1"])
+	if loaded.Templates.Flux["key1"] != "value1" {
+		t.Errorf("expected flux key1=value1, got '%s'", loaded.Templates.Flux["key1"])
 	}
-	if loaded.Templates.Variables["key2"] != "value2" {
-		t.Errorf("expected variable key2=value2, got '%s'", loaded.Templates.Variables["key2"])
+	if loaded.Templates.Flux["key2"] != "value2" {
+		t.Errorf("expected flux key2=value2, got '%s'", loaded.Templates.Flux["key2"])
 	}
 }
 
@@ -259,7 +259,7 @@ func TestSaveConfig_CreatesDirectory(t *testing.T) {
 
 	cfg := &Config{
 		Templates: TemplateConfig{
-			Variables: map[string]string{},
+			Flux: map[string]string{},
 		},
 	}
 
@@ -285,12 +285,12 @@ func TestSaveConfig_CreatesDirectory(t *testing.T) {
 
 func TestProcessTemplate_BasicSubstitution(t *testing.T) {
 	content := "Hello {{name}}, welcome to {{project}}!"
-	variables := map[string]string{
+	flux := map[string]string{
 		"name":    "Alice",
 		"project": "Ailloy",
 	}
 
-	result, err := ProcessTemplate(content, variables, nil)
+	result, err := ProcessTemplate(content, flux, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -302,9 +302,9 @@ func TestProcessTemplate_BasicSubstitution(t *testing.T) {
 
 func TestProcessTemplate_NoVariables(t *testing.T) {
 	content := "Hello world, no placeholders here!"
-	variables := map[string]string{}
+	flux := map[string]string{}
 
-	result, err := ProcessTemplate(content, variables, nil)
+	result, err := ProcessTemplate(content, flux, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -325,9 +325,9 @@ func TestProcessTemplate_EmptyContent(t *testing.T) {
 
 func TestProcessTemplate_MultipleOccurrences(t *testing.T) {
 	content := "{{name}} said: Hello {{name}}!"
-	variables := map[string]string{"name": "Bob"}
+	flux := map[string]string{"name": "Bob"}
 
-	result, err := ProcessTemplate(content, variables, nil)
+	result, err := ProcessTemplate(content, flux, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -339,12 +339,12 @@ func TestProcessTemplate_MultipleOccurrences(t *testing.T) {
 
 func TestProcessTemplate_PartialMatch(t *testing.T) {
 	content := "Use {{board}} for issues on {{board_id}}"
-	variables := map[string]string{
+	flux := map[string]string{
 		"board":    "Engineering",
 		"board_id": "12345",
 	}
 
-	result, err := ProcessTemplate(content, variables, nil)
+	result, err := ProcessTemplate(content, flux, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -367,10 +367,10 @@ func TestProcessTemplate_NilVariables(t *testing.T) {
 
 func TestProcessTemplate_SpecialCharacters(t *testing.T) {
 	content := "URL: {{url}}"
-	variables := map[string]string{
+	flux := map[string]string{
 		"url": "https://example.com/path?query=1&other=2",
 	}
-	result, err := ProcessTemplate(content, variables, nil)
+	result, err := ProcessTemplate(content, flux, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -380,54 +380,54 @@ func TestProcessTemplate_SpecialCharacters(t *testing.T) {
 	}
 }
 
-// --- Model Layer Tests ---
+// --- Ore Layer Tests ---
 
-func TestDefaultModels(t *testing.T) {
-	models := DefaultModels()
+func TestDefaultOre(t *testing.T) {
+	ore := DefaultOre()
 
-	// Status model
-	if models.Status.Enabled {
-		t.Error("expected status model to be disabled by default")
+	// Status ore
+	if ore.Status.Enabled {
+		t.Error("expected status ore to be disabled by default")
 	}
-	if len(models.Status.Options) != 4 {
-		t.Errorf("expected 4 status options, got %d", len(models.Status.Options))
+	if len(ore.Status.Options) != 4 {
+		t.Errorf("expected 4 status options, got %d", len(ore.Status.Options))
 	}
-	if models.Status.Options["ready"].Label != "Ready" {
-		t.Errorf("expected ready label 'Ready', got %q", models.Status.Options["ready"].Label)
+	if ore.Status.Options["ready"].Label != "Ready" {
+		t.Errorf("expected ready label 'Ready', got %q", ore.Status.Options["ready"].Label)
 	}
-	if models.Status.Options["in_progress"].Label != "In Progress" {
-		t.Errorf("expected in_progress label 'In Progress', got %q", models.Status.Options["in_progress"].Label)
+	if ore.Status.Options["in_progress"].Label != "In Progress" {
+		t.Errorf("expected in_progress label 'In Progress', got %q", ore.Status.Options["in_progress"].Label)
 	}
-	if models.Status.Options["in_review"].Label != "In Review" {
-		t.Errorf("expected in_review label 'In Review', got %q", models.Status.Options["in_review"].Label)
+	if ore.Status.Options["in_review"].Label != "In Review" {
+		t.Errorf("expected in_review label 'In Review', got %q", ore.Status.Options["in_review"].Label)
 	}
-	if models.Status.Options["done"].Label != "Done" {
-		t.Errorf("expected done label 'Done', got %q", models.Status.Options["done"].Label)
+	if ore.Status.Options["done"].Label != "Done" {
+		t.Errorf("expected done label 'Done', got %q", ore.Status.Options["done"].Label)
 	}
 
-	// Priority model
-	if models.Priority.Enabled {
-		t.Error("expected priority model to be disabled by default")
+	// Priority ore
+	if ore.Priority.Enabled {
+		t.Error("expected priority ore to be disabled by default")
 	}
-	if len(models.Priority.Options) != 4 {
-		t.Errorf("expected 4 priority options, got %d", len(models.Priority.Options))
+	if len(ore.Priority.Options) != 4 {
+		t.Errorf("expected 4 priority options, got %d", len(ore.Priority.Options))
 	}
 	for _, key := range []string{"p0", "p1", "p2", "p3"} {
-		if _, ok := models.Priority.Options[key]; !ok {
+		if _, ok := ore.Priority.Options[key]; !ok {
 			t.Errorf("expected priority option %q to exist", key)
 		}
 	}
 
-	// Iteration model
-	if models.Iteration.Enabled {
-		t.Error("expected iteration model to be disabled by default")
+	// Iteration ore
+	if ore.Iteration.Enabled {
+		t.Error("expected iteration ore to be disabled by default")
 	}
-	if models.Iteration.Options != nil {
-		t.Error("expected iteration model to have no predefined options")
+	if ore.Iteration.Options != nil {
+		t.Error("expected iteration ore to have no predefined options")
 	}
 }
 
-func TestLoadConfig_WithModels(t *testing.T) {
+func TestLoadConfig_WithOre(t *testing.T) {
 	tmpDir := t.TempDir()
 	origDir, _ := os.Getwd()
 	if err := os.Chdir(tmpDir); err != nil {
@@ -442,7 +442,7 @@ func TestLoadConfig_WithModels(t *testing.T) {
 
 	yamlContent := `project:
   name: test-project
-models:
+ore:
   status:
     enabled: true
     field_mapping: "Vibes"
@@ -474,55 +474,55 @@ models:
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Status model
-	if !cfg.Models.Status.Enabled {
-		t.Error("expected status model to be enabled")
+	// Status ore
+	if !cfg.Ore.Status.Enabled {
+		t.Error("expected status ore to be enabled")
 	}
-	if cfg.Models.Status.FieldMapping != "Vibes" {
-		t.Errorf("expected field mapping 'Vibes', got %q", cfg.Models.Status.FieldMapping)
+	if cfg.Ore.Status.FieldMapping != "Vibes" {
+		t.Errorf("expected field mapping 'Vibes', got %q", cfg.Ore.Status.FieldMapping)
 	}
-	if cfg.Models.Status.FieldID != "PVTSSF_abc123" {
-		t.Errorf("expected field ID 'PVTSSF_abc123', got %q", cfg.Models.Status.FieldID)
+	if cfg.Ore.Status.FieldID != "PVTSSF_abc123" {
+		t.Errorf("expected field ID 'PVTSSF_abc123', got %q", cfg.Ore.Status.FieldID)
 	}
 	// User-customized labels should be preserved
-	if cfg.Models.Status.Options["ready"].Label != "Not Started" {
-		t.Errorf("expected ready label 'Not Started', got %q", cfg.Models.Status.Options["ready"].Label)
+	if cfg.Ore.Status.Options["ready"].Label != "Not Started" {
+		t.Errorf("expected ready label 'Not Started', got %q", cfg.Ore.Status.Options["ready"].Label)
 	}
-	if cfg.Models.Status.Options["in_progress"].Label != "Doing" {
-		t.Errorf("expected in_progress label 'Doing', got %q", cfg.Models.Status.Options["in_progress"].Label)
+	if cfg.Ore.Status.Options["in_progress"].Label != "Doing" {
+		t.Errorf("expected in_progress label 'Doing', got %q", cfg.Ore.Status.Options["in_progress"].Label)
 	}
-	if cfg.Models.Status.Options["in_progress"].ID != "opt_123" {
-		t.Errorf("expected in_progress ID 'opt_123', got %q", cfg.Models.Status.Options["in_progress"].ID)
+	if cfg.Ore.Status.Options["in_progress"].ID != "opt_123" {
+		t.Errorf("expected in_progress ID 'opt_123', got %q", cfg.Ore.Status.Options["in_progress"].ID)
 	}
 	// Default options should be filled in for missing keys
-	if _, ok := cfg.Models.Status.Options["in_review"]; !ok {
+	if _, ok := cfg.Ore.Status.Options["in_review"]; !ok {
 		t.Error("expected in_review option to be filled in from defaults")
 	}
-	if _, ok := cfg.Models.Status.Options["done"]; !ok {
+	if _, ok := cfg.Ore.Status.Options["done"]; !ok {
 		t.Error("expected done option to be filled in from defaults")
 	}
 
-	// Priority model - user defined only p0 and p1, p2 and p3 should be filled in
-	if !cfg.Models.Priority.Enabled {
-		t.Error("expected priority model to be enabled")
+	// Priority ore - user defined only p0 and p1, p2 and p3 should be filled in
+	if !cfg.Ore.Priority.Enabled {
+		t.Error("expected priority ore to be enabled")
 	}
-	if cfg.Models.Priority.Options["p0"].Label != "Critical" {
-		t.Errorf("expected p0 label 'Critical', got %q", cfg.Models.Priority.Options["p0"].Label)
+	if cfg.Ore.Priority.Options["p0"].Label != "Critical" {
+		t.Errorf("expected p0 label 'Critical', got %q", cfg.Ore.Priority.Options["p0"].Label)
 	}
-	if _, ok := cfg.Models.Priority.Options["p2"]; !ok {
+	if _, ok := cfg.Ore.Priority.Options["p2"]; !ok {
 		t.Error("expected p2 option to be filled in from defaults")
 	}
-	if _, ok := cfg.Models.Priority.Options["p3"]; !ok {
+	if _, ok := cfg.Ore.Priority.Options["p3"]; !ok {
 		t.Error("expected p3 option to be filled in from defaults")
 	}
 
 	// Iteration should remain disabled
-	if cfg.Models.Iteration.Enabled {
-		t.Error("expected iteration model to be disabled")
+	if cfg.Ore.Iteration.Enabled {
+		t.Error("expected iteration ore to be disabled")
 	}
 }
 
-func TestLoadConfig_WithoutModels_GetsDefaults(t *testing.T) {
+func TestLoadConfig_WithoutOre_GetsDefaults(t *testing.T) {
 	tmpDir := t.TempDir()
 	origDir, _ := os.Getwd()
 	if err := os.Chdir(tmpDir); err != nil {
@@ -535,11 +535,11 @@ func TestLoadConfig_WithoutModels_GetsDefaults(t *testing.T) {
 		t.Fatalf("failed to create config dir: %v", err)
 	}
 
-	// YAML without models section
+	// YAML without ore section
 	yamlContent := `project:
   name: legacy-project
 templates:
-  variables:
+  flux:
     default_status: "Ready"
     default_priority: "P1"
 `
@@ -553,20 +553,20 @@ templates:
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Models should be initialized with defaults
-	if len(cfg.Models.Status.Options) != 4 {
-		t.Errorf("expected 4 default status options, got %d", len(cfg.Models.Status.Options))
+	// Ore should be initialized with defaults
+	if len(cfg.Ore.Status.Options) != 4 {
+		t.Errorf("expected 4 default status options, got %d", len(cfg.Ore.Status.Options))
 	}
-	if len(cfg.Models.Priority.Options) != 4 {
-		t.Errorf("expected 4 default priority options, got %d", len(cfg.Models.Priority.Options))
+	if len(cfg.Ore.Priority.Options) != 4 {
+		t.Errorf("expected 4 default priority options, got %d", len(cfg.Ore.Priority.Options))
 	}
-	// Existing flat variables should be untouched
-	if cfg.Templates.Variables["default_status"] != "Ready" {
-		t.Errorf("expected flat variable default_status='Ready', got %q", cfg.Templates.Variables["default_status"])
+	// Existing flat flux should be untouched
+	if cfg.Templates.Flux["default_status"] != "Ready" {
+		t.Errorf("expected flat flux default_status='Ready', got %q", cfg.Templates.Flux["default_status"])
 	}
 }
 
-func TestSaveConfig_WithModels(t *testing.T) {
+func TestSaveConfig_WithOre(t *testing.T) {
 	tmpDir := t.TempDir()
 	origDir, _ := os.Getwd()
 	if err := os.Chdir(tmpDir); err != nil {
@@ -575,21 +575,21 @@ func TestSaveConfig_WithModels(t *testing.T) {
 	defer func() { _ = os.Chdir(origDir) }()
 
 	cfg := &Config{
-		Project: ProjectConfig{Name: "model-project"},
+		Project: ProjectConfig{Name: "ore-project"},
 		Templates: TemplateConfig{
-			Variables: map[string]string{"org": "myorg"},
+			Flux: map[string]string{"org": "myorg"},
 		},
-		Models: Models{
-			Status: ModelConfig{
+		Ore: Ore{
+			Status: OreConfig{
 				Enabled:      true,
 				FieldMapping: "Status",
 				FieldID:      "PVTSSF_xyz",
-				Options: map[string]ModelOption{
+				Options: map[string]OreOption{
 					"ready":       {Label: "Ready", ID: "opt_1"},
 					"in_progress": {Label: "In Progress", ID: "opt_2"},
 				},
 			},
-			Priority: ModelConfig{
+			Priority: OreConfig{
 				Enabled: false,
 			},
 		},
@@ -600,50 +600,50 @@ func TestSaveConfig_WithModels(t *testing.T) {
 		t.Fatalf("unexpected error saving config: %v", err)
 	}
 
-	// Load it back and verify models round-trip
+	// Load it back and verify ore round-trip
 	loaded, err := LoadConfig(false)
 	if err != nil {
 		t.Fatalf("failed to load saved config: %v", err)
 	}
 
-	if !loaded.Models.Status.Enabled {
-		t.Error("expected status model to be enabled after round-trip")
+	if !loaded.Ore.Status.Enabled {
+		t.Error("expected status ore to be enabled after round-trip")
 	}
-	if loaded.Models.Status.FieldMapping != "Status" {
-		t.Errorf("expected field mapping 'Status', got %q", loaded.Models.Status.FieldMapping)
+	if loaded.Ore.Status.FieldMapping != "Status" {
+		t.Errorf("expected field mapping 'Status', got %q", loaded.Ore.Status.FieldMapping)
 	}
-	if loaded.Models.Status.FieldID != "PVTSSF_xyz" {
-		t.Errorf("expected field ID 'PVTSSF_xyz', got %q", loaded.Models.Status.FieldID)
+	if loaded.Ore.Status.FieldID != "PVTSSF_xyz" {
+		t.Errorf("expected field ID 'PVTSSF_xyz', got %q", loaded.Ore.Status.FieldID)
 	}
-	if loaded.Models.Status.Options["ready"].ID != "opt_1" {
-		t.Errorf("expected ready ID 'opt_1', got %q", loaded.Models.Status.Options["ready"].ID)
+	if loaded.Ore.Status.Options["ready"].ID != "opt_1" {
+		t.Errorf("expected ready ID 'opt_1', got %q", loaded.Ore.Status.Options["ready"].ID)
 	}
 }
 
-func TestModelsToVariables(t *testing.T) {
-	models := Models{
-		Status: ModelConfig{
+func TestOreToFlux(t *testing.T) {
+	ore := Ore{
+		Status: OreConfig{
 			Enabled: true,
 			FieldID: "PVTSSF_status",
-			Options: map[string]ModelOption{
+			Options: map[string]OreOption{
 				"ready":       {Label: "Not Started"},
 				"in_progress": {Label: "Doing"},
 			},
 		},
-		Priority: ModelConfig{
+		Priority: OreConfig{
 			Enabled: true,
 			FieldID: "PVTSSF_priority",
-			Options: map[string]ModelOption{
+			Options: map[string]OreOption{
 				"p1": {Label: "High"},
 			},
 		},
-		Iteration: ModelConfig{
+		Iteration: OreConfig{
 			Enabled: true,
 			FieldID: "PVTIF_iteration",
 		},
 	}
 
-	vars := ModelsToVariables(models)
+	vars := OreToFlux(ore)
 
 	if vars["default_status"] != "Not Started" {
 		t.Errorf("expected default_status='Not Started', got %q", vars["default_status"])
@@ -662,74 +662,219 @@ func TestModelsToVariables(t *testing.T) {
 	}
 }
 
-func TestModelsToVariables_DisabledModelsSkipped(t *testing.T) {
-	models := Models{
-		Status: ModelConfig{
+func TestOreToFlux_DisabledOreSkipped(t *testing.T) {
+	ore := Ore{
+		Status: OreConfig{
 			Enabled: false,
 			FieldID: "PVTSSF_status",
-			Options: map[string]ModelOption{
+			Options: map[string]OreOption{
 				"ready": {Label: "Ready"},
 			},
 		},
-		Priority: ModelConfig{
+		Priority: OreConfig{
 			Enabled: false,
 		},
 	}
 
-	vars := ModelsToVariables(models)
+	vars := OreToFlux(ore)
 
 	if _, exists := vars["default_status"]; exists {
-		t.Error("expected disabled status model to not generate default_status variable")
+		t.Error("expected disabled status ore to not generate default_status variable")
 	}
 	if _, exists := vars["status_field_id"]; exists {
-		t.Error("expected disabled status model to not generate status_field_id variable")
+		t.Error("expected disabled status ore to not generate status_field_id variable")
 	}
 	if _, exists := vars["default_priority"]; exists {
-		t.Error("expected disabled priority model to not generate default_priority variable")
+		t.Error("expected disabled priority ore to not generate default_priority variable")
 	}
 }
 
-func TestMergeModelVariables_DoesNotOverwriteExisting(t *testing.T) {
+func TestMergeOreFlux_DoesNotOverwriteExisting(t *testing.T) {
 	cfg := &Config{
 		Templates: TemplateConfig{
-			Variables: map[string]string{
+			Flux: map[string]string{
 				"default_status":   "Custom Status",
 				"default_priority": "Custom Priority",
 			},
 		},
-		Models: Models{
-			Status: ModelConfig{
+		Ore: Ore{
+			Status: OreConfig{
 				Enabled: true,
 				FieldID: "PVTSSF_status",
-				Options: map[string]ModelOption{
-					"ready": {Label: "Model Status"},
+				Options: map[string]OreOption{
+					"ready": {Label: "Ore Status"},
 				},
 			},
-			Priority: ModelConfig{
+			Priority: OreConfig{
 				Enabled: true,
 				FieldID: "PVTSSF_priority",
-				Options: map[string]ModelOption{
-					"p1": {Label: "Model Priority"},
+				Options: map[string]OreOption{
+					"p1": {Label: "Ore Priority"},
 				},
 			},
 		},
 	}
 
-	MergeModelVariables(cfg)
+	MergeOreFlux(cfg)
 
-	// Existing flat variables should NOT be overwritten
-	if cfg.Templates.Variables["default_status"] != "Custom Status" {
-		t.Errorf("expected existing default_status to be preserved, got %q", cfg.Templates.Variables["default_status"])
+	// Existing flat flux should NOT be overwritten
+	if cfg.Templates.Flux["default_status"] != "Custom Status" {
+		t.Errorf("expected existing default_status to be preserved, got %q", cfg.Templates.Flux["default_status"])
 	}
-	if cfg.Templates.Variables["default_priority"] != "Custom Priority" {
-		t.Errorf("expected existing default_priority to be preserved, got %q", cfg.Templates.Variables["default_priority"])
+	if cfg.Templates.Flux["default_priority"] != "Custom Priority" {
+		t.Errorf("expected existing default_priority to be preserved, got %q", cfg.Templates.Flux["default_priority"])
 	}
 
-	// But field IDs that weren't in flat variables should be added
-	if cfg.Templates.Variables["status_field_id"] != "PVTSSF_status" {
-		t.Errorf("expected status_field_id to be added from model, got %q", cfg.Templates.Variables["status_field_id"])
+	// But field IDs that weren't in flat flux should be added
+	if cfg.Templates.Flux["status_field_id"] != "PVTSSF_status" {
+		t.Errorf("expected status_field_id to be added from ore, got %q", cfg.Templates.Flux["status_field_id"])
 	}
-	if cfg.Templates.Variables["priority_field_id"] != "PVTSSF_priority" {
-		t.Errorf("expected priority_field_id to be added from model, got %q", cfg.Templates.Variables["priority_field_id"])
+	if cfg.Templates.Flux["priority_field_id"] != "PVTSSF_priority" {
+		t.Errorf("expected priority_field_id to be added from ore, got %q", cfg.Templates.Flux["priority_field_id"])
+	}
+}
+
+// --- New Config File Location Tests ---
+
+func TestLoadConfig_FromAilloyrc(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	yamlContent := `project:
+  name: from-ailloyrc
+templates:
+  flux:
+    source: ailloyrc
+`
+	if err := os.WriteFile(".ailloyrc", []byte(yamlContent), 0600); err != nil {
+		t.Fatalf("failed to write .ailloyrc: %v", err)
+	}
+
+	cfg, err := LoadConfig(false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Project.Name != "from-ailloyrc" {
+		t.Errorf("expected project name 'from-ailloyrc', got '%s'", cfg.Project.Name)
+	}
+	if cfg.Templates.Flux["source"] != "ailloyrc" {
+		t.Errorf("expected flux source=ailloyrc, got '%s'", cfg.Templates.Flux["source"])
+	}
+}
+
+func TestLoadConfig_FromRootAilloyYaml(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	yamlContent := `project:
+  name: from-root-yaml
+templates:
+  flux:
+    source: root-yaml
+`
+	if err := os.WriteFile("ailloy.yaml", []byte(yamlContent), 0600); err != nil {
+		t.Fatalf("failed to write ailloy.yaml: %v", err)
+	}
+
+	cfg, err := LoadConfig(false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Project.Name != "from-root-yaml" {
+		t.Errorf("expected project name 'from-root-yaml', got '%s'", cfg.Project.Name)
+	}
+}
+
+func TestLoadConfig_AilloyrcTakesPrecedence(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	// Create both files - .ailloyrc should be loaded first
+	if err := os.WriteFile(".ailloyrc", []byte(`project:
+  name: from-ailloyrc
+`), 0600); err != nil {
+		t.Fatalf("failed to write .ailloyrc: %v", err)
+	}
+	if err := os.WriteFile("ailloy.yaml", []byte(`project:
+  name: from-root-yaml
+`), 0600); err != nil {
+		t.Fatalf("failed to write ailloy.yaml: %v", err)
+	}
+
+	cfg, err := LoadConfig(false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Project.Name != "from-ailloyrc" {
+		t.Errorf("expected .ailloyrc to take precedence, got '%s'", cfg.Project.Name)
+	}
+}
+
+// --- Layered Config Tests ---
+
+func TestLoadLayeredConfig_SetFlagOverrides(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	// Create project config
+	configDir := filepath.Join(tmpDir, ".ailloy")
+	if err := os.MkdirAll(configDir, 0750); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+	yamlContent := `templates:
+  flux:
+    org: project-org
+    board: Engineering
+`
+	if err := os.WriteFile(filepath.Join(configDir, "ailloy.yaml"), []byte(yamlContent), 0600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cfg, err := LoadLayeredConfig([]string{"org=override-org", "new_var=new_value"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// --set should override project config
+	if cfg.Templates.Flux["org"] != "override-org" {
+		t.Errorf("expected org='override-org', got %q", cfg.Templates.Flux["org"])
+	}
+	// --set should add new vars
+	if cfg.Templates.Flux["new_var"] != "new_value" {
+		t.Errorf("expected new_var='new_value', got %q", cfg.Templates.Flux["new_var"])
+	}
+	// Existing vars not overridden should remain
+	if cfg.Templates.Flux["board"] != "Engineering" {
+		t.Errorf("expected board='Engineering', got %q", cfg.Templates.Flux["board"])
+	}
+}
+
+func TestLoadLayeredConfig_InvalidSetFormat(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	_, err := LoadLayeredConfig([]string{"invalid-no-equals"})
+	if err == nil {
+		t.Error("expected error for invalid --set format")
 	}
 }

--- a/pkg/templates/claude/commands/create-issue.md
+++ b/pkg/templates/claude/commands/create-issue.md
@@ -224,27 +224,27 @@ gh issue edit <issue-number> --add-project "Engineering"
 # - "Reporting"
 ```
 
-{{- if or .models.status.enabled .models.priority.enabled .models.iteration.enabled}}
+{{- if or .ore.status.enabled .ore.priority.enabled .ore.iteration.enabled}}
 
 ## Project Field Management
 
 ### {{.default_board}} Board Field IDs
 
 - Project ID: `{{.project_id}}`
-{{- if .models.status.enabled}}
-- Status Field ID: `{{.models.status.field_id}}`
+{{- if .ore.status.enabled}}
+- Status Field ID: `{{.ore.status.field_id}}`
 {{- end}}
-{{- if .models.priority.enabled}}
-- Priority Field ID: `{{.models.priority.field_id}}`
+{{- if .ore.priority.enabled}}
+- Priority Field ID: `{{.ore.priority.field_id}}`
 {{- end}}
-{{- if .models.iteration.enabled}}
-- Iteration Field ID: `{{.models.iteration.field_id}}`
+{{- if .ore.iteration.enabled}}
+- Iteration Field ID: `{{.ore.iteration.field_id}}`
 {{- end}}
-{{- if .models.status.enabled}}
+{{- if .ore.status.enabled}}
 
 **Status Options:**
 
-{{range $key, $opt := .models.status.options -}}
+{{range $key, $opt := .ore.status.options -}}
 - {{$opt.label}}{{if $opt.id}}: `{{$opt.id}}`{{end}}
 {{end}}
 
@@ -256,7 +256,7 @@ mutation {
     input: {
       projectId: "{{.project_id}}"
       itemId: "<ITEM_ID>"
-      fieldId: "{{.models.status.field_id}}"
+      fieldId: "{{.ore.status.field_id}}"
       value: {
         singleSelectOptionId: "<OPTION_ID>"
       }
@@ -268,11 +268,11 @@ mutation {
 ```
 
 {{- end}}
-{{- if .models.priority.enabled}}
+{{- if .ore.priority.enabled}}
 
 **Priority Options:**
 
-{{range $key, $opt := .models.priority.options -}}
+{{range $key, $opt := .ore.priority.options -}}
 - {{$opt.label}}{{if $opt.id}}: `{{$opt.id}}`{{end}}
 {{end}}
 
@@ -284,7 +284,7 @@ mutation {
     input: {
       projectId: "{{.project_id}}"
       itemId: "<ITEM_ID>"
-      fieldId: "{{.models.priority.field_id}}"
+      fieldId: "{{.ore.priority.field_id}}"
       value: {
         singleSelectOptionId: "<OPTION_ID>"
       }


### PR DESCRIPTION
## Description

Renames internal terminology to match the metallurgy domain model (`Variables` → `Flux`, `Models` → `Ore`) and overhauls the configuration system to support new file locations and values layering. Template data binding now uses `ore` instead of `models` as the nested key, and embedded templates are updated to match.

## Related Issue

Fixes #41

## Testing

All existing tests were updated and new tests added for: new config file locations (`.ailloyrc`, root `ailloy.yaml`), `LoadLayeredConfig` with `--set` overrides, ore round-trip serialization, and precedence ordering. Full test suite passes with 0 lint issues.

## UAT

1. Run `ailloy cast` — templates should render correctly with `{{.ore.status.enabled}}` syntax
2. Create a `.ailloyrc` at project root — `ailloy anneal` should pick it up
3. Run `ailloy cast --set org=myorg` — the `org` flux variable should be injected at highest priority

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [x] I have updated documentation (if applicable)
- [x] My commits have DCO sign-off (`git commit -s`)