### PR TITLE
fix: skip .md files outside output manifest during template parsing

### DIFF
--- a/pkg/mold/temper_test.go
+++ b/pkg/mold/temper_test.go
@@ -359,6 +359,32 @@ output:
 	}
 }
 
+func TestTemper_SkipsNonOutputMarkdown(t *testing.T) {
+	fsys := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte(`
+apiVersion: v1
+kind: mold
+name: test-mold
+version: 1.0.0
+`)},
+		"flux.yaml": &fstest.MapFile{Data: []byte(`
+output:
+  commands: .claude/commands
+`)},
+		"commands/good.md": &fstest.MapFile{Data: []byte("# Good\n{{if .foo}}yes{{end}}")},
+		"docs/plan.md":     &fstest.MapFile{Data: []byte("Example: {{.broken")},
+		"README.md":        &fstest.MapFile{Data: []byte("See {{.broken")},
+	}
+
+	result := Temper(fsys)
+
+	for _, d := range result.Errors() {
+		if d.File == "docs/plan.md" || d.File == "README.md" {
+			t.Errorf("should not validate non-output file %s: %s", d.File, d.Message)
+		}
+	}
+}
+
 func TestTemperResult_ErrorsAndWarnings(t *testing.T) {
 	r := &TemperResult{
 		Diagnostics: []Diagnostic{

--- a/pkg/mold/validate.go
+++ b/pkg/mold/validate.go
@@ -308,8 +308,9 @@ func temperMold(fsys fs.FS, result *TemperResult) {
 	// Validate flux schema consistency
 	temperFluxSchema(fsys, m.Flux, result)
 
-	// Validate template syntax for all .md files
-	validateTemplates(fsys, result)
+	// Validate template syntax only for output-manifest files
+	outputFiles := resolveOutputPaths(flux["output"], fsys)
+	validateTemplates(fsys, outputFiles, result)
 }
 
 // temperIngot validates an ingot package.
@@ -351,8 +352,12 @@ func temperIngot(fsys fs.FS, result *TemperResult) {
 		}
 	}
 
-	// Validate template syntax for all .md files
-	validateTemplates(fsys, result)
+	// Validate template syntax only for ingot files
+	ingotPaths := make(map[string]bool, len(i.Files))
+	for _, f := range i.Files {
+		ingotPaths[f] = true
+	}
+	validateTemplates(fsys, ingotPaths, result)
 }
 
 // temperFluxSchema checks flux declarations for consistency.
@@ -427,8 +432,23 @@ func temperFluxSchema(fsys fs.FS, manifestFlux []FluxVar, result *TemperResult) 
 	}
 }
 
-// validateTemplates parses all .md files through Go text/template to catch syntax errors.
-func validateTemplates(fsys fs.FS, result *TemperResult) {
+// validateTemplates parses .md files through Go text/template to catch syntax errors.
+// When allowedPaths is non-nil, only files in that set are validated.
+// resolveOutputPaths returns the set of source paths from the output manifest.
+// If output is nil (identity mode), all .md files are considered in scope.
+func resolveOutputPaths(output any, fsys fs.FS) map[string]bool {
+	resolved, err := ResolveFiles(output, fsys)
+	if err != nil {
+		return nil // nil means "validate all" as fallback
+	}
+	paths := make(map[string]bool, len(resolved))
+	for _, rf := range resolved {
+		paths[rf.SrcPath] = true
+	}
+	return paths
+}
+
+func validateTemplates(fsys fs.FS, allowedPaths map[string]bool, result *TemperResult) {
 	_ = fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return nil
@@ -441,6 +461,10 @@ func validateTemplates(fsys fs.FS, result *TemperResult) {
 		}
 		// Skip manifest files
 		if path == "mold.yaml" || path == "ingot.yaml" {
+			return nil
+		}
+		// If allowedPaths is set, only validate files in scope
+		if allowedPaths != nil && !allowedPaths[path] {
 			return nil
 		}
 


### PR DESCRIPTION
## Description

Restricts `temper` template validation to only files listed in the `output:` manifest, matching `forge` behavior. Previously, `temper` parsed every `.md` file in the mold directory tree as a Go template, causing false syntax errors on documentation files (e.g. `docs/`, `README.md`) that contain Go-template-like syntax in code examples.

## Related Issue

Fixes #126

## Testing

- Added `TestTemper_SkipsNonOutputMarkdown` which verifies that `.md` files outside the output manifest (`docs/plan.md`, `README.md`) with invalid template syntax do not produce errors.
- All existing tests pass. Full test suite, linter, and build pass via pre-push hooks.

## UAT

1. Clone [`nimble-giant/nimble-mold`](https://github.com/nimble-giant/nimble-mold)
2. Run `ailloy temper .` — should no longer report template syntax errors for `docs/` files
3. Run `ailloy temper --assay .` — should complete without false positives

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [x] I have updated documentation (if applicable)
- [x] My commits have DCO sign-off (`git commit -s`)