### PR TITLE
feat: add temper command for mold/ingot validation

### DIFF
--- a/internal/commands/temper.go
+++ b/internal/commands/temper.go
@@ -1,0 +1,80 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/nimble-giant/ailloy/pkg/mold"
+	"github.com/nimble-giant/ailloy/pkg/styles"
+	"github.com/spf13/cobra"
+)
+
+var temperCmd = &cobra.Command{
+	Use:     "temper [path]",
+	Aliases: []string{"lint"},
+	Short:   "Validate and lint a mold or ingot package",
+	Long: `Validate and lint a mold or ingot package (alias: lint).
+
+Checks structural integrity, manifest fields, file references,
+template syntax, and flux schema consistency. Reports errors
+(blocking) and warnings (informational).`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runTemper,
+}
+
+func init() {
+	rootCmd.AddCommand(temperCmd)
+}
+
+func runTemper(_ *cobra.Command, args []string) error {
+	fmt.Println(styles.WorkingBanner("Tempering..."))
+	fmt.Println()
+
+	moldDir := "."
+	if len(args) > 0 {
+		moldDir = args[0]
+	}
+
+	fsys := os.DirFS(moldDir)
+	result := mold.Temper(fsys)
+
+	if result.Name != "" {
+		fmt.Println(styles.InfoStyle.Render("Package: ") +
+			styles.CodeStyle.Render(result.Name) +
+			styles.SubtleStyle.Render(fmt.Sprintf(" (%s, %s)", result.ManifestKind, result.Version)))
+		fmt.Println()
+	}
+
+	warnings := result.Warnings()
+	errors := result.Errors()
+
+	for _, d := range warnings {
+		loc := ""
+		if d.File != "" {
+			loc = styles.SubtleStyle.Render(d.File + ": ")
+		}
+		fmt.Println(styles.WarningStyle.Render("WARNING: ") + loc + d.Message)
+	}
+
+	for _, d := range errors {
+		loc := ""
+		if d.File != "" {
+			loc = styles.SubtleStyle.Render(d.File + ": ")
+		}
+		fmt.Println(styles.ErrorStyle.Render("ERROR: ") + loc + d.Message)
+	}
+
+	if len(warnings) > 0 || len(errors) > 0 {
+		fmt.Println()
+	}
+
+	if result.HasErrors() {
+		fmt.Println(styles.ErrorStyle.Render(fmt.Sprintf("Validation failed: %d error(s), %d warning(s)",
+			len(errors), len(warnings))))
+		return fmt.Errorf("temper: %d error(s) found", len(errors))
+	}
+
+	msg := fmt.Sprintf("Validation passed: 0 errors, %d warning(s)", len(warnings))
+	fmt.Println(styles.SuccessStyle.Render(msg))
+	return nil
+}

--- a/pkg/mold/temper_test.go
+++ b/pkg/mold/temper_test.go
@@ -1,0 +1,349 @@
+package mold
+
+import (
+	"testing"
+	"testing/fstest"
+)
+
+func TestTemper_ValidMold(t *testing.T) {
+	fsys := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte(`
+apiVersion: v1
+kind: mold
+name: test-mold
+version: 1.0.0
+output:
+  commands: .claude/commands
+`)},
+		"commands/hello.md": &fstest.MapFile{Data: []byte("# Hello\nThis is a test.")},
+	}
+
+	result := Temper(fsys)
+
+	if result.HasErrors() {
+		t.Errorf("expected no errors, got: %v", result.Errors())
+	}
+	if result.ManifestKind != "mold" {
+		t.Errorf("expected manifest kind 'mold', got %q", result.ManifestKind)
+	}
+	if result.Name != "test-mold" {
+		t.Errorf("expected name 'test-mold', got %q", result.Name)
+	}
+	if result.Version != "1.0.0" {
+		t.Errorf("expected version '1.0.0', got %q", result.Version)
+	}
+}
+
+func TestTemper_ValidIngot(t *testing.T) {
+	fsys := fstest.MapFS{
+		"ingot.yaml": &fstest.MapFile{Data: []byte(`
+apiVersion: v1
+kind: ingot
+name: test-ingot
+version: 2.0.0
+files:
+  - templates/pr.md
+`)},
+		"templates/pr.md": &fstest.MapFile{Data: []byte("# PR Template")},
+	}
+
+	result := Temper(fsys)
+
+	if result.HasErrors() {
+		t.Errorf("expected no errors, got: %v", result.Errors())
+	}
+	if result.ManifestKind != "ingot" {
+		t.Errorf("expected manifest kind 'ingot', got %q", result.ManifestKind)
+	}
+	if result.Name != "test-ingot" {
+		t.Errorf("expected name 'test-ingot', got %q", result.Name)
+	}
+}
+
+func TestTemper_NoManifest(t *testing.T) {
+	fsys := fstest.MapFS{
+		"readme.md": &fstest.MapFile{Data: []byte("# Readme")},
+	}
+
+	result := Temper(fsys)
+
+	if !result.HasErrors() {
+		t.Fatal("expected errors for missing manifest")
+	}
+	errors := result.Errors()
+	if len(errors) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(errors))
+	}
+	if errors[0].Message != "no mold.yaml or ingot.yaml found" {
+		t.Errorf("unexpected error message: %s", errors[0].Message)
+	}
+}
+
+func TestTemper_InvalidMoldManifest(t *testing.T) {
+	fsys := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte(`
+apiVersion: v1
+kind: mold
+name: ""
+version: not-semver
+`)},
+	}
+
+	result := Temper(fsys)
+
+	if !result.HasErrors() {
+		t.Fatal("expected errors for invalid manifest")
+	}
+
+	errorMessages := make(map[string]bool)
+	for _, d := range result.Errors() {
+		errorMessages[d.Message] = true
+	}
+
+	if !errorMessages["name is required"] {
+		t.Error("expected 'name is required' error")
+	}
+	if !errorMessages[`version "not-semver" is not valid semver`] {
+		t.Errorf("expected semver error, got errors: %v", result.Errors())
+	}
+}
+
+func TestTemper_InvalidIngotManifest(t *testing.T) {
+	fsys := fstest.MapFS{
+		"ingot.yaml": &fstest.MapFile{Data: []byte(`
+apiVersion: v1
+kind: ingot
+name: ""
+version: bad
+`)},
+	}
+
+	result := Temper(fsys)
+
+	if !result.HasErrors() {
+		t.Fatal("expected errors for invalid ingot manifest")
+	}
+
+	found := false
+	for _, d := range result.Errors() {
+		if d.Message == "name is required" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected 'name is required' error")
+	}
+}
+
+func TestTemper_MissingIngotFiles(t *testing.T) {
+	fsys := fstest.MapFS{
+		"ingot.yaml": &fstest.MapFile{Data: []byte(`
+apiVersion: v1
+kind: ingot
+name: test-ingot
+version: 1.0.0
+files:
+  - missing.md
+`)},
+	}
+
+	result := Temper(fsys)
+
+	if !result.HasErrors() {
+		t.Fatal("expected errors for missing ingot files")
+	}
+
+	found := false
+	for _, d := range result.Errors() {
+		if d.File == "ingot.yaml" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected error referencing ingot.yaml")
+	}
+}
+
+func TestTemper_TemplateSyntaxError(t *testing.T) {
+	fsys := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte(`
+apiVersion: v1
+kind: mold
+name: test-mold
+version: 1.0.0
+`)},
+		"commands/broken.md": &fstest.MapFile{Data: []byte("# Broken\n{{if .foo}")},
+	}
+
+	result := Temper(fsys)
+
+	if !result.HasErrors() {
+		t.Fatal("expected errors for broken template")
+	}
+
+	found := false
+	for _, d := range result.Errors() {
+		if d.File == "commands/broken.md" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected error referencing commands/broken.md")
+	}
+}
+
+func TestTemper_ValidTemplate(t *testing.T) {
+	fsys := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte(`
+apiVersion: v1
+kind: mold
+name: test-mold
+version: 1.0.0
+`)},
+		"commands/good.md": &fstest.MapFile{Data: []byte("# Good\n{{if .foo}}yes{{end}}")},
+	}
+
+	result := Temper(fsys)
+
+	if result.HasErrors() {
+		t.Errorf("expected no errors, got: %v", result.Errors())
+	}
+}
+
+func TestTemper_FluxSchemaValidation(t *testing.T) {
+	fsys := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte(`
+apiVersion: v1
+kind: mold
+name: test-mold
+version: 1.0.0
+`)},
+		"flux.schema.yaml": &fstest.MapFile{Data: []byte(`
+- name: org
+  type: string
+  required: true
+- name: bad
+  type: float
+`)},
+	}
+
+	result := Temper(fsys)
+
+	if !result.HasErrors() {
+		t.Fatal("expected errors for invalid flux schema type")
+	}
+
+	found := false
+	for _, d := range result.Errors() {
+		if d.File == "flux.schema.yaml" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected error referencing flux.schema.yaml")
+	}
+}
+
+func TestTemper_DualFluxWarning(t *testing.T) {
+	fsys := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte(`
+apiVersion: v1
+kind: mold
+name: test-mold
+version: 1.0.0
+flux:
+  - name: org
+    type: string
+    required: true
+`)},
+		"flux.schema.yaml": &fstest.MapFile{Data: []byte(`
+- name: org
+  type: string
+  required: true
+`)},
+	}
+
+	result := Temper(fsys)
+
+	warnings := result.Warnings()
+	if len(warnings) == 0 {
+		t.Fatal("expected warning about dual flux definitions")
+	}
+
+	found := false
+	for _, w := range warnings {
+		if w.Message == "flux variables defined in both mold.yaml and flux.schema.yaml; schema file takes precedence at runtime" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected dual flux definition warning")
+	}
+}
+
+func TestTemper_MalformedYAML(t *testing.T) {
+	fsys := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte(`{{{invalid`)},
+	}
+
+	result := Temper(fsys)
+
+	if !result.HasErrors() {
+		t.Fatal("expected errors for malformed YAML")
+	}
+	if result.Errors()[0].File != "mold.yaml" {
+		t.Errorf("expected error referencing mold.yaml, got %q", result.Errors()[0].File)
+	}
+}
+
+func TestTemper_MissingOutputSources(t *testing.T) {
+	fsys := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte(`
+apiVersion: v1
+kind: mold
+name: test-mold
+version: 1.0.0
+output:
+  nonexistent: .claude/commands
+`)},
+	}
+
+	result := Temper(fsys)
+
+	if !result.HasErrors() {
+		t.Fatal("expected errors for missing output source directory")
+	}
+}
+
+func TestTemperResult_ErrorsAndWarnings(t *testing.T) {
+	r := &TemperResult{
+		Diagnostics: []Diagnostic{
+			{Severity: SeverityError, Message: "err1"},
+			{Severity: SeverityWarning, Message: "warn1"},
+			{Severity: SeverityError, Message: "err2"},
+			{Severity: SeverityWarning, Message: "warn2"},
+		},
+	}
+
+	if !r.HasErrors() {
+		t.Error("expected HasErrors to return true")
+	}
+	if len(r.Errors()) != 2 {
+		t.Errorf("expected 2 errors, got %d", len(r.Errors()))
+	}
+	if len(r.Warnings()) != 2 {
+		t.Errorf("expected 2 warnings, got %d", len(r.Warnings()))
+	}
+}
+
+func TestTemperResult_NoErrors(t *testing.T) {
+	r := &TemperResult{
+		Diagnostics: []Diagnostic{
+			{Severity: SeverityWarning, Message: "warn1"},
+		},
+	}
+
+	if r.HasErrors() {
+		t.Error("expected HasErrors to return false with only warnings")
+	}
+}

--- a/pkg/mold/validate.go
+++ b/pkg/mold/validate.go
@@ -3,8 +3,10 @@ package mold
 import (
 	"fmt"
 	"io/fs"
+	"path/filepath"
 	"regexp"
 	"strings"
+	"text/template"
 )
 
 // semverRegex matches semver strings like "1.0.0", "0.2.0-beta.1", etc.
@@ -139,4 +141,292 @@ func ValidateIngotFiles(i *Ingot, fsys fs.FS, base string) error {
 		return fmt.Errorf("ingot references missing files:\n  - %s", strings.Join(missing, "\n  - "))
 	}
 	return nil
+}
+
+// DiagSeverity indicates whether a diagnostic is an error (blocking) or warning (informational).
+type DiagSeverity int
+
+const (
+	// SeverityError is a blocking issue that causes validation to fail.
+	SeverityError DiagSeverity = iota
+	// SeverityWarning is an informational issue that does not cause failure.
+	SeverityWarning
+)
+
+// Diagnostic represents a single validation finding with severity and location.
+type Diagnostic struct {
+	Severity DiagSeverity
+	Message  string
+	File     string // file path, if applicable
+}
+
+// TemperResult holds the outcome of a temper validation run.
+type TemperResult struct {
+	Diagnostics  []Diagnostic
+	ManifestKind string // "mold" or "ingot"
+	Name         string
+	Version      string
+}
+
+// HasErrors returns true if any diagnostic is an error.
+func (r *TemperResult) HasErrors() bool {
+	for _, d := range r.Diagnostics {
+		if d.Severity == SeverityError {
+			return true
+		}
+	}
+	return false
+}
+
+// Errors returns only error-severity diagnostics.
+func (r *TemperResult) Errors() []Diagnostic {
+	var errs []Diagnostic
+	for _, d := range r.Diagnostics {
+		if d.Severity == SeverityError {
+			errs = append(errs, d)
+		}
+	}
+	return errs
+}
+
+// Warnings returns only warning-severity diagnostics.
+func (r *TemperResult) Warnings() []Diagnostic {
+	var warnings []Diagnostic
+	for _, d := range r.Diagnostics {
+		if d.Severity == SeverityWarning {
+			warnings = append(warnings, d)
+		}
+	}
+	return warnings
+}
+
+// Temper validates a mold or ingot at the given filesystem root.
+// It checks manifest presence, manifest fields, file references,
+// template syntax, and flux schema consistency.
+func Temper(fsys fs.FS) *TemperResult {
+	result := &TemperResult{}
+
+	// Detect manifest type
+	hasMold := fileExists(fsys, "mold.yaml")
+	hasIngot := fileExists(fsys, "ingot.yaml")
+
+	if !hasMold && !hasIngot {
+		result.Diagnostics = append(result.Diagnostics, Diagnostic{
+			Severity: SeverityError,
+			Message:  "no mold.yaml or ingot.yaml found",
+		})
+		return result
+	}
+
+	if hasMold {
+		result.ManifestKind = "mold"
+		temperMold(fsys, result)
+	} else {
+		result.ManifestKind = "ingot"
+		temperIngot(fsys, result)
+	}
+
+	return result
+}
+
+// temperMold validates a mold package.
+func temperMold(fsys fs.FS, result *TemperResult) {
+	m, err := LoadMoldFromFS(fsys, "mold.yaml")
+	if err != nil {
+		result.Diagnostics = append(result.Diagnostics, Diagnostic{
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("failed to parse mold.yaml: %v", err),
+			File:     "mold.yaml",
+		})
+		return
+	}
+
+	result.Name = m.Name
+	result.Version = m.Version
+
+	// Validate manifest fields
+	if err := ValidateMold(m); err != nil {
+		for _, line := range extractValidationErrors(err) {
+			result.Diagnostics = append(result.Diagnostics, Diagnostic{
+				Severity: SeverityError,
+				Message:  line,
+				File:     "mold.yaml",
+			})
+		}
+	}
+
+	// Validate output source references
+	if err := ValidateOutputSources(m, fsys); err != nil {
+		result.Diagnostics = append(result.Diagnostics, Diagnostic{
+			Severity: SeverityError,
+			Message:  err.Error(),
+			File:     "mold.yaml",
+		})
+	}
+
+	// Validate flux schema consistency
+	temperFluxSchema(fsys, m.Flux, result)
+
+	// Validate template syntax for all .md files
+	validateTemplates(fsys, result)
+}
+
+// temperIngot validates an ingot package.
+func temperIngot(fsys fs.FS, result *TemperResult) {
+	i, err := LoadIngotFromFS(fsys, "ingot.yaml")
+	if err != nil {
+		result.Diagnostics = append(result.Diagnostics, Diagnostic{
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("failed to parse ingot.yaml: %v", err),
+			File:     "ingot.yaml",
+		})
+		return
+	}
+
+	result.Name = i.Name
+	result.Version = i.Version
+
+	// Validate manifest fields
+	if err := ValidateIngot(i); err != nil {
+		for _, line := range extractValidationErrors(err) {
+			result.Diagnostics = append(result.Diagnostics, Diagnostic{
+				Severity: SeverityError,
+				Message:  line,
+				File:     "ingot.yaml",
+			})
+		}
+	}
+
+	// Validate file references
+	if len(i.Files) > 0 {
+		for _, f := range i.Files {
+			if !fileExists(fsys, f) {
+				result.Diagnostics = append(result.Diagnostics, Diagnostic{
+					Severity: SeverityError,
+					Message:  fmt.Sprintf("referenced file not found: %s", f),
+					File:     "ingot.yaml",
+				})
+			}
+		}
+	}
+
+	// Validate template syntax for all .md files
+	validateTemplates(fsys, result)
+}
+
+// temperFluxSchema checks flux declarations for consistency.
+func temperFluxSchema(fsys fs.FS, manifestFlux []FluxVar, result *TemperResult) {
+	// Check inline flux declarations (already validated by ValidateMold)
+	// Also check flux.schema.yaml if present
+	schemaFlux, err := LoadFluxSchema(fsys, "flux.schema.yaml")
+	if err != nil {
+		result.Diagnostics = append(result.Diagnostics, Diagnostic{
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("failed to parse flux.schema.yaml: %v", err),
+			File:     "flux.schema.yaml",
+		})
+		return
+	}
+
+	if schemaFlux == nil {
+		return
+	}
+
+	// Validate schema file flux declarations
+	for i, f := range schemaFlux {
+		if f.Name == "" {
+			result.Diagnostics = append(result.Diagnostics, Diagnostic{
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("flux[%d].name is required", i),
+				File:     "flux.schema.yaml",
+			})
+		}
+		if f.Type == "" {
+			result.Diagnostics = append(result.Diagnostics, Diagnostic{
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("flux[%d].type is required", i),
+				File:     "flux.schema.yaml",
+			})
+		} else if !validFluxTypes[f.Type] {
+			result.Diagnostics = append(result.Diagnostics, Diagnostic{
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("flux[%d].type %q is not valid (allowed: string, bool, int, list)", i, f.Type),
+				File:     "flux.schema.yaml",
+			})
+		}
+	}
+
+	// Warn if both manifest and schema file define flux vars
+	if len(manifestFlux) > 0 && len(schemaFlux) > 0 {
+		result.Diagnostics = append(result.Diagnostics, Diagnostic{
+			Severity: SeverityWarning,
+			Message:  "flux variables defined in both mold.yaml and flux.schema.yaml; schema file takes precedence at runtime",
+		})
+	}
+}
+
+// validateTemplates parses all .md files through Go text/template to catch syntax errors.
+func validateTemplates(fsys fs.FS, result *TemperResult) {
+	_ = fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if filepath.Ext(path) != ".md" {
+			return nil
+		}
+		// Skip manifest files
+		if path == "mold.yaml" || path == "ingot.yaml" {
+			return nil
+		}
+
+		data, readErr := fs.ReadFile(fsys, path)
+		if readErr != nil {
+			result.Diagnostics = append(result.Diagnostics, Diagnostic{
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("failed to read file: %v", readErr),
+				File:     path,
+			})
+			return nil
+		}
+
+		content := preProcessTemplate(string(data))
+		if _, parseErr := template.New(path).Option("missingkey=zero").Parse(content); parseErr != nil {
+			result.Diagnostics = append(result.Diagnostics, Diagnostic{
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("template syntax error: %v", parseErr),
+				File:     path,
+			})
+		}
+
+		return nil
+	})
+}
+
+// fileExists checks if a file exists in the given filesystem.
+func fileExists(fsys fs.FS, path string) bool {
+	_, err := fs.Stat(fsys, path)
+	return err == nil
+}
+
+// extractValidationErrors splits a multi-line validation error into individual messages.
+func extractValidationErrors(err error) []string {
+	msg := err.Error()
+	// Validation errors are formatted as "...:\n  - error1\n  - error2"
+	parts := strings.SplitN(msg, ":\n", 2)
+	if len(parts) < 2 {
+		return []string{msg}
+	}
+	lines := strings.Split(parts[1], "\n")
+	var result []string
+	for _, line := range lines {
+		trimmed := strings.TrimPrefix(line, "  - ")
+		trimmed = strings.TrimSpace(trimmed)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
 }


### PR DESCRIPTION
## Description

Add `temper` command (with `lint` alias) to validate and lint mold and ingot packages. The command checks:
- Manifest presence and validity (mold.yaml or ingot.yaml)
- Required manifest fields and correct formats (semver versions)
- File references and their existence
- Template syntax (parses all .md files without rendering)
- Flux schema consistency (inline and flux.schema.yaml)

Reports blocking errors and informational warnings with file paths. Exit code 0 if valid, non-zero if errors found.

## Related Issue

Fixes #43

## Testing

- Unit tests: 14 new tests in `pkg/mold/temper_test.go` cover valid/invalid molds, ingots, syntax errors, flux schema issues
- Integration test: `ailloy temper nimble-mold` and `ailloy lint nimble-mold` both pass successfully
- Pre-push hooks: All tests, lint, and build checks pass across the entire project

## UAT

```bash
# Validate a mold or ingot in current directory
ailloy temper .
ailloy lint .

# Validate a specific directory
ailloy temper /path/to/mold
ailloy lint /path/to/mold
```

Exit code 0 indicates validation passed, non-zero indicates errors found.

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [x] My commits have DCO sign-off (`git commit -s`)