### PR TITLE
feat: add --lint flag to temper command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Key CLI commands for working with molds:
 - **cast** (`install`): Install molds into a project
 - **forge** (`template`): Preview rendered output (dry run)
 - **assay** (`lint`): Lint AI instruction files against best practices
-- **temper** (`validate`): Validate a mold or ingot package
+- **temper** (`validate`): Validate a mold or ingot package; use `--lint` to also render and lint output
 - **anneal** (`configure`): Configure flux variables interactively
 - **smelt** (`package`): Package a mold for distribution
 - **recast**: Re-render and update previously cast blanks

--- a/README.md
+++ b/README.md
@@ -173,6 +173,9 @@ Validate a mold or ingot package (alias: `validate`):
 
 - Checks structural integrity, manifest fields, file references, template syntax, and flux schema consistency
 - Reports errors (blocking) and warnings (informational)
+- `--lint`: Also render blanks and run assay (lint) on the output — catches content issues before casting
+- `--set key=value`, `-f, --values file`: Provide flux values for rendering (same as forge/cast)
+- `--format`, `--fail-on`, `--max-lines`: Control assay output and failure threshold
 
 ### `ailloy foundry`
 

--- a/docs/temper.md
+++ b/docs/temper.md
@@ -4,7 +4,7 @@ The `temper` command validates mold and ingot packages. It checks manifest field
 
 Alias: `validate`
 
-> **Note:** To lint rendered AI instruction files (CLAUDE.md, AGENTS.md, Cursor rules, etc.), use [`ailloy assay`](assay.md) instead.
+> **Note:** To lint rendered AI instruction files (CLAUDE.md, AGENTS.md, Cursor rules, etc.) in an already-cast project, use [`ailloy assay`](assay.md). To lint a mold's output *before* casting, use `ailloy temper --lint`.
 
 ## Quick Start
 
@@ -14,6 +14,9 @@ ailloy temper ./my-mold
 
 # Validate an ingot
 ailloy temper ./my-ingot
+
+# Validate and lint rendered output in one step
+ailloy temper --lint ./my-mold
 
 # Using the alias
 ailloy validate ./my-mold
@@ -73,24 +76,45 @@ For ingots (`ingot.yaml` present), temper checks:
 
 Currently the only warning is when flux variables are defined in both `mold.yaml` and `flux.schema.yaml` (the schema file takes precedence at runtime).
 
+## Linting Rendered Output (`--lint`)
+
+The `--lint` flag renders the mold's blanks into a temporary directory and runs [`ailloy assay`](assay.md) against the output. This catches content-level issues (line count, structure, cross-references, naming conventions) before casting — without needing a separate `cast` + `assay` step.
+
+```bash
+# Validate structure and lint rendered output
+ailloy temper --lint ./my-mold
+
+# Provide flux values for rendering (same flags as forge/cast)
+ailloy temper --lint -f my-values.yaml ./my-mold
+ailloy temper --lint --set project.organization=acme ./my-mold
+
+# Control assay output format and failure threshold
+ailloy temper --lint --format json ./my-mold
+ailloy temper --lint --fail-on warning ./my-mold
+
+# Override assay line-count threshold
+ailloy temper --lint --max-lines 200 ./my-mold
+```
+
+When `--lint` is used, temper first runs its normal structural validation. If that passes, it renders blanks using the mold's flux defaults (plus any `-f` / `--set` overrides) and runs assay on the result. Both sets of findings are reported.
+
+> **Note:** `--lint` is only supported for molds, not ingots.
+
 ## CI Integration
 
 Run `ailloy temper` in your CI pipeline to catch issues before packaging or releasing:
 
 ```yaml
 # GitHub Actions example
-- name: Validate mold
-  run: ailloy temper ./my-mold
+- name: Validate and lint mold
+  run: ailloy temper --lint ./my-mold
 ```
 
 A recommended workflow:
 
 ```bash
-# Validate structure
-ailloy temper ./my-mold
-
-# Preview rendered output
-ailloy forge ./my-mold
+# Validate structure and lint rendered output in one step
+ailloy temper --lint ./my-mold
 
 # Package for distribution
 ailloy smelt ./my-mold
@@ -107,4 +131,15 @@ Common template errors caught:
 - Invalid template function calls
 - Malformed template expressions
 
-Note: Temper checks syntax only, not whether variables resolve to values. Use `ailloy forge` with your actual flux values to verify that all variables are populated.
+Note: Temper checks syntax only, not whether variables resolve to values. Use `ailloy temper --lint` or `ailloy forge` with your actual flux values to verify that all variables are populated.
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--lint` | Render blanks and run assay (lint) on the output |
+| `--set key=value` | Set flux values for rendering (can be repeated) |
+| `-f, --values file` | Layer flux value files for rendering (can be repeated) |
+| `--format format` | Assay output format: `console` (default), `json`, `markdown` |
+| `--fail-on level` | Assay exit threshold: `error` (default), `warning`, `suggestion` |
+| `--max-lines n` | Override assay line-count threshold (default: 150) |

--- a/internal/commands/temper.go
+++ b/internal/commands/temper.go
@@ -2,8 +2,13 @@ package commands
 
 import (
 	"fmt"
+	"io/fs"
+	"log"
 	"os"
+	"path/filepath"
 
+	"github.com/nimble-giant/ailloy/pkg/assay"
+	"github.com/nimble-giant/ailloy/pkg/blanks"
 	"github.com/nimble-giant/ailloy/pkg/mold"
 	"github.com/nimble-giant/ailloy/pkg/styles"
 	"github.com/spf13/cobra"
@@ -17,13 +22,33 @@ var temperCmd = &cobra.Command{
 
 Checks structural integrity, manifest fields, file references,
 template syntax, and flux schema consistency. Reports errors
-(blocking) and warnings (informational).`,
+(blocking) and warnings (informational).
+
+Use --lint to also render blanks and run assay (lint) on the output.
+This catches content-level issues (line count, structure, cross-references)
+before casting, without needing a separate cast + assay step.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runTemper,
 }
 
+var (
+	temperLint      bool
+	temperSetValues []string
+	temperValFiles  []string
+	temperFormat    string
+	temperFailOn    string
+	temperMaxLines  int
+)
+
 func init() {
 	rootCmd.AddCommand(temperCmd)
+
+	temperCmd.Flags().BoolVar(&temperLint, "lint", false, "render blanks and run assay (lint) on the output")
+	temperCmd.Flags().StringArrayVar(&temperSetValues, "set", nil, "set flux values for rendering (key=value)")
+	temperCmd.Flags().StringArrayVarP(&temperValFiles, "values", "f", nil, "flux value files for rendering (can be repeated)")
+	temperCmd.Flags().StringVar(&temperFormat, "format", "console", "assay output format: console, json, markdown")
+	temperCmd.Flags().StringVar(&temperFailOn, "fail-on", "error", "assay exit threshold: error, warning, suggestion")
+	temperCmd.Flags().IntVar(&temperMaxLines, "max-lines", 0, "override assay line-count threshold (default: 150)")
 }
 
 func runTemper(_ *cobra.Command, args []string) error {
@@ -76,5 +101,208 @@ func runTemper(_ *cobra.Command, args []string) error {
 
 	msg := fmt.Sprintf("Validation passed: 0 errors, %d warning(s)", len(warnings))
 	fmt.Println(styles.SuccessStyle.Render(msg))
+
+	// Run assay (lint) on rendered blanks if requested
+	if temperLint {
+		if result.ManifestKind != "mold" {
+			fmt.Println()
+			fmt.Println(styles.InfoStyle.Render("--lint is only supported for molds, skipping."))
+			return nil
+		}
+
+		fmt.Println()
+		if err := runTemperLint(moldDir); err != nil {
+			return err
+		}
+	}
+
 	return nil
+}
+
+// runTemperLint renders the mold blanks into a temp directory and runs assay on them.
+func runTemperLint(moldDir string) error {
+	fmt.Println(styles.WorkingBanner("Linting rendered blanks..."))
+	fmt.Println()
+
+	reader, err := blanks.NewMoldReaderFromPath(moldDir)
+	if err != nil {
+		return fmt.Errorf("reading mold: %w", err)
+	}
+
+	// Load flux with layering (same precedence as forge/cast)
+	flux, err := loadTemperFlux(reader)
+	if err != nil {
+		return fmt.Errorf("loading flux: %w", err)
+	}
+
+	manifest, err := reader.LoadManifest()
+	if err != nil {
+		return fmt.Errorf("loading manifest: %w", err)
+	}
+
+	// Validate flux against schema
+	schema, _ := reader.LoadFluxSchema()
+	if schema == nil && len(manifest.Flux) > 0 {
+		schema = manifest.Flux
+	}
+	if err := mold.ValidateFlux(schema, flux); err != nil {
+		log.Printf("warning: %v", err)
+	}
+
+	// Build ingot resolver and render files
+	resolver := buildIngotResolver(flux)
+	opts := []mold.TemplateOption{mold.WithIngotResolver(resolver)}
+
+	resolved, err := mold.ResolveFiles(flux["output"], reader.FS())
+	if err != nil {
+		return fmt.Errorf("resolving output files: %w", err)
+	}
+
+	// Render to temp directory
+	tmpDir, err := os.MkdirTemp("", "ailloy-temper-lint-*")
+	if err != nil {
+		return fmt.Errorf("creating temp directory: %w", err)
+	}
+	defer os.RemoveAll(tmpDir) //#nosec G104
+
+	if err := writeRenderedFiles(resolved, reader.FS(), flux, opts, tmpDir); err != nil {
+		return err
+	}
+
+	// Run assay on the rendered output
+	return runAssayOnDir(tmpDir)
+}
+
+// writeRenderedFiles renders resolved files and writes them to outputDir.
+func writeRenderedFiles(resolved []mold.ResolvedFile, moldFS fs.FS, flux map[string]any, opts []mold.TemplateOption, outputDir string) error {
+	for _, rf := range resolved {
+		content, err := fs.ReadFile(moldFS, rf.SrcPath)
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", rf.SrcPath, err)
+		}
+
+		var rendered string
+		if rf.Process {
+			rendered, err = renderFile(rf.SrcPath, content, flux, opts...)
+			if err != nil {
+				return err
+			}
+		} else {
+			rendered = string(content)
+		}
+
+		dest := filepath.Join(outputDir, rf.DestPath)
+		if err := os.MkdirAll(filepath.Dir(dest), 0750); err != nil { // #nosec G301 -- Output directories need group read access
+			return fmt.Errorf("creating directory for %s: %w", rf.DestPath, err)
+		}
+		//#nosec G306 -- Rendered blanks need to be readable
+		if err := os.WriteFile(dest, []byte(rendered), 0644); err != nil {
+			return fmt.Errorf("writing %s: %w", rf.DestPath, err)
+		}
+	}
+	return nil
+}
+
+// runAssayOnDir runs assay against the given directory and formats the output.
+func runAssayOnDir(dir string) error {
+	cfg := assay.DefaultConfig()
+
+	if temperMaxLines > 0 {
+		if cfg.Rules == nil {
+			cfg.Rules = make(map[string]assay.RuleConfig)
+		}
+		rc := cfg.Rules["line-count"]
+		if rc.Options == nil {
+			rc.Options = make(map[string]any)
+		}
+		rc.Options["max-lines"] = temperMaxLines
+		cfg.Rules["line-count"] = rc
+	}
+
+	result, err := assay.Assay(dir, cfg)
+	if err != nil {
+		return fmt.Errorf("assay: %w", err)
+	}
+
+	if result.FilesScanned == 0 {
+		fmt.Println(styles.InfoStyle.Render("No AI instruction files found in rendered output."))
+		return nil
+	}
+
+	// Format and print output
+	formatter := assay.NewFormatter(temperFormat, dir)
+	output := formatter.Format(result)
+	if output != "" {
+		fmt.Print(output)
+	}
+
+	// Print summary
+	errs := len(result.Errors())
+	warns := len(result.Warnings())
+	suggestions := len(result.Suggestions())
+
+	if errs > 0 || warns > 0 || suggestions > 0 {
+		fmt.Println()
+	}
+
+	fmt.Printf("%s scanned, ", styles.InfoStyle.Render(fmt.Sprintf("%d file(s)", result.FilesScanned)))
+
+	var failOnSeverity mold.DiagSeverity
+	switch temperFailOn {
+	case "suggestion":
+		failOnSeverity = mold.SeveritySuggestion
+	case "warning":
+		failOnSeverity = mold.SeverityWarning
+	default:
+		failOnSeverity = mold.SeverityError
+	}
+
+	if result.HasFailures(failOnSeverity) {
+		fmt.Println(styles.ErrorStyle.Render(fmt.Sprintf("%d error(s), %d warning(s), %d suggestion(s)",
+			errs, warns, suggestions)))
+		return fmt.Errorf("temper --lint: assay findings exceed --%s threshold", temperFailOn)
+	}
+
+	fmt.Println(styles.SuccessStyle.Render(fmt.Sprintf("%d error(s), %d warning(s), %d suggestion(s)",
+		errs, warns, suggestions)))
+
+	return nil
+}
+
+// loadTemperFlux loads layered flux values using the same Helm-style precedence as forge/cast.
+func loadTemperFlux(reader *blanks.MoldReader) (map[string]any, error) {
+	// Layer 1: Load mold flux.yaml as base
+	fluxDefaults, err := reader.LoadFluxDefaults()
+	if err != nil {
+		fluxDefaults = make(map[string]any)
+	}
+
+	// Layer 2: Apply mold.yaml schema defaults
+	manifest, _ := reader.LoadManifest()
+	if manifest != nil && len(manifest.Flux) > 0 {
+		fluxDefaults = mold.ApplyFluxDefaults(manifest.Flux, fluxDefaults)
+	}
+
+	flux := make(map[string]any)
+	for k, v := range fluxDefaults {
+		flux[k] = v
+	}
+
+	// Layer 3: Layer -f files left-to-right
+	if len(temperValFiles) > 0 {
+		overlay, err := mold.LayerFluxFiles(temperValFiles)
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range overlay {
+			flux[k] = v
+		}
+	}
+
+	// Layer 4: Apply --set overrides (highest precedence)
+	if err := mold.ApplySetOverrides(flux, temperSetValues); err != nil {
+		return nil, err
+	}
+
+	return flux, nil
 }

--- a/internal/commands/temper.go
+++ b/internal/commands/temper.go
@@ -163,7 +163,9 @@ func runTemperLint(moldDir string) error {
 	if err != nil {
 		return fmt.Errorf("creating temp directory: %w", err)
 	}
-	defer os.RemoveAll(tmpDir) //#nosec G104
+	defer func() {
+		_ = os.RemoveAll(tmpDir) //#nosec G104
+	}()
 
 	if err := writeRenderedFiles(resolved, reader.FS(), flux, opts, tmpDir); err != nil {
 		return err

--- a/internal/commands/temper_integration_test.go
+++ b/internal/commands/temper_integration_test.go
@@ -1,0 +1,183 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nimble-giant/ailloy/pkg/assay"
+	"github.com/nimble-giant/ailloy/pkg/mold"
+)
+
+func TestIntegration_TemperLint_RendersAndLints(t *testing.T) {
+	reader := testMoldReader(t)
+	flux := testFlux(t, reader)
+
+	manifest, err := reader.LoadManifest()
+	if err != nil {
+		t.Fatalf("failed to load manifest: %v", err)
+	}
+
+	// Validate flux against schema
+	schema, _ := reader.LoadFluxSchema()
+	if schema == nil && len(manifest.Flux) > 0 {
+		schema = manifest.Flux
+	}
+
+	// Build ingot resolver and resolve files
+	resolver := buildIngotResolver(flux)
+	opts := []mold.TemplateOption{mold.WithIngotResolver(resolver)}
+
+	resolved, err := mold.ResolveFiles(flux["output"], reader.FS())
+	if err != nil {
+		t.Fatalf("failed to resolve files: %v", err)
+	}
+
+	if len(resolved) == 0 {
+		t.Fatal("expected resolved files, got none")
+	}
+
+	// Render to temp directory
+	tmpDir := t.TempDir()
+	err = writeRenderedFiles(resolved, reader.FS(), flux, opts, tmpDir)
+	if err != nil {
+		t.Fatalf("writeRenderedFiles failed: %v", err)
+	}
+
+	// Verify files were written
+	for _, rf := range resolved {
+		path := filepath.Join(tmpDir, rf.DestPath)
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Errorf("expected file %s to be created: %v", rf.DestPath, err)
+			continue
+		}
+		if info.Size() == 0 {
+			t.Errorf("file %s is empty", rf.DestPath)
+		}
+	}
+
+	// Run assay on the rendered output
+	cfg := assay.DefaultConfig()
+	result, err := assay.Assay(tmpDir, cfg)
+	if err != nil {
+		t.Fatalf("assay failed: %v", err)
+	}
+
+	if result.FilesScanned == 0 {
+		t.Error("expected assay to scan at least one file")
+	}
+}
+
+func TestIntegration_TemperLint_WriteRenderedFiles_CreatesDirectories(t *testing.T) {
+	reader := testMoldReader(t)
+	flux := testFlux(t, reader)
+
+	resolver := buildIngotResolver(flux)
+	opts := []mold.TemplateOption{mold.WithIngotResolver(resolver)}
+
+	resolved, err := mold.ResolveFiles(flux["output"], reader.FS())
+	if err != nil {
+		t.Fatalf("failed to resolve files: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	err = writeRenderedFiles(resolved, reader.FS(), flux, opts, tmpDir)
+	if err != nil {
+		t.Fatalf("writeRenderedFiles failed: %v", err)
+	}
+
+	// Verify expected directories exist
+	expectedDirs := []string{
+		".claude/commands",
+		".claude/skills",
+	}
+
+	for _, dir := range expectedDirs {
+		path := filepath.Join(tmpDir, dir)
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Errorf("directory %s not created: %v", dir, err)
+			continue
+		}
+		if !info.IsDir() {
+			t.Errorf("expected %s to be a directory", dir)
+		}
+	}
+}
+
+func TestIntegration_TemperLint_AssayFindsClaudeFiles(t *testing.T) {
+	// Create a minimal rendered output structure that assay can detect
+	tmpDir := t.TempDir()
+
+	claudeDir := filepath.Join(tmpDir, ".claude", "commands")
+	if err := os.MkdirAll(claudeDir, 0750); err != nil {
+		t.Fatalf("failed to create dir: %v", err)
+	}
+
+	// Write a command file with frontmatter that assay will scan
+	content := `---
+description: Test command for temper lint integration
+---
+
+# Test Command
+
+This is a test command.
+`
+	if err := os.WriteFile(filepath.Join(claudeDir, "test.md"), []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+
+	cfg := assay.DefaultConfig()
+	result, err := assay.Assay(tmpDir, cfg)
+	if err != nil {
+		t.Fatalf("assay failed: %v", err)
+	}
+
+	if result.FilesScanned == 0 {
+		t.Error("expected assay to find files in rendered output")
+	}
+}
+
+func TestWriteRenderedFiles_RendersTemplates(t *testing.T) {
+	reader := testMoldReader(t)
+	flux := testFlux(t, reader)
+
+	resolver := buildIngotResolver(flux)
+	opts := []mold.TemplateOption{mold.WithIngotResolver(resolver)}
+
+	resolved, err := mold.ResolveFiles(flux["output"], reader.FS())
+	if err != nil {
+		t.Fatalf("failed to resolve files: %v", err)
+	}
+
+	// Filter to processable files only
+	var processable []mold.ResolvedFile
+	for _, rf := range resolved {
+		if rf.Process {
+			processable = append(processable, rf)
+		}
+	}
+
+	if len(processable) == 0 {
+		t.Skip("no processable files found in mold")
+	}
+
+	tmpDir := t.TempDir()
+	err = writeRenderedFiles(processable, reader.FS(), flux, opts, tmpDir)
+	if err != nil {
+		t.Fatalf("writeRenderedFiles failed: %v", err)
+	}
+
+	// Verify content is non-empty and was rendered
+	for _, rf := range processable {
+		content, err := os.ReadFile(filepath.Join(tmpDir, rf.DestPath))
+		if err != nil {
+			t.Errorf("failed to read %s: %v", rf.DestPath, err)
+			continue
+		}
+		if len(content) == 0 {
+			t.Errorf("rendered file %s is empty", rf.DestPath)
+		}
+	}
+}

--- a/internal/commands/temper_integration_test.go
+++ b/internal/commands/temper_integration_test.go
@@ -13,15 +13,10 @@ func TestIntegration_TemperLint_RendersAndLints(t *testing.T) {
 	reader := testMoldReader(t)
 	flux := testFlux(t, reader)
 
-	manifest, err := reader.LoadManifest()
+	// Load manifest to ensure it's valid (used implicitly by ResolveFiles)
+	_, err := reader.LoadManifest()
 	if err != nil {
 		t.Fatalf("failed to load manifest: %v", err)
-	}
-
-	// Validate flux against schema
-	schema, _ := reader.LoadFluxSchema()
-	if schema == nil && len(manifest.Flux) > 0 {
-		schema = manifest.Flux
 	}
 
 	// Build ingot resolver and resolve files


### PR DESCRIPTION
## Description

Added `--lint` flag to `ailloy temper` to render mold blanks and run assay (lint) on the output in one step. This catches content-level issues (line count, structure, cross-references) before casting without needing separate `cast` + `assay` steps.

## Changes

- New `--lint` flag renders blanks to temp dir and runs assay
- New flags for flux layering: `--set key=value`, `-f/--values file` (same as forge/cast)
- New flags for assay control: `--format`, `--fail-on`, `--max-lines`
- Helper functions: `writeRenderedFiles()`, `runAssayOnDir()`, `loadTemperFlux()`
- Integration tests covering rendering, directory creation, and assay detection
- Updated docs with examples and full flags table

## Testing

- All existing tests pass
- New integration tests verify rendering pipeline and assay integration
- Tested with nimble-mold reference

## UAT

```bash
# Validate structure and lint output in one step
ailloy temper --lint ./my-mold

# Provide flux values for rendering
ailloy temper --lint -f my-values.yaml ./my-mold
ailloy temper --lint --set project.organization=acme ./my-mold

# Control failure threshold
ailloy temper --lint --fail-on warning ./my-mold

# Output as JSON for CI
ailloy temper --lint --format json ./my-mold
```