### PR TITLE
feat: add CODEOWNERS for nimble-giant/engineers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for everything in the repo
+* @nimble-giant/engineers


### PR DESCRIPTION
## Description

Adds a `.github/CODEOWNERS` file that assigns `@nimble-giant/engineers` as the default reviewer for all files in the repository.

## Related Issue

No related issue

## Testing

N/A — configuration file only

## UAT

Verify that PRs opened against this repo automatically request review from `@nimble-giant/engineers`

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [x] I have updated documentation (if applicable)
- [x] My commits have DCO sign-off (`git commit -s`)