### PR TITLE
fix: skip writing files that render to empty content

### DIFF
--- a/internal/commands/cast.go
+++ b/internal/commands/cast.go
@@ -430,6 +430,12 @@ func copyResolvedFiles(reader *blanks.MoldReader, manifest *mold.Mold, flux map[
 			outputContent = content
 		}
 
+		// Skip files that render to empty or whitespace-only content (#130)
+		if rf.Process && strings.TrimSpace(string(outputContent)) == "" {
+			log.Printf("skipping %s: rendered to empty content", rf.SrcPath)
+			continue
+		}
+
 		if err := os.MkdirAll(filepath.Dir(rf.DestPath), 0750); err != nil { // #nosec G301
 			return fmt.Errorf("failed to create directory for %s: %w", rf.DestPath, err)
 		}

--- a/internal/commands/cast_integration_test.go
+++ b/internal/commands/cast_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"testing/fstest"
 
 	"github.com/nimble-giant/ailloy/pkg/blanks"
 	"github.com/nimble-giant/ailloy/pkg/foundry"
@@ -201,6 +202,51 @@ func TestIntegration_ResolvedFilesMatchMold(t *testing.T) {
 		if expectedContent != string(fileContent) {
 			t.Errorf("file %s content mismatch between processed mold and copied version", rf.DestPath)
 		}
+	}
+}
+
+func TestCopyResolvedFiles_SkipsEmptyRenderedFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	moldFS := fstest.MapFS{
+		"commands/empty.md": &fstest.MapFile{
+			Data: []byte("{{- if false -}}content{{- end -}}"),
+		},
+		"commands/nonempty.md": &fstest.MapFile{
+			Data: []byte("# Hello\nThis has content."),
+		},
+	}
+	reader := blanks.NewMoldReader(moldFS)
+
+	resolved := []mold.ResolvedFile{
+		{SrcPath: "commands/empty.md", DestPath: filepath.Join(tmpDir, ".claude/commands/empty.md"), Process: true},
+		{SrcPath: "commands/nonempty.md", DestPath: filepath.Join(tmpDir, ".claude/commands/nonempty.md"), Process: true},
+	}
+
+	err := copyResolvedFiles(reader, nil, map[string]any{}, resolved)
+	if err != nil {
+		t.Fatalf("copyResolvedFiles failed: %v", err)
+	}
+
+	// The empty-rendering file should NOT exist
+	emptyPath := filepath.Join(tmpDir, ".claude/commands/empty.md")
+	if _, err := os.Stat(emptyPath); err == nil {
+		t.Error("expected empty-rendering file to be skipped, but it was written")
+	}
+
+	// The non-empty file SHOULD exist
+	nonEmptyPath := filepath.Join(tmpDir, ".claude/commands/nonempty.md")
+	info, err := os.Stat(nonEmptyPath)
+	if err != nil {
+		t.Fatalf("expected non-empty file to be written: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Error("non-empty file should have content")
 	}
 }
 

--- a/internal/commands/forge.go
+++ b/internal/commands/forge.go
@@ -157,6 +157,12 @@ func runForge(_ *cobra.Command, args []string) error {
 			rendered = string(content)
 		}
 
+		// Skip files that render to empty or whitespace-only content (#130)
+		if rf.Process && strings.TrimSpace(rendered) == "" {
+			log.Printf("skipping %s: rendered to empty content", rf.SrcPath)
+			continue
+		}
+
 		files = append(files, renderedFile{
 			destPath: rf.DestPath,
 			content:  rendered,

--- a/internal/commands/temper.go
+++ b/internal/commands/temper.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/nimble-giant/ailloy/pkg/assay"
 	"github.com/nimble-giant/ailloy/pkg/blanks"
@@ -193,6 +194,12 @@ func writeRenderedFiles(resolved []mold.ResolvedFile, moldFS fs.FS, flux map[str
 			}
 		} else {
 			rendered = string(content)
+		}
+
+		// Skip files that render to empty or whitespace-only content (#130)
+		if rf.Process && strings.TrimSpace(rendered) == "" {
+			log.Printf("skipping %s: rendered to empty content", rf.SrcPath)
+			continue
 		}
 
 		dest := filepath.Join(outputDir, rf.DestPath)

--- a/internal/commands/temper_integration_test.go
+++ b/internal/commands/temper_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"testing/fstest"
 
 	"github.com/nimble-giant/ailloy/pkg/assay"
 	"github.com/nimble-giant/ailloy/pkg/mold"
@@ -131,6 +132,68 @@ This is a test command.
 
 	if result.FilesScanned == 0 {
 		t.Error("expected assay to find files in rendered output")
+	}
+}
+
+func TestWriteRenderedFiles_SkipsEmptyRenderedFiles(t *testing.T) {
+	// Create an in-memory filesystem with a template that renders to empty
+	moldFS := fstest.MapFS{
+		"commands/empty.md": &fstest.MapFile{
+			Data: []byte("{{- if false -}}content{{- end -}}"),
+		},
+		"commands/nonempty.md": &fstest.MapFile{
+			Data: []byte("# Hello\nThis has content."),
+		},
+	}
+
+	resolved := []mold.ResolvedFile{
+		{SrcPath: "commands/empty.md", DestPath: ".claude/commands/empty.md", Process: true},
+		{SrcPath: "commands/nonempty.md", DestPath: ".claude/commands/nonempty.md", Process: true},
+	}
+
+	tmpDir := t.TempDir()
+	err := writeRenderedFiles(resolved, moldFS, map[string]any{}, nil, tmpDir)
+	if err != nil {
+		t.Fatalf("writeRenderedFiles failed: %v", err)
+	}
+
+	// The empty-rendering file should NOT exist
+	emptyPath := filepath.Join(tmpDir, ".claude/commands/empty.md")
+	if _, err := os.Stat(emptyPath); err == nil {
+		t.Error("expected empty-rendering file to be skipped, but it was written")
+	}
+
+	// The non-empty file SHOULD exist
+	nonEmptyPath := filepath.Join(tmpDir, ".claude/commands/nonempty.md")
+	info, err := os.Stat(nonEmptyPath)
+	if err != nil {
+		t.Fatalf("expected non-empty file to be written: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Error("non-empty file should have content")
+	}
+}
+
+func TestWriteRenderedFiles_SkipsWhitespaceOnlyRenderedFiles(t *testing.T) {
+	moldFS := fstest.MapFS{
+		"commands/whitespace.md": &fstest.MapFile{
+			Data: []byte("  \n\t\n  "),
+		},
+	}
+
+	resolved := []mold.ResolvedFile{
+		{SrcPath: "commands/whitespace.md", DestPath: ".claude/commands/whitespace.md", Process: true},
+	}
+
+	tmpDir := t.TempDir()
+	err := writeRenderedFiles(resolved, moldFS, map[string]any{}, nil, tmpDir)
+	if err != nil {
+		t.Fatalf("writeRenderedFiles failed: %v", err)
+	}
+
+	wsPath := filepath.Join(tmpDir, ".claude/commands/whitespace.md")
+	if _, err := os.Stat(wsPath); err == nil {
+		t.Error("expected whitespace-only file to be skipped, but it was written")
 	}
 }
 


### PR DESCRIPTION
## Description

After template rendering, if a blank's content is empty or whitespace-only, skip writing the file entirely. This prevents zero-byte files from being produced when conditional templates (e.g. `{{- if has "copilot" .agent.targets -}}`) evaluate to false. The check is applied in all three render-write paths: `cast`, `forge`, and `temper --assay`.

## Related Issue

Fixes #130

## Testing

- Added `TestCopyResolvedFiles_SkipsEmptyRenderedFiles` for the cast path
- Added `TestWriteRenderedFiles_SkipsEmptyRenderedFiles` for the temper path
- Added `TestWriteRenderedFiles_SkipsWhitespaceOnlyRenderedFiles` for whitespace-only content
- All existing tests continue to pass (`go test ./...`, `go vet`, `golangci-lint`)
- Pre-push hook passed: build, lint, and full test suite

## UAT

1. Create a mold with a template wrapped in a conditional that evaluates to false (e.g. `{{- if false -}}content{{- end -}}`)
2. Run `ailloy forge <mold> -o /tmp/out`
3. Verify the file is **not** written to `/tmp/out`
4. Run `ailloy cast` with a mold containing agent-target conditionals and confirm no zero-byte files are produced
5. Run `ailloy temper --assay` and confirm no `empty-file` warnings for conditionally excluded files

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [ ] I have updated documentation (if applicable)
- [x] My commits have DCO sign-off (`git commit -s`)