### PR TITLE
refactor: move output config from mold.yaml to flux.yaml

### DIFF
--- a/docs/blanks.md
+++ b/docs/blanks.md
@@ -64,9 +64,9 @@ ailloy cast ./nimble-mold
 Blanks live in mold directories (e.g., `nimble-mold/commands/`). To add new blanks:
 
 1. Create a new `.md` file in `nimble-mold/commands/`
-2. Add the filename to `nimble-mold/mold.yaml` under `commands:`
+2. Ensure the directory is mapped in the `output:` section of `nimble-mold/flux.yaml`
 3. Include clear instructions for Claude Code
 4. Define workflow steps and expected outputs
 5. Test with `ailloy forge ./nimble-mold`
 
-Blanks are automatically discovered by the `MoldReader` from the mold's `mold.yaml` manifest.
+Blanks are automatically discovered by the `MoldReader` from the mold's output mapping in `flux.yaml`.

--- a/internal/commands/forge.go
+++ b/internal/commands/forge.go
@@ -125,8 +125,8 @@ func runForge(_ *cobra.Command, args []string) error {
 	resolver := buildIngotResolver(flux)
 	opts := []mold.TemplateOption{mold.WithIngotResolver(resolver)}
 
-	// Resolve all output files from the mold.
-	resolved, err := mold.ResolveFiles(manifest, reader.FS())
+	// Resolve all output files from the flux.
+	resolved, err := mold.ResolveFiles(flux["output"], reader.FS())
 	if err != nil {
 		return fmt.Errorf("resolving output files: %w", err)
 	}

--- a/nimble-mold/flux.yaml
+++ b/nimble-mold/flux.yaml
@@ -1,3 +1,9 @@
+output:
+  commands: .claude/commands
+  skills: .claude/skills
+  workflows:
+    dest: .github/workflows
+    process: false
 api:
   base: gh api
   file_content: gh api repos/:owner/:repo/contents/<file-path>?ref=<ref>

--- a/nimble-mold/mold.yaml
+++ b/nimble-mold/mold.yaml
@@ -8,9 +8,3 @@ author:
   url: https://github.com/nimble-giant/ailloy
 requires:
   ailloy: ">=0.2.0"
-output:
-  commands: .claude/commands
-  skills: .claude/skills
-  workflows:
-    dest: .github/workflows
-    process: false

--- a/pkg/blanks/blanks_test.go
+++ b/pkg/blanks/blanks_test.go
@@ -15,14 +15,14 @@ func testReader() *MoldReader {
 kind: mold
 name: test-mold
 version: 1.0.0
-output:
+`)},
+		"flux.yaml": &fstest.MapFile{Data: []byte(`output:
   commands: .claude/commands
   skills: .claude/skills
   workflows:
     dest: .github/workflows
     process: false
-`)},
-		"flux.yaml": &fstest.MapFile{Data: []byte(`board: Engineering
+board: Engineering
 org: test-org
 `)},
 		"flux.schema.yaml": &fstest.MapFile{Data: []byte(`- name: org
@@ -39,12 +39,12 @@ org: test-org
 
 func TestResolveFiles(t *testing.T) {
 	reader := testReader()
-	manifest, err := reader.LoadManifest()
+	flux, err := reader.LoadFluxDefaults()
 	if err != nil {
-		t.Fatalf("unexpected error loading manifest: %v", err)
+		t.Fatalf("unexpected error loading flux: %v", err)
 	}
 
-	resolved, err := mold.ResolveFiles(manifest, reader.FS())
+	resolved, err := mold.ResolveFiles(flux["output"], reader.FS())
 	if err != nil {
 		t.Fatalf("unexpected error resolving files: %v", err)
 	}
@@ -68,12 +68,12 @@ func TestResolveFiles(t *testing.T) {
 
 func TestResolveFiles_OutputMapping(t *testing.T) {
 	reader := testReader()
-	manifest, err := reader.LoadManifest()
+	flux, err := reader.LoadFluxDefaults()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	resolved, err := mold.ResolveFiles(manifest, reader.FS())
+	resolved, err := mold.ResolveFiles(flux["output"], reader.FS())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -103,12 +103,12 @@ func TestResolveFiles_OutputMapping(t *testing.T) {
 
 func TestResolveFiles_ProcessFlag(t *testing.T) {
 	reader := testReader()
-	manifest, err := reader.LoadManifest()
+	flux, err := reader.LoadFluxDefaults()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	resolved, err := mold.ResolveFiles(manifest, reader.FS())
+	resolved, err := mold.ResolveFiles(flux["output"], reader.FS())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -134,9 +134,6 @@ func TestLoadManifest(t *testing.T) {
 	}
 	if manifest.Name != "test-mold" {
 		t.Errorf("expected name=test-mold, got %q", manifest.Name)
-	}
-	if manifest.Output == nil {
-		t.Error("expected output to be set")
 	}
 }
 

--- a/pkg/mold/mold.go
+++ b/pkg/mold/mold.go
@@ -84,7 +84,6 @@ type Mold struct {
 	Author       Author       `yaml:"author,omitempty"`
 	Requires     Requires     `yaml:"requires,omitempty"`
 	Flux         []FluxVar    `yaml:"flux,omitempty"`
-	Output       any          `yaml:"output,omitempty"`
 	Dependencies []Dependency `yaml:"dependencies,omitempty"`
 }
 

--- a/pkg/mold/mold_test.go
+++ b/pkg/mold/mold_test.go
@@ -28,12 +28,6 @@ flux:
     type: string
     required: false
     default: "Engineering"
-output:
-  commands: .claude/commands
-  skills: .claude/skills
-  workflows:
-    dest: .github/workflows
-    process: false
 dependencies:
   - ingot: pr-format
     version: "^1.0.0"
@@ -76,9 +70,6 @@ dependencies:
 	}
 	if m.Flux[1].Default != "Engineering" {
 		t.Errorf("expected flux[1].default Engineering, got %s", m.Flux[1].Default)
-	}
-	if m.Output == nil {
-		t.Error("expected output to be set")
 	}
 	if len(m.Dependencies) != 1 {
 		t.Fatalf("expected 1 dependency, got %d", len(m.Dependencies))
@@ -256,23 +247,20 @@ func TestValidateMold_ValidFluxTypes(t *testing.T) {
 }
 
 func TestValidateOutputSources(t *testing.T) {
-	m := &Mold{
-		Output: map[string]any{
-			"commands": ".claude/commands",
-		},
+	output := map[string]any{
+		"commands": ".claude/commands",
 	}
 	fsys := fstest.MapFS{
 		"commands/create-issue.md": &fstest.MapFile{Data: []byte("# test")},
 	}
-	if err := ValidateOutputSources(m, fsys); err != nil {
+	if err := ValidateOutputSources(output, fsys); err != nil {
 		t.Errorf("expected no error, got: %v", err)
 	}
 }
 
 func TestValidateOutputSources_NilOutput(t *testing.T) {
-	m := &Mold{Output: nil}
 	fsys := fstest.MapFS{}
-	if err := ValidateOutputSources(m, fsys); err != nil {
+	if err := ValidateOutputSources(nil, fsys); err != nil {
 		t.Errorf("expected no error for nil output, got: %v", err)
 	}
 }

--- a/pkg/mold/output.go
+++ b/pkg/mold/output.go
@@ -28,9 +28,9 @@ type fileMapping struct {
 }
 
 // ResolveFiles walks the mold filesystem and resolves all files according
-// to the output mapping in the manifest.
+// to the output mapping.
 //
-// If output is absent, all top-level directories (excluding reserved names
+// If output is nil, all top-level directories (excluding reserved names
 // like "ingots") are walked with identity mapping (src path = dest path).
 //
 // If output is a string, it's treated as a parent directory — all top-level
@@ -39,12 +39,12 @@ type fileMapping struct {
 // If output is a map, each entry maps a source directory or file to a
 // destination. Values can be strings (simple dest path) or maps with
 // "dest" and optional "process" fields.
-func ResolveFiles(m *Mold, moldFS fs.FS) ([]ResolvedFile, error) {
-	if m.Output == nil {
+func ResolveFiles(output any, moldFS fs.FS) ([]ResolvedFile, error) {
+	if output == nil {
 		return resolveIdentity(moldFS)
 	}
 
-	dirs, files, err := parseOutput(m.Output, moldFS)
+	dirs, files, err := parseOutput(output, moldFS)
 	if err != nil {
 		return nil, fmt.Errorf("parsing output mapping: %w", err)
 	}

--- a/pkg/mold/output_test.go
+++ b/pkg/mold/output_test.go
@@ -11,9 +11,7 @@ func TestResolveFiles_StringOutput(t *testing.T) {
 		"skills/helper.md":  &fstest.MapFile{Data: []byte("helper")},
 	}
 
-	m := &Mold{Output: ".claude"}
-
-	resolved, err := ResolveFiles(m, moldFS)
+	resolved, err := ResolveFiles(".claude", moldFS)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -48,14 +46,12 @@ func TestResolveFiles_MapOutput(t *testing.T) {
 		"skills/helper.md":  &fstest.MapFile{Data: []byte("helper")},
 	}
 
-	m := &Mold{
-		Output: map[string]any{
-			"commands": ".claude/commands",
-			"skills":   ".claude/skills",
-		},
+	output := map[string]any{
+		"commands": ".claude/commands",
+		"skills":   ".claude/skills",
 	}
 
-	resolved, err := ResolveFiles(m, moldFS)
+	resolved, err := ResolveFiles(output, moldFS)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -87,17 +83,15 @@ func TestResolveFiles_ExpandedOutput(t *testing.T) {
 		"workflows/ci.yml":  &fstest.MapFile{Data: []byte("name: CI")},
 	}
 
-	m := &Mold{
-		Output: map[string]any{
-			"commands": ".claude/commands",
-			"workflows": map[string]any{
-				"dest":    ".github/workflows",
-				"process": false,
-			},
+	output := map[string]any{
+		"commands": ".claude/commands",
+		"workflows": map[string]any{
+			"dest":    ".github/workflows",
+			"process": false,
 		},
 	}
 
-	resolved, err := ResolveFiles(m, moldFS)
+	resolved, err := ResolveFiles(output, moldFS)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -134,14 +128,12 @@ func TestResolveFiles_FileLevelOverride(t *testing.T) {
 		"commands/special.md": &fstest.MapFile{Data: []byte("special")},
 	}
 
-	m := &Mold{
-		Output: map[string]any{
-			"commands":            ".claude/commands",
-			"commands/special.md": "custom/special.md",
-		},
+	output := map[string]any{
+		"commands":            ".claude/commands",
+		"commands/special.md": "custom/special.md",
 	}
 
-	resolved, err := ResolveFiles(m, moldFS)
+	resolved, err := ResolveFiles(output, moldFS)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -171,13 +163,11 @@ func TestResolveFiles_RecursiveWalk(t *testing.T) {
 		"commands/sub/nested.md": &fstest.MapFile{Data: []byte("nested")},
 	}
 
-	m := &Mold{
-		Output: map[string]any{
-			"commands": "dest",
-		},
+	output := map[string]any{
+		"commands": "dest",
 	}
 
-	resolved, err := ResolveFiles(m, moldFS)
+	resolved, err := ResolveFiles(output, moldFS)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -200,9 +190,7 @@ func TestResolveFiles_NoOutput(t *testing.T) {
 		"ingots/foo.md":     &fstest.MapFile{Data: []byte("ingot")},
 	}
 
-	m := &Mold{Output: nil}
-
-	resolved, err := ResolveFiles(m, moldFS)
+	resolved, err := ResolveFiles(nil, moldFS)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -228,16 +216,14 @@ func TestResolveFiles_MissingSourceDir(t *testing.T) {
 		"commands/hello.md": &fstest.MapFile{Data: []byte("hello")},
 	}
 
-	m := &Mold{
-		Output: map[string]any{
-			"nonexistent": ".claude/nonexistent",
-		},
+	output := map[string]any{
+		"nonexistent": ".claude/nonexistent",
 	}
 
 	// "nonexistent" is not a directory in the FS, so parseMapOutput treats it
 	// as a file mapping. The remaining-files loop tries to stat it and returns
 	// an error since the file doesn't exist.
-	_, err := ResolveFiles(m, moldFS)
+	_, err := ResolveFiles(output, moldFS)
 	if err == nil {
 		t.Fatal("expected error for nonexistent file mapping")
 	}
@@ -250,9 +236,7 @@ func TestResolveFiles_ExcludesReservedDirs(t *testing.T) {
 		".hidden/bar.md":    &fstest.MapFile{Data: []byte("hidden")},
 	}
 
-	m := &Mold{Output: ".claude"}
-
-	resolved, err := ResolveFiles(m, moldFS)
+	resolved, err := ResolveFiles(".claude", moldFS)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/mold/temper_test.go
+++ b/pkg/mold/temper_test.go
@@ -12,6 +12,8 @@ apiVersion: v1
 kind: mold
 name: test-mold
 version: 1.0.0
+`)},
+		"flux.yaml": &fstest.MapFile{Data: []byte(`
 output:
   commands: .claude/commands
 `)},
@@ -303,6 +305,8 @@ apiVersion: v1
 kind: mold
 name: test-mold
 version: 1.0.0
+`)},
+		"flux.yaml": &fstest.MapFile{Data: []byte(`
 output:
   nonexistent: .claude/commands
 `)},

--- a/pkg/mold/validate.go
+++ b/pkg/mold/validate.go
@@ -90,12 +90,12 @@ func ValidateMold(m *Mold) error {
 
 // ValidateOutputSources checks that all source directories/files referenced in
 // the output mapping actually exist in the mold filesystem.
-func ValidateOutputSources(m *Mold, fsys fs.FS) error {
-	if m.Output == nil {
+func ValidateOutputSources(output any, fsys fs.FS) error {
+	if output == nil {
 		return nil // no output mapping, identity mode — discovery handles existence
 	}
 
-	resolved, err := ResolveFiles(m, fsys)
+	resolved, err := ResolveFiles(output, fsys)
 	if err != nil {
 		return fmt.Errorf("resolving output mapping: %w", err)
 	}
@@ -265,12 +265,13 @@ func temperMold(fsys fs.FS, result *TemperResult) {
 		}
 	}
 
-	// Validate output source references
-	if err := ValidateOutputSources(m, fsys); err != nil {
+	// Validate output source references (output lives in flux.yaml)
+	flux, _ := LoadFluxFile(fsys, "flux.yaml")
+	if err := ValidateOutputSources(flux["output"], fsys); err != nil {
 		result.Diagnostics = append(result.Diagnostics, Diagnostic{
 			Severity: SeverityError,
 			Message:  err.Error(),
-			File:     "mold.yaml",
+			File:     "flux.yaml",
 		})
 	}
 

--- a/pkg/plugin/generator.go
+++ b/pkg/plugin/generator.go
@@ -92,12 +92,12 @@ func (g *Generator) Generate() error {
 
 // loadBlanks loads all blanks from the mold reader using convention-based discovery.
 func (g *Generator) loadBlanks() error {
-	manifest, err := g.reader.LoadManifest()
+	flux, err := g.reader.LoadFluxDefaults()
 	if err != nil {
-		return fmt.Errorf("loading manifest: %w", err)
+		flux = make(map[string]any)
 	}
 
-	resolved, err := mold.ResolveFiles(manifest, g.reader.FS())
+	resolved, err := mold.ResolveFiles(flux["output"], g.reader.FS())
 	if err != nil {
 		return fmt.Errorf("resolving files: %w", err)
 	}

--- a/pkg/smelt/binary.go
+++ b/pkg/smelt/binary.go
@@ -34,7 +34,7 @@ func PackageBinary(moldDir, outputDir string) (string, int64, error) {
 	moldFS := os.DirFS(cleanDir)
 
 	// Collect files to include in the binary.
-	files, hasFluxYAML, err := collectMoldFiles(m, moldFS, cleanDir)
+	files, hasFluxYAML, err := collectMoldFiles(moldFS, cleanDir)
 	if err != nil {
 		return "", 0, fmt.Errorf("collecting files: %w", err)
 	}


### PR DESCRIPTION
## Description

Moves the `output` configuration from `mold.yaml` to `flux.yaml`, making output mappings part of the consumer-configurable flux value layer. This allows users to override destination paths using standard flux layering (`-f` value files or `--set` flags), treating output as a first-class configurable aspect of molds rather than a manifest-level concern.

## Changes

- **Core types**: Remove `Output` field from `Mold` struct; change `ResolveFiles` and `ValidateOutputSources` signatures to accept output directly
- **Consumers**: Update `cast`, `forge`, `smelt`, and plugin commands to load output from flux
- **Data**: Move output mapping from `nimble-mold/mold.yaml` to `nimble-mold/flux.yaml`
- **Tests & Docs**: Update all test fixtures and move documentation from smelt.md Step 1 to Step 2

## Testing

All tests pass (unit and integration). Manual verification confirms `ailloy forge ./nimble-mold` renders correctly and `ailloy temper` validates the mold successfully.

## Checklist

- [x] Code compiles with no errors
- [x] All tests pass
- [x] go vet passes
- [x] Documentation updated
- [x] Git hooks (pre-commit, commit-msg, pre-push) all pass