### PR TITLE
feat: add temper command for mold/ingot validation (#43)

### DIFF
--- a/internal/commands/temper.go
+++ b/internal/commands/temper.go
@@ -1,0 +1,114 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/nimble-giant/ailloy/pkg/mold"
+	"github.com/nimble-giant/ailloy/pkg/safepath"
+	"github.com/nimble-giant/ailloy/pkg/styles"
+	"github.com/spf13/cobra"
+)
+
+var temperCmd = &cobra.Command{
+	Use:     "temper [path]",
+	Aliases: []string{"lint"},
+	Short:   "Validate a mold or ingot package",
+	Long: `Validate a mold or ingot package for structural and template errors (alias: lint).
+
+Checks manifest fields, file references, template syntax, and flux schema
+consistency. Reports errors (blocking) and warnings (informational).
+
+Exit code 0 if valid, non-zero if errors are found.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runTemper,
+}
+
+func init() {
+	rootCmd.AddCommand(temperCmd)
+}
+
+func runTemper(cmd *cobra.Command, args []string) error {
+	dir := "."
+	if len(args) > 0 {
+		dir = args[0]
+	}
+
+	cleanDir, err := safepath.Clean(dir)
+	if err != nil {
+		return fmt.Errorf("invalid path: %w", err)
+	}
+
+	// Resolve to absolute path so we can split into parent (FS root) and base name.
+	// fs.FS paths cannot start with "." or "/", so we use the parent directory as
+	// the FS root and the directory name as the base path prefix.
+	absDir, err := filepath.Abs(cleanDir)
+	if err != nil {
+		return fmt.Errorf("resolving path: %w", err)
+	}
+	parentDir := filepath.Dir(absDir)
+	baseName := filepath.Base(absDir)
+
+	moldPath := filepath.Join(absDir, "mold.yaml")
+	ingotPath := filepath.Join(absDir, "ingot.yaml")
+
+	var result *mold.ValidationResult
+
+	switch {
+	case fileExists(moldPath):
+		m, err := mold.LoadMold(moldPath)
+		if err != nil {
+			return fmt.Errorf("loading mold manifest: %w", err)
+		}
+		fmt.Println(styles.HeaderStyle.Render("Tempering mold: " + m.Name))
+		result = mold.TemperMold(m, os.DirFS(parentDir), baseName)
+
+	case fileExists(ingotPath):
+		i, err := mold.LoadIngot(ingotPath)
+		if err != nil {
+			return fmt.Errorf("loading ingot manifest: %w", err)
+		}
+		fmt.Println(styles.HeaderStyle.Render("Tempering ingot: " + i.Name))
+		result = mold.TemperIngot(i, os.DirFS(parentDir), baseName)
+
+	default:
+		return fmt.Errorf("no mold.yaml or ingot.yaml found in %s", cleanDir)
+	}
+
+	printTemperResults(result)
+
+	if result.HasErrors() {
+		return fmt.Errorf("validation failed with %d error(s)", len(result.Errors))
+	}
+	return nil
+}
+
+func printTemperResults(result *mold.ValidationResult) {
+	for _, e := range result.Errors {
+		loc := ""
+		if e.File != "" {
+			loc = e.File + ": "
+		}
+		fmt.Println(styles.ErrorStyle.Render("ERROR ") + loc + e.Message)
+	}
+
+	for _, w := range result.Warnings {
+		loc := ""
+		if w.File != "" {
+			loc = w.File + ": "
+		}
+		fmt.Println(styles.WarningStyle.Render("WARNING ") + loc + w.Message)
+	}
+
+	if !result.HasErrors() && len(result.Warnings) == 0 {
+		fmt.Println(styles.SuccessStyle.Render("OK") + " — no issues found")
+	} else if !result.HasErrors() {
+		fmt.Println(styles.SuccessStyle.Render("OK") + fmt.Sprintf(" — %d warning(s), no errors", len(result.Warnings)))
+	}
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/internal/commands/temper_test.go
+++ b/internal/commands/temper_test.go
@@ -1,0 +1,112 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunTemper_NoManifest(t *testing.T) {
+	dir := t.TempDir()
+	err := runTemper(temperCmd, []string{dir})
+	if err == nil {
+		t.Fatal("expected error when no manifest exists")
+	}
+	if !strings.Contains(err.Error(), "no mold.yaml or ingot.yaml") {
+		t.Errorf("expected 'no mold.yaml or ingot.yaml' error, got: %v", err)
+	}
+}
+
+func TestRunTemper_ValidMold(t *testing.T) {
+	dir := t.TempDir()
+
+	moldYAML := `apiVersion: v1
+kind: mold
+name: test-mold
+version: 1.0.0
+commands:
+  - hello.md
+`
+	if err := os.WriteFile(filepath.Join(dir, "mold.yaml"), []byte(moldYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmdDir := filepath.Join(dir, "claude", "commands")
+	if err := os.MkdirAll(cmdDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cmdDir, "hello.md"), []byte("# Hello {{.name}}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runTemper(temperCmd, []string{dir})
+	if err != nil {
+		t.Errorf("expected no error for valid mold, got: %v", err)
+	}
+}
+
+func TestRunTemper_InvalidMold(t *testing.T) {
+	dir := t.TempDir()
+
+	// Mold with missing required fields
+	moldYAML := `kind: mold
+`
+	if err := os.WriteFile(filepath.Join(dir, "mold.yaml"), []byte(moldYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runTemper(temperCmd, []string{dir})
+	if err == nil {
+		t.Fatal("expected error for invalid mold")
+	}
+	if !strings.Contains(err.Error(), "validation failed") {
+		t.Errorf("expected 'validation failed' error, got: %v", err)
+	}
+}
+
+func TestRunTemper_ValidIngot(t *testing.T) {
+	dir := t.TempDir()
+
+	ingotYAML := `apiVersion: v1
+kind: ingot
+name: test-ingot
+version: 1.0.0
+files:
+  - templates/partial.md
+`
+	if err := os.WriteFile(filepath.Join(dir, "ingot.yaml"), []byte(ingotYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	tmplDir := filepath.Join(dir, "templates")
+	if err := os.MkdirAll(tmplDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmplDir, "partial.md"), []byte("# Partial"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runTemper(temperCmd, []string{dir})
+	if err != nil {
+		t.Errorf("expected no error for valid ingot, got: %v", err)
+	}
+}
+
+func TestRunTemper_DefaultsToCurrentDir(t *testing.T) {
+	// Should fail since the test working dir won't have mold.yaml/ingot.yaml at temp path
+	dir := t.TempDir()
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(origDir) }) //nolint:errcheck
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	err = runTemper(temperCmd, []string{})
+	if err == nil {
+		t.Fatal("expected error when no manifest in current dir")
+	}
+}

--- a/pkg/mold/validate_test.go
+++ b/pkg/mold/validate_test.go
@@ -1,0 +1,262 @@
+package mold
+
+import (
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+// --- ValidationResult tests ---
+
+func TestValidationResult_AddError(t *testing.T) {
+	r := &ValidationResult{}
+	r.AddError("mold.yaml", "something is wrong")
+	if len(r.Errors) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(r.Errors))
+	}
+	if r.Errors[0].File != "mold.yaml" {
+		t.Errorf("expected file mold.yaml, got %q", r.Errors[0].File)
+	}
+	if r.Errors[0].Message != "something is wrong" {
+		t.Errorf("expected message 'something is wrong', got %q", r.Errors[0].Message)
+	}
+}
+
+func TestValidationResult_AddWarning(t *testing.T) {
+	r := &ValidationResult{}
+	r.AddWarning("mold.yaml", "minor issue")
+	if len(r.Warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d", len(r.Warnings))
+	}
+}
+
+func TestValidationResult_HasErrors(t *testing.T) {
+	r := &ValidationResult{}
+	if r.HasErrors() {
+		t.Error("expected no errors initially")
+	}
+	r.AddError("", "err")
+	if !r.HasErrors() {
+		t.Error("expected HasErrors to be true after AddError")
+	}
+}
+
+func TestValidationResult_Merge(t *testing.T) {
+	r1 := &ValidationResult{}
+	r1.AddError("a", "err1")
+	r1.AddWarning("a", "warn1")
+
+	r2 := &ValidationResult{}
+	r2.AddError("b", "err2")
+	r2.AddWarning("b", "warn2")
+
+	r1.Merge(r2)
+
+	if len(r1.Errors) != 2 {
+		t.Errorf("expected 2 errors after merge, got %d", len(r1.Errors))
+	}
+	if len(r1.Warnings) != 2 {
+		t.Errorf("expected 2 warnings after merge, got %d", len(r1.Warnings))
+	}
+}
+
+// --- ValidateTemplateSyntax tests ---
+
+func TestValidateTemplateSyntax_Valid(t *testing.T) {
+	content := []byte(`# Hello {{.name}}
+
+{{if .enabled}}Feature is on{{end}}
+
+Use {{ingot "partial"}} here.`)
+
+	result := ValidateTemplateSyntax("test.md", content)
+	if result.HasErrors() {
+		t.Errorf("expected no errors for valid template, got: %v", result.Errors[0].Message)
+	}
+}
+
+func TestValidateTemplateSyntax_Invalid(t *testing.T) {
+	content := []byte(`# Broken {{if}}{{end`)
+
+	result := ValidateTemplateSyntax("broken.md", content)
+	if !result.HasErrors() {
+		t.Fatal("expected error for invalid template syntax")
+	}
+	if !strings.Contains(result.Errors[0].Message, "template syntax error") {
+		t.Errorf("expected 'template syntax error' in message, got: %q", result.Errors[0].Message)
+	}
+}
+
+func TestValidateTemplateSyntax_EmptyTemplate(t *testing.T) {
+	result := ValidateTemplateSyntax("empty.md", []byte(""))
+	if result.HasErrors() {
+		t.Error("expected no errors for empty template")
+	}
+}
+
+func TestValidateTemplateSyntax_PlainText(t *testing.T) {
+	result := ValidateTemplateSyntax("plain.md", []byte("No template syntax here, just markdown."))
+	if result.HasErrors() {
+		t.Error("expected no errors for plain text")
+	}
+}
+
+// --- TemperMold tests ---
+
+func TestTemperMold_Valid(t *testing.T) {
+	m := &Mold{
+		APIVersion: "v1",
+		Kind:       "mold",
+		Name:       "test-mold",
+		Version:    "1.0.0",
+		Commands:   []string{"cmd.md"},
+		Skills:     []string{"skill.md"},
+		Flux: []FluxVar{
+			{Name: "org", Type: "string", Required: true},
+		},
+	}
+
+	fsys := fstest.MapFS{
+		"root/claude/commands/cmd.md": &fstest.MapFile{Data: []byte("# Command {{.org}}")},
+		"root/claude/skills/skill.md": &fstest.MapFile{Data: []byte("# Skill")},
+	}
+
+	result := TemperMold(m, fsys, "root")
+	if result.HasErrors() {
+		t.Errorf("expected no errors for valid mold, got %d error(s):", len(result.Errors))
+		for _, e := range result.Errors {
+			t.Errorf("  %s: %s", e.File, e.Message)
+		}
+	}
+}
+
+func TestTemperMold_MissingFiles(t *testing.T) {
+	m := &Mold{
+		APIVersion: "v1",
+		Kind:       "mold",
+		Name:       "test-mold",
+		Version:    "1.0.0",
+		Commands:   []string{"missing.md"},
+	}
+
+	fsys := fstest.MapFS{}
+
+	result := TemperMold(m, fsys, "root")
+	if !result.HasErrors() {
+		t.Fatal("expected errors for missing files")
+	}
+}
+
+func TestTemperMold_InvalidManifest(t *testing.T) {
+	m := &Mold{} // all required fields missing
+
+	fsys := fstest.MapFS{}
+
+	result := TemperMold(m, fsys, "root")
+	if !result.HasErrors() {
+		t.Fatal("expected errors for invalid manifest")
+	}
+}
+
+func TestTemperMold_BadTemplateSyntax(t *testing.T) {
+	m := &Mold{
+		APIVersion: "v1",
+		Kind:       "mold",
+		Name:       "test-mold",
+		Version:    "1.0.0",
+		Commands:   []string{"bad.md"},
+	}
+
+	fsys := fstest.MapFS{
+		"root/claude/commands/bad.md": &fstest.MapFile{Data: []byte("# Broken {{if}}{{end")},
+	}
+
+	result := TemperMold(m, fsys, "root")
+	if !result.HasErrors() {
+		t.Fatal("expected errors for bad template syntax")
+	}
+
+	foundSyntaxError := false
+	for _, e := range result.Errors {
+		if strings.Contains(e.Message, "template syntax error") {
+			foundSyntaxError = true
+			break
+		}
+	}
+	if !foundSyntaxError {
+		t.Error("expected a template syntax error in results")
+	}
+}
+
+func TestTemperMold_InvalidFluxType(t *testing.T) {
+	m := &Mold{
+		APIVersion: "v1",
+		Kind:       "mold",
+		Name:       "test-mold",
+		Version:    "1.0.0",
+		Flux: []FluxVar{
+			{Name: "var1", Type: "float"},
+		},
+	}
+
+	fsys := fstest.MapFS{}
+
+	result := TemperMold(m, fsys, "root")
+	// Invalid flux type is caught by ValidateMold as an error, but also by TemperMold's
+	// flux schema check as a warning. Either way, the result should flag it.
+	if !result.HasErrors() && len(result.Warnings) == 0 {
+		t.Fatal("expected errors or warnings for invalid flux type")
+	}
+}
+
+// --- TemperIngot tests ---
+
+func TestTemperIngot_Valid(t *testing.T) {
+	i := &Ingot{
+		APIVersion: "v1",
+		Kind:       "ingot",
+		Name:       "test-ingot",
+		Version:    "1.0.0",
+		Files:      []string{"templates/partial.md"},
+	}
+
+	fsys := fstest.MapFS{
+		"root/templates/partial.md": &fstest.MapFile{Data: []byte("# Partial")},
+	}
+
+	result := TemperIngot(i, fsys, "root")
+	if result.HasErrors() {
+		t.Errorf("expected no errors for valid ingot, got %d error(s):", len(result.Errors))
+		for _, e := range result.Errors {
+			t.Errorf("  %s: %s", e.File, e.Message)
+		}
+	}
+}
+
+func TestTemperIngot_InvalidManifest(t *testing.T) {
+	i := &Ingot{} // all required fields missing
+
+	fsys := fstest.MapFS{}
+
+	result := TemperIngot(i, fsys, "root")
+	if !result.HasErrors() {
+		t.Fatal("expected errors for invalid ingot manifest")
+	}
+}
+
+func TestTemperIngot_MissingFiles(t *testing.T) {
+	i := &Ingot{
+		APIVersion: "v1",
+		Kind:       "ingot",
+		Name:       "test-ingot",
+		Version:    "1.0.0",
+		Files:      []string{"missing.md"},
+	}
+
+	fsys := fstest.MapFS{}
+
+	result := TemperIngot(i, fsys, "root")
+	if !result.HasErrors() {
+		t.Fatal("expected errors for missing ingot files")
+	}
+}


### PR DESCRIPTION
## Description

Adds `ailloy temper [path]` (alias: `lint`) command that validates a mold or ingot package before packaging or distribution, analogous to `helm lint`. Extends `pkg/mold/validate.go` with a structured `ValidationResult` type, `ValidateTemplateSyntax` (with bare-variable preprocessing to handle the project's `{{variable}}` shorthand), and `TemperMold`/`TemperIngot` orchestrators that reuse existing validation functions. The command reports errors (blocking, non-zero exit) and warnings (informational) with file context.

## Related Issue

Fixes #43

## Testing

- Added 12 unit tests covering `ValidationResult`, `ValidateTemplateSyntax`, `TemperMold`, and `TemperIngot` in `pkg/mold/validate_test.go`
- Added 5 command-level tests in `internal/commands/temper_test.go` covering no-manifest, valid mold, invalid mold, valid ingot, and default-dir cases
- All pre-push hooks pass: `golangci-lint`, `go build`, `go test -race`

## UAT

```bash
# Validate the embedded mold
ailloy temper ./pkg/templates

# Use the lint alias
ailloy lint ./pkg/templates

# Verify non-zero exit on invalid package
mkdir /tmp/bad-mold && echo "kind: mold" > /tmp/bad-mold/mold.yaml
ailloy temper /tmp/bad-mold; echo "exit: $?"
```

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [x] I have updated documentation (if applicable)
- [x] My commits have DCO sign-off (`git commit -s`)