### PR TITLE
fix: yaml-parse --set values to support array types

### DIFF
--- a/pkg/mold/flux.go
+++ b/pkg/mold/flux.go
@@ -167,6 +167,9 @@ func LayerFluxFiles(paths []string) (map[string]any, error) {
 }
 
 // ApplySetOverrides applies --set key=value flags to a flux map using dotted paths.
+// Values that look like YAML sequences or mappings are parsed into their
+// corresponding Go types so that template functions like Sprig's `has` work
+// correctly (e.g. --set 'agent.targets=[claude,copilot]').
 func ApplySetOverrides(flux map[string]any, setFlags []string) error {
 	for _, flag := range setFlags {
 		parts := strings.SplitN(flag, "=", 2)
@@ -178,6 +181,19 @@ func ApplySetOverrides(flux map[string]any, setFlags []string) error {
 		if key == "" {
 			return fmt.Errorf("--set key cannot be empty")
 		}
+
+		// Try YAML-parsing the value to support structured types (arrays, maps).
+		// Plain scalars (strings, numbers, booleans) are kept as strings for
+		// backward compatibility.
+		var parsed any
+		if err := yaml.Unmarshal([]byte(value), &parsed); err == nil {
+			switch parsed.(type) {
+			case []any, map[string]any:
+				SetNestedAny(flux, key, parsed)
+				continue
+			}
+		}
+
 		SetNestedValue(flux, key, value)
 	}
 	return nil

--- a/pkg/mold/flux_test.go
+++ b/pkg/mold/flux_test.go
@@ -730,6 +730,69 @@ func TestApplySetOverrides_ValueWithEquals(t *testing.T) {
 	}
 }
 
+func TestApplySetOverrides_ArrayValue(t *testing.T) {
+	flux := map[string]any{}
+	err := ApplySetOverrides(flux, []string{"agent.targets=[claude,copilot]"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	agent, ok := flux["agent"].(map[string]any)
+	if !ok {
+		t.Fatal("expected agent to be a map")
+	}
+	targets, ok := agent["targets"].([]any)
+	if !ok {
+		t.Fatalf("expected targets to be a slice, got %T", agent["targets"])
+	}
+	if len(targets) != 2 {
+		t.Fatalf("expected 2 targets, got %d", len(targets))
+	}
+	if targets[0] != "claude" {
+		t.Errorf("expected targets[0]=claude, got %v", targets[0])
+	}
+	if targets[1] != "copilot" {
+		t.Errorf("expected targets[1]=copilot, got %v", targets[1])
+	}
+}
+
+func TestApplySetOverrides_SingleElementArray(t *testing.T) {
+	flux := map[string]any{}
+	err := ApplySetOverrides(flux, []string{"agent.targets=[claude]"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	agent, ok := flux["agent"].(map[string]any)
+	if !ok {
+		t.Fatal("expected agent to be a map")
+	}
+	targets, ok := agent["targets"].([]any)
+	if !ok {
+		t.Fatalf("expected targets to be a slice, got %T", agent["targets"])
+	}
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 target, got %d", len(targets))
+	}
+	if targets[0] != "claude" {
+		t.Errorf("expected targets[0]=claude, got %v", targets[0])
+	}
+}
+
+func TestApplySetOverrides_PlainStringUnchanged(t *testing.T) {
+	flux := map[string]any{}
+	err := ApplySetOverrides(flux, []string{"board=Product"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Plain string values must remain strings (backward compatibility).
+	val, ok := flux["board"].(string)
+	if !ok {
+		t.Fatalf("expected board to be a string, got %T", flux["board"])
+	}
+	if val != "Product" {
+		t.Errorf("expected board=Product, got %v", val)
+	}
+}
+
 // --- GetNestedAny tests ---
 
 func TestGetNestedAny_String(t *testing.T) {


### PR DESCRIPTION
## Description

`ApplySetOverrides` now YAML-unmarshals the value portion of `--set` flags. When the parsed result is a structured type (slice or map), it is stored via `SetNestedAny` instead of as a raw string. This allows template functions like Sprig's `has` to work correctly with array values (e.g. `--set 'agent.targets=[claude,copilot]'`). Plain scalar values remain strings for backward compatibility.

## Related Issue

Fixes #129

## Testing

Added three new unit tests in `pkg/mold/flux_test.go`:
- `TestApplySetOverrides_ArrayValue` — multi-element array `[claude,copilot]` parses into a proper `[]any` slice
- `TestApplySetOverrides_SingleElementArray` — single-element `[claude]` parses correctly
- `TestApplySetOverrides_PlainStringUnchanged` — plain strings remain strings (backward compat)

All existing tests continue to pass. Full suite green (`go test ./...`), lint clean, build clean.

## UAT

```bash
# Before: CLAUDE.md renders empty because has receives a string
ailloy forge . --set 'agent.targets=[claude]'

# After: CLAUDE.md renders with content (has "claude" .agent.targets == true)
ailloy forge . --set 'agent.targets=[claude]'

# Multi-target also works:
ailloy forge . --set 'agent.targets=[claude,copilot]'
```

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [x] I have updated documentation (if applicable)
- [x] My commits have DCO sign-off (`git commit -s`)