### PR TITLE
feat: ingot template partials and flux schema validation (#44)

### DIFF
--- a/internal/commands/cast_integration_test.go
+++ b/internal/commands/cast_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/nimble-giant/ailloy/pkg/config"
+	"github.com/nimble-giant/ailloy/pkg/mold"
 	embeddedtemplates "github.com/nimble-giant/ailloy/pkg/templates"
 )
 
@@ -180,6 +181,13 @@ func TestIntegration_TemplateFilesMatchEmbedded(t *testing.T) {
 		t.Fatalf("failed to list embedded templates: %v", err)
 	}
 
+	// Load manifest to apply the same flux defaults that copyTemplateFiles now applies
+	manifest, err := embeddedtemplates.LoadManifest()
+	if err != nil {
+		t.Fatalf("failed to load manifest: %v", err)
+	}
+	flux := mold.ApplyFluxDefaults(manifest.Flux, make(map[string]string))
+
 	// Verify each embedded template has a corresponding file
 	// Note: templates are processed through the Go template engine,
 	// so we compare against the processed embedded content (not raw source)
@@ -191,11 +199,11 @@ func TestIntegration_TemplateFilesMatchEmbedded(t *testing.T) {
 		}
 
 		// Process embedded content through the same template engine
-		// (with default ore and no flux, matching what copyTemplateFiles does)
+		// (with default ore and flux defaults, matching what copyTemplateFiles does)
 		defaultOre := config.DefaultOre()
 		expectedContent, err := config.ProcessTemplate(
 			string(embeddedContent),
-			make(map[string]string),
+			flux,
 			&defaultOre,
 		)
 		if err != nil {
@@ -233,7 +241,7 @@ func TestIntegration_TemplateFilesMatchEmbedded(t *testing.T) {
 		defaultOre := config.DefaultOre()
 		expectedContent, err := config.ProcessTemplate(
 			string(embeddedContent),
-			make(map[string]string),
+			flux,
 			&defaultOre,
 		)
 		if err != nil {

--- a/pkg/config/ingot.go
+++ b/pkg/config/ingot.go
@@ -1,0 +1,111 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/nimble-giant/ailloy/pkg/mold"
+	"github.com/nimble-giant/ailloy/pkg/safepath"
+)
+
+// IngotResolver resolves {{ingot "name"}} template function calls by searching
+// for ingot content across a list of directories. It supports both manifest-based
+// ingots (directory with ingot.yaml) and bare file ingots (name.md).
+type IngotResolver struct {
+	SearchPaths []string
+	Flux        map[string]string
+	Ore         *Ore
+	resolving   map[string]bool
+}
+
+// NewIngotResolver creates a resolver that searches the given paths in order.
+func NewIngotResolver(searchPaths []string, flux map[string]string, ore *Ore) *IngotResolver {
+	return &IngotResolver{
+		SearchPaths: searchPaths,
+		Flux:        flux,
+		Ore:         ore,
+		resolving:   make(map[string]bool),
+	}
+}
+
+// Resolve finds and renders an ingot by name. It searches each path for a
+// directory with an ingot.yaml manifest first, then falls back to a bare .md file.
+// The ingot content is rendered through the same template engine with the same
+// flux and ore context. Circular references are detected and reported as errors.
+func (r *IngotResolver) Resolve(name string) (string, error) {
+	if r.resolving[name] {
+		return "", fmt.Errorf("circular ingot reference detected: %s", name)
+	}
+	r.resolving[name] = true
+	defer delete(r.resolving, name)
+
+	for _, base := range r.SearchPaths {
+		// Try directory with manifest first
+		manifestPath := filepath.Join(base, "ingots", name, "ingot.yaml")
+		if content, err := r.resolveManifest(manifestPath, name); err == nil {
+			return r.render(content)
+		}
+
+		// Fall back to bare file
+		barePath := filepath.Join(base, "ingots", name+".md")
+		if content, err := r.readFile(barePath); err == nil {
+			return r.render(string(content))
+		}
+	}
+
+	searched := make([]string, len(r.SearchPaths))
+	for i, p := range r.SearchPaths {
+		searched[i] = filepath.Join(p, "ingots")
+	}
+	return "", fmt.Errorf("ingot %q not found (searched: %s)", name, strings.Join(searched, ", "))
+}
+
+// resolveManifest loads an ingot.yaml manifest and concatenates all listed files.
+func (r *IngotResolver) resolveManifest(manifestPath, name string) (string, error) {
+	cleanPath, err := safepath.Clean(manifestPath)
+	if err != nil {
+		return "", err
+	}
+
+	data, err := os.ReadFile(cleanPath) // #nosec G304 -- path sanitized by safepath.Clean
+	if err != nil {
+		return "", err
+	}
+
+	ingot, err := mold.ParseIngot(data)
+	if err != nil {
+		return "", fmt.Errorf("parsing ingot %q manifest: %w", name, err)
+	}
+
+	ingotDir := filepath.Dir(cleanPath)
+	var combined strings.Builder
+	for _, f := range ingot.Files {
+		filePath, err := safepath.Join(ingotDir, f)
+		if err != nil {
+			return "", fmt.Errorf("ingot %q file %q: %w", name, f, err)
+		}
+		content, err := os.ReadFile(filePath) // #nosec G304 -- path sanitized by safepath.Join
+		if err != nil {
+			return "", fmt.Errorf("reading ingot %q file %q: %w", name, f, err)
+		}
+		combined.Write(content)
+	}
+
+	return combined.String(), nil
+}
+
+// readFile reads a file with path sanitization.
+func (r *IngotResolver) readFile(path string) ([]byte, error) {
+	cleanPath, err := safepath.Clean(path)
+	if err != nil {
+		return nil, err
+	}
+	return os.ReadFile(cleanPath) // #nosec G304 -- path sanitized by safepath.Clean
+}
+
+// render processes ingot content through the template engine with the same context.
+func (r *IngotResolver) render(content string) (string, error) {
+	return ProcessTemplate(content, r.Flux, r.Ore, WithIngotResolver(r))
+}

--- a/pkg/config/ingot_test.go
+++ b/pkg/config/ingot_test.go
@@ -1,0 +1,242 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestIngotResolver_BareFile(t *testing.T) {
+	dir := t.TempDir()
+	ingotDir := filepath.Join(dir, "ingots")
+	if err := os.MkdirAll(ingotDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(ingotDir, "footer.md"), []byte("-- footer --"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewIngotResolver([]string{dir}, nil, nil)
+	result, err := r.Resolve("footer")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "-- footer --" {
+		t.Errorf("expected '-- footer --', got %q", result)
+	}
+}
+
+func TestIngotResolver_ManifestBased(t *testing.T) {
+	dir := t.TempDir()
+	ingotDir := filepath.Join(dir, "ingots", "pr-format")
+	if err := os.MkdirAll(ingotDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	manifest := `apiVersion: v1
+kind: ingot
+name: pr-format
+version: 1.0.0
+files:
+  - header.md
+  - body.md
+`
+	if err := os.WriteFile(filepath.Join(ingotDir, "ingot.yaml"), []byte(manifest), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(ingotDir, "header.md"), []byte("# Header\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(ingotDir, "body.md"), []byte("Body content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewIngotResolver([]string{dir}, nil, nil)
+	result, err := r.Resolve("pr-format")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "# Header") {
+		t.Error("expected result to contain header")
+	}
+	if !strings.Contains(result, "Body content") {
+		t.Error("expected result to contain body")
+	}
+}
+
+func TestIngotResolver_ManifestTakesPrecedenceOverBareFile(t *testing.T) {
+	dir := t.TempDir()
+	ingotDir := filepath.Join(dir, "ingots", "snippet")
+	if err := os.MkdirAll(ingotDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	manifest := `apiVersion: v1
+kind: ingot
+name: snippet
+version: 1.0.0
+files:
+  - content.md
+`
+	if err := os.WriteFile(filepath.Join(ingotDir, "ingot.yaml"), []byte(manifest), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(ingotDir, "content.md"), []byte("from manifest"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Also create bare file
+	if err := os.WriteFile(filepath.Join(dir, "ingots", "snippet.md"), []byte("from bare file"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewIngotResolver([]string{dir}, nil, nil)
+	result, err := r.Resolve("snippet")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "from manifest" {
+		t.Errorf("expected manifest content, got %q", result)
+	}
+}
+
+func TestIngotResolver_SearchPathOrder(t *testing.T) {
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+
+	ingotDir2 := filepath.Join(dir2, "ingots")
+	if err := os.MkdirAll(ingotDir2, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(ingotDir2, "shared.md"), []byte("from second path"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewIngotResolver([]string{dir1, dir2}, nil, nil)
+	result, err := r.Resolve("shared")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "from second path" {
+		t.Errorf("expected 'from second path', got %q", result)
+	}
+}
+
+func TestIngotResolver_FirstPathWins(t *testing.T) {
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+
+	for _, dir := range []string{dir1, dir2} {
+		ingotDir := filepath.Join(dir, "ingots")
+		if err := os.MkdirAll(ingotDir, 0750); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir1, "ingots", "item.md"), []byte("first"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir2, "ingots", "item.md"), []byte("second"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewIngotResolver([]string{dir1, dir2}, nil, nil)
+	result, err := r.Resolve("item")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "first" {
+		t.Errorf("expected 'first', got %q", result)
+	}
+}
+
+func TestIngotResolver_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	r := NewIngotResolver([]string{dir}, nil, nil)
+
+	_, err := r.Resolve("nonexistent")
+	if err == nil {
+		t.Fatal("expected error for missing ingot")
+	}
+	if !strings.Contains(err.Error(), "nonexistent") {
+		t.Errorf("expected error to mention ingot name, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' in error, got: %v", err)
+	}
+}
+
+func TestIngotResolver_CircularReference(t *testing.T) {
+	dir := t.TempDir()
+	ingotDir := filepath.Join(dir, "ingots")
+	if err := os.MkdirAll(ingotDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	// Ingot A references itself
+	if err := os.WriteFile(filepath.Join(ingotDir, "self.md"), []byte(`{{ingot "self"}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewIngotResolver([]string{dir}, nil, nil)
+	_, err := r.Resolve("self")
+	if err == nil {
+		t.Fatal("expected error for circular reference")
+	}
+	if !strings.Contains(err.Error(), "circular ingot reference") {
+		t.Errorf("expected circular reference error, got: %v", err)
+	}
+}
+
+func TestIngotResolver_FluxVariablesRendered(t *testing.T) {
+	dir := t.TempDir()
+	ingotDir := filepath.Join(dir, "ingots")
+	if err := os.MkdirAll(ingotDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(ingotDir, "greeting.md"), []byte("Hello {{organization}}!"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	flux := map[string]string{"organization": "Acme"}
+	r := NewIngotResolver([]string{dir}, flux, nil)
+	result, err := r.Resolve("greeting")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "Hello Acme!" {
+		t.Errorf("expected 'Hello Acme!', got %q", result)
+	}
+}
+
+func TestIngotResolver_NestedIngots(t *testing.T) {
+	dir := t.TempDir()
+	ingotDir := filepath.Join(dir, "ingots")
+	if err := os.MkdirAll(ingotDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(ingotDir, "inner.md"), []byte("inner content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(ingotDir, "outer.md"), []byte(`before {{ingot "inner"}} after`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewIngotResolver([]string{dir}, nil, nil)
+	result, err := r.Resolve("outer")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "before inner content after" {
+		t.Errorf("expected 'before inner content after', got %q", result)
+	}
+}
+
+func TestIngotResolver_EmptySearchPaths(t *testing.T) {
+	r := NewIngotResolver(nil, nil, nil)
+	_, err := r.Resolve("anything")
+	if err == nil {
+		t.Fatal("expected error with no search paths")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' error, got: %v", err)
+	}
+}

--- a/pkg/mold/flux.go
+++ b/pkg/mold/flux.go
@@ -1,0 +1,85 @@
+package mold
+
+import (
+	"fmt"
+	"maps"
+	"strconv"
+	"strings"
+)
+
+// ApplyFluxDefaults returns a new flux map with default values applied for any
+// schema variables that have a default and are not already set in the input map.
+// The input map is not mutated.
+func ApplyFluxDefaults(schema []FluxVar, flux map[string]string) map[string]string {
+	result := make(map[string]string, len(flux))
+	maps.Copy(result, flux)
+
+	for _, fv := range schema {
+		if fv.Default == "" {
+			continue
+		}
+		if _, exists := result[fv.Name]; !exists {
+			result[fv.Name] = fv.Default
+		}
+	}
+
+	return result
+}
+
+// ValidateFlux validates provided flux values against the schema declarations.
+// It checks that all required variables are present and that values match their
+// declared types. All errors are collected and returned at once.
+func ValidateFlux(schema []FluxVar, flux map[string]string) error {
+	var errs []string
+
+	for _, fv := range schema {
+		val, exists := flux[fv.Name]
+
+		// Check required
+		if fv.Required && (!exists || val == "") {
+			errs = append(errs, fmt.Sprintf("flux %q is required but not provided", fv.Name))
+			continue
+		}
+
+		// Skip type validation if value is not set
+		if !exists || val == "" {
+			continue
+		}
+
+		// Type validation
+		if err := validateFluxType(fv.Type, fv.Name, val); err != "" {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("flux validation failed:\n  - %s", strings.Join(errs, "\n  - "))
+	}
+	return nil
+}
+
+// validateFluxType checks that a value conforms to the declared type.
+// Returns an error message string, or empty string if valid.
+func validateFluxType(typ, name, val string) string {
+	switch typ {
+	case "string":
+		// Any value is valid
+		return ""
+	case "bool":
+		lower := strings.ToLower(val)
+		if lower != "true" && lower != "false" {
+			return fmt.Sprintf("flux %q must be a bool (true/false), got %q", name, val)
+		}
+		return ""
+	case "int":
+		if _, err := strconv.Atoi(val); err != nil {
+			return fmt.Sprintf("flux %q must be an int, got %q", name, val)
+		}
+		return ""
+	case "list":
+		// Any non-empty comma-separated value is valid; already checked non-empty above
+		return ""
+	default:
+		return fmt.Sprintf("flux %q has unknown type %q", name, typ)
+	}
+}

--- a/pkg/mold/flux_test.go
+++ b/pkg/mold/flux_test.go
@@ -1,0 +1,231 @@
+package mold
+
+import (
+	"strings"
+	"testing"
+)
+
+// --- ApplyFluxDefaults tests ---
+
+func TestApplyFluxDefaults_AppliesMissingDefaults(t *testing.T) {
+	schema := []FluxVar{
+		{Name: "board", Type: "string", Default: "Engineering"},
+		{Name: "org", Type: "string", Required: true},
+	}
+	flux := map[string]string{"org": "acme"}
+
+	result := ApplyFluxDefaults(schema, flux)
+
+	if result["board"] != "Engineering" {
+		t.Errorf("expected board=Engineering, got %q", result["board"])
+	}
+	if result["org"] != "acme" {
+		t.Errorf("expected org=acme, got %q", result["org"])
+	}
+}
+
+func TestApplyFluxDefaults_DoesNotOverrideExisting(t *testing.T) {
+	schema := []FluxVar{
+		{Name: "board", Type: "string", Default: "Engineering"},
+	}
+	flux := map[string]string{"board": "Product"}
+
+	result := ApplyFluxDefaults(schema, flux)
+
+	if result["board"] != "Product" {
+		t.Errorf("expected board=Product (not overridden), got %q", result["board"])
+	}
+}
+
+func TestApplyFluxDefaults_DoesNotMutateInput(t *testing.T) {
+	schema := []FluxVar{
+		{Name: "board", Type: "string", Default: "Engineering"},
+	}
+	flux := map[string]string{}
+
+	result := ApplyFluxDefaults(schema, flux)
+
+	if _, exists := flux["board"]; exists {
+		t.Error("input map should not be mutated")
+	}
+	if result["board"] != "Engineering" {
+		t.Errorf("expected board=Engineering in result, got %q", result["board"])
+	}
+}
+
+func TestApplyFluxDefaults_EmptySchema(t *testing.T) {
+	flux := map[string]string{"key": "val"}
+	result := ApplyFluxDefaults(nil, flux)
+
+	if result["key"] != "val" {
+		t.Errorf("expected key=val, got %q", result["key"])
+	}
+}
+
+func TestApplyFluxDefaults_SkipsEmptyDefault(t *testing.T) {
+	schema := []FluxVar{
+		{Name: "org", Type: "string", Required: true},
+	}
+	flux := map[string]string{}
+
+	result := ApplyFluxDefaults(schema, flux)
+
+	if _, exists := result["org"]; exists {
+		t.Error("should not set value for var with no default")
+	}
+}
+
+// --- ValidateFlux tests ---
+
+func TestValidateFlux_RequiredMissing(t *testing.T) {
+	schema := []FluxVar{
+		{Name: "org", Type: "string", Required: true},
+	}
+	err := ValidateFlux(schema, map[string]string{})
+	if err == nil {
+		t.Fatal("expected error for missing required var")
+	}
+	if !strings.Contains(err.Error(), "org") {
+		t.Errorf("expected error to mention 'org', got: %v", err)
+	}
+}
+
+func TestValidateFlux_RequiredEmpty(t *testing.T) {
+	schema := []FluxVar{
+		{Name: "org", Type: "string", Required: true},
+	}
+	err := ValidateFlux(schema, map[string]string{"org": ""})
+	if err == nil {
+		t.Fatal("expected error for empty required var")
+	}
+}
+
+func TestValidateFlux_RequiredPresent(t *testing.T) {
+	schema := []FluxVar{
+		{Name: "org", Type: "string", Required: true},
+	}
+	if err := ValidateFlux(schema, map[string]string{"org": "acme"}); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateFlux_OptionalMissing(t *testing.T) {
+	schema := []FluxVar{
+		{Name: "board", Type: "string", Required: false},
+	}
+	if err := ValidateFlux(schema, map[string]string{}); err != nil {
+		t.Errorf("unexpected error for missing optional var: %v", err)
+	}
+}
+
+func TestValidateFlux_BoolValid(t *testing.T) {
+	schema := []FluxVar{
+		{Name: "enabled", Type: "bool", Required: true},
+	}
+	for _, val := range []string{"true", "false", "True", "FALSE"} {
+		if err := ValidateFlux(schema, map[string]string{"enabled": val}); err != nil {
+			t.Errorf("expected %q to be valid bool, got: %v", val, err)
+		}
+	}
+}
+
+func TestValidateFlux_BoolInvalid(t *testing.T) {
+	schema := []FluxVar{
+		{Name: "enabled", Type: "bool", Required: true},
+	}
+	err := ValidateFlux(schema, map[string]string{"enabled": "yes"})
+	if err == nil {
+		t.Fatal("expected error for invalid bool")
+	}
+	if !strings.Contains(err.Error(), "must be a bool") {
+		t.Errorf("expected bool error, got: %v", err)
+	}
+}
+
+func TestValidateFlux_IntValid(t *testing.T) {
+	schema := []FluxVar{
+		{Name: "count", Type: "int", Required: true},
+	}
+	for _, val := range []string{"0", "42", "-1", "100"} {
+		if err := ValidateFlux(schema, map[string]string{"count": val}); err != nil {
+			t.Errorf("expected %q to be valid int, got: %v", val, err)
+		}
+	}
+}
+
+func TestValidateFlux_IntInvalid(t *testing.T) {
+	schema := []FluxVar{
+		{Name: "count", Type: "int", Required: true},
+	}
+	err := ValidateFlux(schema, map[string]string{"count": "abc"})
+	if err == nil {
+		t.Fatal("expected error for invalid int")
+	}
+	if !strings.Contains(err.Error(), "must be an int") {
+		t.Errorf("expected int error, got: %v", err)
+	}
+}
+
+func TestValidateFlux_ListValid(t *testing.T) {
+	schema := []FluxVar{
+		{Name: "tags", Type: "list", Required: true},
+	}
+	for _, val := range []string{"a,b,c", "single", "one,two"} {
+		if err := ValidateFlux(schema, map[string]string{"tags": val}); err != nil {
+			t.Errorf("expected %q to be valid list, got: %v", val, err)
+		}
+	}
+}
+
+func TestValidateFlux_StringAlwaysValid(t *testing.T) {
+	schema := []FluxVar{
+		{Name: "name", Type: "string", Required: true},
+	}
+	for _, val := range []string{"hello", "123", "true", "a,b,c", "anything goes"} {
+		if err := ValidateFlux(schema, map[string]string{"name": val}); err != nil {
+			t.Errorf("expected %q to be valid string, got: %v", val, err)
+		}
+	}
+}
+
+func TestValidateFlux_MultipleErrors(t *testing.T) {
+	schema := []FluxVar{
+		{Name: "org", Type: "string", Required: true},
+		{Name: "enabled", Type: "bool", Required: true},
+		{Name: "count", Type: "int", Required: true},
+	}
+	err := ValidateFlux(schema, map[string]string{})
+	if err == nil {
+		t.Fatal("expected multiple errors")
+	}
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "org") {
+		t.Error("expected error to mention 'org'")
+	}
+	if !strings.Contains(errMsg, "enabled") {
+		t.Error("expected error to mention 'enabled'")
+	}
+	if !strings.Contains(errMsg, "count") {
+		t.Error("expected error to mention 'count'")
+	}
+}
+
+func TestValidateFlux_EmptySchema(t *testing.T) {
+	if err := ValidateFlux(nil, map[string]string{"extra": "val"}); err != nil {
+		t.Errorf("expected no error for empty schema, got: %v", err)
+	}
+}
+
+func TestValidateFlux_TypeAndRequiredCombined(t *testing.T) {
+	schema := []FluxVar{
+		{Name: "count", Type: "int", Required: true},
+	}
+	// Provided but wrong type
+	err := ValidateFlux(schema, map[string]string{"count": "not-a-number"})
+	if err == nil {
+		t.Fatal("expected error for wrong type")
+	}
+	if !strings.Contains(err.Error(), "must be an int") {
+		t.Errorf("expected type error, got: %v", err)
+	}
+}

--- a/pkg/mold/validate.go
+++ b/pkg/mold/validate.go
@@ -20,6 +20,7 @@ var validFluxTypes = map[string]bool{
 	"string": true,
 	"bool":   true,
 	"int":    true,
+	"list":   true,
 }
 
 // ValidateMold validates a Mold manifest for required fields and correct formats.
@@ -54,7 +55,7 @@ func ValidateMold(m *Mold) error {
 		if f.Type == "" {
 			errs = append(errs, fmt.Sprintf("flux[%d].type is required", i))
 		} else if !validFluxTypes[f.Type] {
-			errs = append(errs, fmt.Sprintf("flux[%d].type %q is not valid (allowed: string, bool, int)", i, f.Type))
+			errs = append(errs, fmt.Sprintf("flux[%d].type %q is not valid (allowed: string, bool, int, list)", i, f.Type))
 		}
 	}
 


### PR DESCRIPTION
## Description

Extends the template engine to support ingot reusable template partials via `{{ingot "name"}}` and adds flux schema validation to catch variable mismatches before rendering. Ingots resolve from mold-local `ingots/`, project `.ailloy/ingots/`, and global `~/.ailloy/ingots/` directories, with both manifest-based (directory + `ingot.yaml`) and bare-file fallback. Circular references are detected and reported clearly. Flux validation reads schema from `mold.yaml`, applies defaults for unset optional variables, validates types (`string`, `bool`, `int`, `list`), and reports all errors at once rather than failing on the first.

## Related Issue

Fixes #44

## Testing

- 14 new tests in `pkg/mold/flux_test.go` covering required/optional vars, type validation (bool/int/list/string), defaults, and multi-error collection
- 10 new tests in `pkg/config/ingot_test.go` covering bare file, manifest-based, search path order, cycle detection, flux rendering in ingots, and nested ingot resolution
- 3 new tests in `pkg/config/template_test.go` for the `{{ingot "name"}}` template function
- All existing tests pass; `golangci-lint` reports 0 issues

## UAT

1. Create an `ingots/` directory with a file `ingots/footer.md` containing some text
2. Use `{{ingot "footer"}}` in a command template and run `ailloy forge` — the ingot content should be inlined
3. Set a required flux variable in `mold.yaml` and run `forge` without providing it — a warning should appear in the log
4. Set a flux variable with `required: false` and a `default` — run `forge` without setting it and confirm the default value is applied

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [ ] I have updated documentation (if applicable)
- [x] My commits have DCO sign-off (`git commit -s`)