### PR TITLE
fix: register template functions in temper validation and skip lock for global cast

### DIFF
--- a/internal/commands/cast.go
+++ b/internal/commands/cast.go
@@ -62,7 +62,11 @@ func runCast(_ *cobra.Command, args []string) error {
 func resolveMoldReader(args []string) (*blanks.MoldReader, error) {
 	if len(args) >= 1 {
 		if foundry.IsRemoteReference(args[0]) {
-			fsys, err := foundry.Resolve(args[0])
+			var resolveOpts []foundry.ResolveOption
+			if castGlobal {
+				resolveOpts = append(resolveOpts, foundry.WithoutLock())
+			}
+			fsys, err := foundry.Resolve(args[0], resolveOpts...)
 			if err != nil {
 				return nil, fmt.Errorf("resolving remote mold: %w", err)
 			}

--- a/pkg/foundry/foundry.go
+++ b/pkg/foundry/foundry.go
@@ -7,40 +7,63 @@ import (
 	"time"
 )
 
+// ResolveOption configures optional behaviour for Resolve.
+type ResolveOption func(*resolveConfig)
+
+type resolveConfig struct {
+	skipLock bool
+}
+
+// WithoutLock disables reading and writing the ailloy.lock file during resolution.
+// Use this for global installs where a project-local lock file is not appropriate.
+func WithoutLock() ResolveOption {
+	return func(c *resolveConfig) {
+		c.skipLock = true
+	}
+}
+
 // Resolve is the main entry point for SCM-native mold resolution.
 // It parses a raw reference, checks the lock file, resolves the version
 // from remote tags, fetches/caches the mold, updates the lock, and returns
 // an fs.FS rooted at the mold directory.
-func Resolve(rawRef string) (fs.FS, error) {
+func Resolve(rawRef string, opts ...ResolveOption) (fs.FS, error) {
 	ref, err := ParseReference(rawRef)
 	if err != nil {
 		return nil, fmt.Errorf("parsing reference: %w", err)
 	}
 
 	git := DefaultGitRunner()
-	return ResolveWith(ref, git)
+	return ResolveWith(ref, git, opts...)
 }
 
 // ResolveWith is like Resolve but accepts an injectable GitRunner (for testing).
-func ResolveWith(ref *Reference, git GitRunner) (fs.FS, error) {
-	// Read existing lock file.
-	lock, err := ReadLockFile(LockFileName)
-	if err != nil {
-		log.Printf("warning: reading lock file: %v", err)
+func ResolveWith(ref *Reference, git GitRunner, opts ...ResolveOption) (fs.FS, error) {
+	var cfg resolveConfig
+	for _, opt := range opts {
+		opt(&cfg)
 	}
 
-	// Check lock for a pinned version.
+	// Read existing lock file.
 	var resolved *ResolvedVersion
-	if entry := lock.FindEntry(ref.CacheKey()); entry != nil && ref.Type != Branch && ref.Type != SHA {
-		// Use locked version if it satisfies the reference.
-		if lockedSatisfies(ref, entry) {
-			resolved = &ResolvedVersion{Tag: entry.Version, Commit: entry.Commit}
-			log.Printf("using locked version %s@%s", ref.CacheKey(), entry.Version)
+	if !cfg.skipLock {
+		lock, err := ReadLockFile(LockFileName)
+		if err != nil {
+			log.Printf("warning: reading lock file: %v", err)
+		}
+
+		// Check lock for a pinned version.
+		if entry := lock.FindEntry(ref.CacheKey()); entry != nil && ref.Type != Branch && ref.Type != SHA {
+			// Use locked version if it satisfies the reference.
+			if lockedSatisfies(ref, entry) {
+				resolved = &ResolvedVersion{Tag: entry.Version, Commit: entry.Commit}
+				log.Printf("using locked version %s@%s", ref.CacheKey(), entry.Version)
+			}
 		}
 	}
 
 	// Resolve version from remote if not locked.
 	if resolved == nil {
+		var err error
 		resolved, err = ResolveVersion(ref, git)
 		if err != nil {
 			return nil, fmt.Errorf("resolving version: %w", err)
@@ -59,8 +82,10 @@ func ResolveWith(ref *Reference, git GitRunner) (fs.FS, error) {
 	}
 
 	// Update lock file.
-	if err := updateLock(ref, resolved); err != nil {
-		log.Printf("warning: updating lock file: %v", err)
+	if !cfg.skipLock {
+		if err := updateLock(ref, resolved); err != nil {
+			log.Printf("warning: updating lock file: %v", err)
+		}
 	}
 
 	return fsys, nil

--- a/pkg/mold/temper_test.go
+++ b/pkg/mold/temper_test.go
@@ -212,6 +212,26 @@ version: 1.0.0
 	}
 }
 
+func TestTemper_HasFunctionInTemplate(t *testing.T) {
+	fsys := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte(`
+apiVersion: v1
+kind: mold
+name: test-mold
+version: 1.0.0
+`)},
+		"commands/has.md": &fstest.MapFile{Data: []byte(`{{- if has "claude" .agent.targets -}}yes{{- end -}}`)},
+	}
+
+	result := Temper(fsys)
+
+	if result.HasErrors() {
+		for _, d := range result.Errors() {
+			t.Errorf("unexpected error: %s: %s", d.File, d.Message)
+		}
+	}
+}
+
 func TestTemper_FluxSchemaValidation(t *testing.T) {
 	fsys := fstest.MapFS{
 		"mold.yaml": &fstest.MapFile{Data: []byte(`

--- a/pkg/mold/template.go
+++ b/pkg/mold/template.go
@@ -36,6 +36,7 @@ var goTemplateKeywords = map[string]bool{
 	"println": true, "call": true,
 	"eq": true, "ne": true, "lt": true, "le": true, "gt": true, "ge": true,
 	"ingot": true,
+	"has":   true,
 }
 
 // TemplateOption configures optional behaviour for ProcessTemplate.
@@ -72,6 +73,25 @@ func preProcessTemplate(content string) string {
 	})
 }
 
+// baseFuncMap returns the template function map shared by ProcessTemplate and
+// template validation (Temper). Keeping it in one place ensures that the
+// validator accepts every function the renderer does.
+func baseFuncMap() template.FuncMap {
+	return template.FuncMap{
+		"has": func(value any, slice any) bool {
+			switch s := slice.(type) {
+			case []any:
+				return slices.Contains(s, value)
+			case []string:
+				if v, ok := value.(string); ok {
+					return slices.Contains(s, v)
+				}
+			}
+			return false
+		},
+	}
+}
+
 // ProcessTemplate renders a template string using Go's text/template engine.
 //
 // It supports:
@@ -98,19 +118,7 @@ func ProcessTemplate(content string, flux map[string]any, opts ...TemplateOption
 
 	data := BuildTemplateData(flux)
 
-	funcMap := template.FuncMap{
-		"has": func(value any, slice any) bool {
-			switch s := slice.(type) {
-			case []any:
-				return slices.Contains(s, value)
-			case []string:
-				if v, ok := value.(string); ok {
-					return slices.Contains(s, v)
-				}
-			}
-			return false
-		},
-	}
+	funcMap := baseFuncMap()
 	if cfg.ingotResolver != nil {
 		funcMap["ingot"] = cfg.ingotResolver.Resolve
 	}

--- a/pkg/mold/validate.go
+++ b/pkg/mold/validate.go
@@ -455,7 +455,11 @@ func validateTemplates(fsys fs.FS, result *TemperResult) {
 		}
 
 		content := preProcessTemplate(string(data))
-		if _, parseErr := template.New(path).Funcs(baseFuncMap()).Option("missingkey=zero").Parse(content); parseErr != nil {
+		funcMap := baseFuncMap()
+		// Register a no-op ingot stub so validation accepts {{ingot "name"}}
+		// even without a resolver. The real resolver is only available at render time.
+		funcMap["ingot"] = func(name string) string { return "" }
+		if _, parseErr := template.New(path).Funcs(funcMap).Option("missingkey=zero").Parse(content); parseErr != nil {
 			result.Diagnostics = append(result.Diagnostics, Diagnostic{
 				Severity: SeverityError,
 				Message:  fmt.Sprintf("template syntax error: %v", parseErr),

--- a/pkg/mold/validate.go
+++ b/pkg/mold/validate.go
@@ -455,7 +455,7 @@ func validateTemplates(fsys fs.FS, result *TemperResult) {
 		}
 
 		content := preProcessTemplate(string(data))
-		if _, parseErr := template.New(path).Option("missingkey=zero").Parse(content); parseErr != nil {
+		if _, parseErr := template.New(path).Funcs(baseFuncMap()).Option("missingkey=zero").Parse(content); parseErr != nil {
 			result.Diagnostics = append(result.Diagnostics, Diagnostic{
 				Severity: SeverityError,
 				Message:  fmt.Sprintf("template syntax error: %v", parseErr),


### PR DESCRIPTION
## Summary

- **`has` function missing from `temper` validation**: `validateTemplates()` parsed templates with bare `template.New().Parse()` — no `FuncMap` was registered. Templates using `has` (or `ingot`) were rejected during `ailloy temper` even though they render fine with `forge`/`cast`. Extracted a shared `baseFuncMap()` and registered it in the validator alongside a no-op `ingot` stub.
- **`cast -g` creating `ailloy.lock` in project directory**: `foundry.Resolve()` always wrote a lock file to the current working directory, even for global installs. Added a `WithoutLock()` resolve option to skip lock file I/O when `--global` is set.

## Changes

- `pkg/mold/template.go` — Extract `baseFuncMap()`, add `"has"` to `goTemplateKeywords`
- `pkg/mold/validate.go` — Use `baseFuncMap()` + no-op `ingot` stub in `validateTemplates()`
- `pkg/mold/temper_test.go` — Add `TestTemper_HasFunctionInTemplate` regression test
- `pkg/foundry/foundry.go` — Add `ResolveOption`/`WithoutLock()` functional option
- `internal/commands/cast.go` — Pass `WithoutLock()` when `castGlobal` is true

## Test plan

- [x] `TestTemper_HasFunctionInTemplate` — validates templates with `has` pass temper
- [x] `TestProcessTemplate_HasFunction*` — existing `has` render tests still pass
- [x] `TestProcessTemplate_WithoutIngotResolver` — confirms `ingot` still errors at render time without resolver
- [x] Full test suite passes (`go test ./...`)
- [ ] Manual: `ailloy temper .` against nimble-mold no longer errors on `has`
- [ ] Manual: `ailloy cast -g <mold>` does not create `ailloy.lock` in cwd