### PR TITLE
Remove hardcoded release version from config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,6 @@
   "packages": {
     ".": {
       "release-type": "go",
-      "release-as": "0.6.7",
       "component": "ailloy",
       "include-component-in-tag": false,
       "initial-version": "0.1.0",


### PR DESCRIPTION
## Description

Remove the hardcoded `release-as: "0.6.7"` configuration from `release-please-config.json`. This allows release-please to automatically determine the next version based on conventional commits rather than being pinned to a specific version.

## Related Issue

N/A

## Testing

N/A - Configuration change only. The release-please tool will use semantic versioning based on commit messages for the next release.

## UAT

N/A

## Checklist

- [ ] I have read the CONTRIBUTING guidelines
- [ ] My code follows the project style
- [ ] I have added tests (if applicable)
- [ ] I have updated documentation (if applicable)
- [ ] My commits have DCO sign-off (`git commit -s`)

https://claude.ai/code/session_01ERfY5egRrarUiHhZf3erwS