### PR TITLE
feat: multi-destination output mapping with per-dest context (#135)

### DIFF
--- a/docs/blanks.md
+++ b/docs/blanks.md
@@ -395,3 +395,41 @@ output:
 ```
 
 Since `output:` lives in flux, consumers can override destination paths at install time using `-f` value files or `--set` flags. This means a single mold can serve teams using different AI coding tools.
+
+### Fan-out: one source, many destinations
+
+When the same source directory should render to multiple destinations — for example, an agent definition that needs to land in `.claude/agents/`, `.opencode/agents/`, and `.cursor/rules/` — use a list of destinations:
+
+```yaml
+output:
+  agents:
+    - dest: .claude/agents
+      set:
+        agent.current_target: claude
+    - dest: .opencode/agents
+      set:
+        agent.current_target: opencode
+    - dest: .cursor/rules
+      set:
+        agent.current_target: cursor
+```
+
+Each list entry can be either a string (just a destination path) or a map with `dest`, optional `process`, and optional `set`. The `set` map injects values into the template context for that render pass only — without touching the global flux. Inside the template, switch on the injected value:
+
+```markdown
+{{- if eq .agent.current_target "claude" -}}
+---
+name: coding-agent
+model: opus
+---
+{{- else if eq .agent.current_target "opencode" -}}
+---
+mode: primary
+model: anthropic/claude-opus-4-20250514
+---
+{{- end -}}
+
+{{ingot "coding-agent-body"}}
+```
+
+Keys in `set` may use dotted paths (`agent.current_target`) which expand to nested maps, or be nested maps directly. The fan-out form works for both directory mappings and individual file mappings.

--- a/internal/commands/ailloy.lock
+++ b/internal/commands/ailloy.lock
@@ -1,0 +1,7 @@
+apiVersion: v1
+molds:
+- name: nimble-mold
+  source: github.com/nimble-giant/nimble-mold
+  version: v0.1.10
+  commit: 2347a626798553252668a15dc98dd020ab9a9c0c
+  timestamp: 2026-05-01T20:00:40.616798Z

--- a/internal/commands/cast.go
+++ b/internal/commands/cast.go
@@ -421,7 +421,11 @@ func copyResolvedFiles(reader *blanks.MoldReader, manifest *mold.Mold, flux map[
 
 		var outputContent []byte
 		if rf.Process {
-			processed, err := mold.ProcessTemplate(string(content), flux, opts...)
+			fluxForFile := flux
+			if len(rf.Set) > 0 {
+				fluxForFile = mold.MergeSet(flux, rf.Set)
+			}
+			processed, err := mold.ProcessTemplate(string(content), fluxForFile, opts...)
 			if err != nil {
 				return fmt.Errorf("failed to process %s: %w", rf.SrcPath, err)
 			}

--- a/internal/commands/forge.go
+++ b/internal/commands/forge.go
@@ -149,7 +149,11 @@ func runForge(_ *cobra.Command, args []string) error {
 
 		var rendered string
 		if rf.Process {
-			rendered, err = renderFile(rf.SrcPath, content, flux, opts...)
+			fluxForFile := flux
+			if len(rf.Set) > 0 {
+				fluxForFile = mold.MergeSet(flux, rf.Set)
+			}
+			rendered, err = renderFile(rf.SrcPath, content, fluxForFile, opts...)
 			if err != nil {
 				return err
 			}

--- a/pkg/mold/flux.go
+++ b/pkg/mold/flux.go
@@ -234,6 +234,60 @@ func SetNestedAny(m map[string]any, dottedKey string, value any) {
 	}
 }
 
+// MergeSet returns a deep copy of base with the values from set merged in.
+// Top-level keys in set that contain dots are expanded as nested paths
+// (e.g., "agent.current_target" creates base["agent"]["current_target"]).
+// Map values merge recursively rather than replace. The base map (and any
+// nested maps it contains) is never mutated.
+func MergeSet(base, set map[string]any) map[string]any {
+	out := deepCopyMap(base)
+	for k, v := range set {
+		if strings.Contains(k, ".") {
+			SetNestedAny(out, k, v)
+			continue
+		}
+		if nested, ok := v.(map[string]any); ok {
+			existing, _ := out[k].(map[string]any)
+			out[k] = mergeMaps(existing, nested)
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
+// mergeMaps returns a deep copy of base with overlay merged in recursively.
+// Neither map is mutated.
+func mergeMaps(base, overlay map[string]any) map[string]any {
+	out := deepCopyMap(base)
+	for k, v := range overlay {
+		if nested, ok := v.(map[string]any); ok {
+			existing, _ := out[k].(map[string]any)
+			out[k] = mergeMaps(existing, nested)
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
+// deepCopyMap recursively copies a map[string]any so nested maps can be
+// mutated without affecting the original.
+func deepCopyMap(m map[string]any) map[string]any {
+	if m == nil {
+		return map[string]any{}
+	}
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		if nested, ok := v.(map[string]any); ok {
+			out[k] = deepCopyMap(nested)
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
 // validateFluxType checks that a value conforms to the declared type.
 // Returns an error message string, or empty string if valid.
 func validateFluxType(typ, name, val string) string {

--- a/pkg/mold/flux_test.go
+++ b/pkg/mold/flux_test.go
@@ -920,3 +920,65 @@ func TestSetNestedAny_MapValue(t *testing.T) {
 		t.Errorf("expected Ready, got %v", ready["label"])
 	}
 }
+
+func TestMergeSet_DottedKey(t *testing.T) {
+	base := map[string]any{
+		"agent": map[string]any{"name": "coding"},
+	}
+	set := map[string]any{
+		"agent.current_target": "claude",
+	}
+
+	out := MergeSet(base, set)
+
+	agent, ok := out["agent"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected agent map, got %T", out["agent"])
+	}
+	if agent["name"] != "coding" {
+		t.Errorf("expected base value preserved, got %v", agent["name"])
+	}
+	if agent["current_target"] != "claude" {
+		t.Errorf("expected current_target=claude, got %v", agent["current_target"])
+	}
+
+	// Original base map must not be mutated.
+	baseAgent := base["agent"].(map[string]any)
+	if _, exists := baseAgent["current_target"]; exists {
+		t.Error("expected base to be untouched, but current_target was set")
+	}
+}
+
+func TestMergeSet_NestedMap(t *testing.T) {
+	base := map[string]any{
+		"agent": map[string]any{"name": "coding"},
+	}
+	set := map[string]any{
+		"agent": map[string]any{"current_target": "opencode"},
+	}
+
+	out := MergeSet(base, set)
+	agent := out["agent"].(map[string]any)
+	if agent["name"] != "coding" {
+		t.Errorf("expected name=coding preserved, got %v", agent["name"])
+	}
+	if agent["current_target"] != "opencode" {
+		t.Errorf("expected current_target=opencode, got %v", agent["current_target"])
+	}
+}
+
+func TestMergeSet_TopLevelScalar(t *testing.T) {
+	base := map[string]any{"x": "old"}
+	set := map[string]any{"x": "new", "y": 42}
+
+	out := MergeSet(base, set)
+	if out["x"] != "new" {
+		t.Errorf("expected x=new, got %v", out["x"])
+	}
+	if out["y"] != 42 {
+		t.Errorf("expected y=42, got %v", out["y"])
+	}
+	if base["x"] != "old" {
+		t.Error("expected base unchanged")
+	}
+}

--- a/pkg/mold/mold.go
+++ b/pkg/mold/mold.go
@@ -54,12 +54,14 @@ type Dependency struct {
 }
 
 // OutputTarget represents a single output directory or file mapping.
-// It supports two YAML forms:
+// It supports three YAML forms:
 //   - Simple string: "dest/path" (process defaults to true)
-//   - Expanded map: {dest: "dest/path", process: false}
+//   - Expanded map: {dest: "dest/path", process: false, set: {...}}
+//   - List of either form, expanded into multiple targets (multi-destination)
 type OutputTarget struct {
-	Dest    string `yaml:"dest"`
-	Process *bool  `yaml:"process,omitempty"` // nil = true (default)
+	Dest    string         `yaml:"dest"`
+	Process *bool          `yaml:"process,omitempty"` // nil = true (default)
+	Set     map[string]any `yaml:"set,omitempty"`     // per-destination context overrides
 }
 
 // ShouldProcess returns whether files under this target should be template-processed.
@@ -69,9 +71,10 @@ func (o OutputTarget) ShouldProcess() bool {
 
 // ResolvedFile represents a single file resolved from the output mapping.
 type ResolvedFile struct {
-	SrcPath  string // path within the mold fs (e.g., "commands/hello.md")
-	DestPath string // output path (e.g., ".claude/commands/hello.md")
-	Process  bool   // whether to apply template processing
+	SrcPath  string         // path within the mold fs (e.g., "commands/hello.md")
+	DestPath string         // output path (e.g., ".claude/commands/hello.md")
+	Process  bool           // whether to apply template processing
+	Set      map[string]any // context overrides applied to this render pass
 }
 
 // Mold represents a mold.yaml manifest.

--- a/pkg/mold/output.go
+++ b/pkg/mold/output.go
@@ -47,6 +47,7 @@ type fileMapping struct {
 	src     string // source file path in the mold fs
 	dest    string // destination file path
 	process bool
+	set     map[string]any
 }
 
 // resolveConfig holds configuration for ResolveFiles.
@@ -247,19 +248,22 @@ func parseMapOutput(m map[string]any, moldFS fs.FS) ([]dirMapping, []fileMapping
 	for src, val := range m {
 		isDir := isDirectory(moldFS, src)
 
-		target, err := parseOutputValue(val)
+		targets, err := parseOutputValue(val)
 		if err != nil {
 			return nil, nil, fmt.Errorf("output key %q: %w", src, err)
 		}
 
-		if isDir {
-			dirs = append(dirs, dirMapping{src: src, target: target})
-		} else {
-			files = append(files, fileMapping{
-				src:     src,
-				dest:    target.Dest,
-				process: target.ShouldProcess(),
-			})
+		for _, target := range targets {
+			if isDir {
+				dirs = append(dirs, dirMapping{src: src, target: target})
+			} else {
+				files = append(files, fileMapping{
+					src:     src,
+					dest:    target.Dest,
+					process: target.ShouldProcess(),
+					set:     target.Set,
+				})
+			}
 		}
 	}
 
@@ -289,39 +293,81 @@ func parseMapOutput(m map[string]any, moldFS fs.FS) ([]dirMapping, []fileMapping
 	return dirs, files, nil
 }
 
-// parseOutputValue normalizes a single output value (string or map).
-func parseOutputValue(val any) (OutputTarget, error) {
+// parseOutputValue normalizes a single output value into one or more targets.
+//
+// Accepted forms:
+//   - string: simple destination path
+//   - map: expanded form with dest/process/set fields
+//   - list: each entry is a string or map; expands to multiple targets so a
+//     single source can fan out to multiple destinations with per-dest context
+func parseOutputValue(val any) ([]OutputTarget, error) {
 	switch v := val.(type) {
 	case string:
-		return OutputTarget{Dest: v}, nil
+		return []OutputTarget{{Dest: v}}, nil
 	case map[string]any:
-		t := OutputTarget{}
-		if dest, ok := v["dest"]; ok {
-			d, ok := dest.(string)
-			if !ok {
-				return t, fmt.Errorf("dest must be a string")
-			}
-			t.Dest = d
+		t, err := parseTargetMap(v)
+		if err != nil {
+			return nil, err
 		}
-		if proc, ok := v["process"]; ok {
-			b, ok := proc.(bool)
-			if !ok {
-				return t, fmt.Errorf("process must be a boolean")
-			}
-			t.Process = &b
+		return []OutputTarget{t}, nil
+	case []any:
+		if len(v) == 0 {
+			return nil, fmt.Errorf("list of destinations must not be empty")
 		}
-		return t, nil
+		targets := make([]OutputTarget, 0, len(v))
+		for i, entry := range v {
+			switch e := entry.(type) {
+			case string:
+				targets = append(targets, OutputTarget{Dest: e})
+			case map[string]any:
+				t, err := parseTargetMap(e)
+				if err != nil {
+					return nil, fmt.Errorf("list entry %d: %w", i, err)
+				}
+				targets = append(targets, t)
+			default:
+				return nil, fmt.Errorf("list entry %d: must be a string or map, got %T", i, entry)
+			}
+		}
+		return targets, nil
 	default:
-		return OutputTarget{}, fmt.Errorf("value must be a string or map, got %T", val)
+		return nil, fmt.Errorf("value must be a string, map, or list, got %T", val)
 	}
+}
+
+// parseTargetMap parses the expanded map form into an OutputTarget.
+func parseTargetMap(v map[string]any) (OutputTarget, error) {
+	t := OutputTarget{}
+	if dest, ok := v["dest"]; ok {
+		d, ok := dest.(string)
+		if !ok {
+			return t, fmt.Errorf("dest must be a string")
+		}
+		t.Dest = d
+	}
+	if proc, ok := v["process"]; ok {
+		b, ok := proc.(bool)
+		if !ok {
+			return t, fmt.Errorf("process must be a boolean")
+		}
+		t.Process = &b
+	}
+	if s, ok := v["set"]; ok {
+		sm, ok := s.(map[string]any)
+		if !ok {
+			return t, fmt.Errorf("set must be a map")
+		}
+		t.Set = sm
+	}
+	return t, nil
 }
 
 // resolveFromMappings walks directories and applies mappings to produce resolved files.
 func resolveFromMappings(dirs []dirMapping, files []fileMapping, moldFS fs.FS) ([]ResolvedFile, error) {
-	// Build file override set for quick lookup.
-	fileOverrides := make(map[string]fileMapping)
+	// Group file overrides by src so a single file can fan out to multiple destinations.
+	fileOverrides := make(map[string][]fileMapping)
 	for _, f := range files {
-		fileOverrides[f.src] = f
+		fileOverrides[f.src] = append(fileOverrides[f.src], f)
 	}
 
 	var resolved []ResolvedFile
@@ -336,13 +382,16 @@ func resolveFromMappings(dirs []dirMapping, files []fileMapping, moldFS fs.FS) (
 				return nil
 			}
 
-			// Check for file-level override.
-			if fo, ok := fileOverrides[p]; ok {
-				resolved = append(resolved, ResolvedFile{
-					SrcPath:  p,
-					DestPath: fo.dest,
-					Process:  fo.process,
-				})
+			// Check for file-level override (one entry per destination).
+			if overrides, ok := fileOverrides[p]; ok {
+				for _, fo := range overrides {
+					resolved = append(resolved, ResolvedFile{
+						SrcPath:  p,
+						DestPath: fo.dest,
+						Process:  fo.process,
+						Set:      fo.set,
+					})
+				}
 				delete(fileOverrides, p) // consumed
 				return nil
 			}
@@ -356,6 +405,7 @@ func resolveFromMappings(dirs []dirMapping, files []fileMapping, moldFS fs.FS) (
 				SrcPath:  p,
 				DestPath: destPath,
 				Process:  dm.target.ShouldProcess(),
+				Set:      dm.target.Set,
 			})
 			return nil
 		})
@@ -365,19 +415,19 @@ func resolveFromMappings(dirs []dirMapping, files []fileMapping, moldFS fs.FS) (
 	}
 
 	// Add remaining file-level mappings (files not inside any mapped directory).
-	for _, f := range files {
-		if _, consumed := fileOverrides[f.src]; !consumed {
-			continue
-		}
+	for src, overrides := range fileOverrides {
 		// Read the file to verify it exists.
-		if _, err := fs.Stat(moldFS, f.src); err != nil {
-			return nil, fmt.Errorf("file mapping %q: %w", f.src, err)
+		if _, err := fs.Stat(moldFS, src); err != nil {
+			return nil, fmt.Errorf("file mapping %q: %w", src, err)
 		}
-		resolved = append(resolved, ResolvedFile{
-			SrcPath:  f.src,
-			DestPath: f.dest,
-			Process:  f.process,
-		})
+		for _, f := range overrides {
+			resolved = append(resolved, ResolvedFile{
+				SrcPath:  f.src,
+				DestPath: f.dest,
+				Process:  f.process,
+				Set:      f.set,
+			})
+		}
 	}
 
 	// Sort for deterministic output.

--- a/pkg/mold/output_test.go
+++ b/pkg/mold/output_test.go
@@ -413,6 +413,241 @@ func TestResolveFiles_RootFiles_MapOutput_AutoDiscover(t *testing.T) {
 	}
 }
 
+func TestResolveFiles_ListOutput_Strings(t *testing.T) {
+	moldFS := fstest.MapFS{
+		"agents/coding.md": &fstest.MapFile{Data: []byte("agent")},
+	}
+
+	output := map[string]any{
+		"agents": []any{".claude/agents", ".opencode/agents"},
+	}
+
+	resolved, err := ResolveFiles(output, moldFS)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(resolved) != 2 {
+		t.Fatalf("expected 2 resolved files (one per dest), got %d", len(resolved))
+	}
+
+	dests := map[string]bool{}
+	for _, rf := range resolved {
+		if rf.SrcPath != "agents/coding.md" {
+			t.Errorf("unexpected src path: %s", rf.SrcPath)
+		}
+		if !rf.Process {
+			t.Errorf("expected Process=true for %s", rf.DestPath)
+		}
+		dests[rf.DestPath] = true
+	}
+
+	if !dests[".claude/agents/coding.md"] {
+		t.Error("missing .claude/agents/coding.md")
+	}
+	if !dests[".opencode/agents/coding.md"] {
+		t.Error("missing .opencode/agents/coding.md")
+	}
+}
+
+func TestResolveFiles_ListOutput_WithSet(t *testing.T) {
+	moldFS := fstest.MapFS{
+		"agents/coding.md": &fstest.MapFile{Data: []byte("agent")},
+	}
+
+	output := map[string]any{
+		"agents": []any{
+			map[string]any{
+				"dest": ".claude/agents",
+				"set": map[string]any{
+					"agent.current_target": "claude",
+				},
+			},
+			map[string]any{
+				"dest": ".opencode/agents",
+				"set": map[string]any{
+					"agent.current_target": "opencode",
+				},
+			},
+		},
+	}
+
+	resolved, err := ResolveFiles(output, moldFS)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(resolved) != 2 {
+		t.Fatalf("expected 2 resolved files, got %d", len(resolved))
+	}
+
+	byDest := map[string]ResolvedFile{}
+	for _, rf := range resolved {
+		byDest[rf.DestPath] = rf
+	}
+
+	claude, ok := byDest[".claude/agents/coding.md"]
+	if !ok {
+		t.Fatal("missing .claude/agents/coding.md")
+	}
+	if got := claude.Set["agent.current_target"]; got != "claude" {
+		t.Errorf("claude dest: expected set agent.current_target=claude, got %v", got)
+	}
+
+	oc, ok := byDest[".opencode/agents/coding.md"]
+	if !ok {
+		t.Fatal("missing .opencode/agents/coding.md")
+	}
+	if got := oc.Set["agent.current_target"]; got != "opencode" {
+		t.Errorf("opencode dest: expected set agent.current_target=opencode, got %v", got)
+	}
+}
+
+func TestResolveFiles_ListOutput_MixedWithProcess(t *testing.T) {
+	moldFS := fstest.MapFS{
+		"workflows/ci.yml": &fstest.MapFile{Data: []byte("name: CI")},
+	}
+
+	output := map[string]any{
+		"workflows": []any{
+			map[string]any{
+				"dest":    ".github/workflows",
+				"process": false,
+			},
+			".other/workflows",
+		},
+	}
+
+	resolved, err := ResolveFiles(output, moldFS)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(resolved) != 2 {
+		t.Fatalf("expected 2 resolved files, got %d", len(resolved))
+	}
+
+	for _, rf := range resolved {
+		switch rf.DestPath {
+		case ".github/workflows/ci.yml":
+			if rf.Process {
+				t.Error("github workflows: expected Process=false")
+			}
+		case ".other/workflows/ci.yml":
+			if !rf.Process {
+				t.Error("other workflows: expected Process=true")
+			}
+		default:
+			t.Errorf("unexpected dest: %s", rf.DestPath)
+		}
+	}
+}
+
+func TestResolveFiles_ListOutput_FileLevel(t *testing.T) {
+	moldFS := fstest.MapFS{
+		"AGENT.md": &fstest.MapFile{Data: []byte("body")},
+	}
+
+	output := map[string]any{
+		"AGENT.md": []any{"AGENTS.md", "CLAUDE.md"},
+	}
+
+	resolved, err := ResolveFiles(output, moldFS)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(resolved) != 2 {
+		t.Fatalf("expected 2 resolved files, got %d", len(resolved))
+	}
+
+	dests := map[string]bool{}
+	for _, rf := range resolved {
+		if rf.SrcPath != "AGENT.md" {
+			t.Errorf("unexpected src: %s", rf.SrcPath)
+		}
+		dests[rf.DestPath] = true
+	}
+	if !dests["AGENTS.md"] || !dests["CLAUDE.md"] {
+		t.Errorf("expected both AGENTS.md and CLAUDE.md, got %v", dests)
+	}
+}
+
+func TestResolveFiles_ListOutput_RendersWithSet(t *testing.T) {
+	moldFS := fstest.MapFS{
+		"agents/coding.md": &fstest.MapFile{Data: []byte("target={{.agent.current_target}}")},
+	}
+
+	output := map[string]any{
+		"agents": []any{
+			map[string]any{
+				"dest": ".claude/agents",
+				"set":  map[string]any{"agent.current_target": "claude"},
+			},
+			map[string]any{
+				"dest": ".opencode/agents",
+				"set":  map[string]any{"agent.current_target": "opencode"},
+			},
+		},
+	}
+
+	resolved, err := ResolveFiles(output, moldFS)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	flux := map[string]any{}
+	rendered := map[string]string{}
+	for _, rf := range resolved {
+		fluxForFile := flux
+		if len(rf.Set) > 0 {
+			fluxForFile = MergeSet(flux, rf.Set)
+		}
+		out, err := ProcessTemplate("target={{.agent.current_target}}", fluxForFile)
+		if err != nil {
+			t.Fatalf("ProcessTemplate %s: %v", rf.DestPath, err)
+		}
+		rendered[rf.DestPath] = out
+	}
+
+	if rendered[".claude/agents/coding.md"] != "target=claude" {
+		t.Errorf("claude render: got %q", rendered[".claude/agents/coding.md"])
+	}
+	if rendered[".opencode/agents/coding.md"] != "target=opencode" {
+		t.Errorf("opencode render: got %q", rendered[".opencode/agents/coding.md"])
+	}
+}
+
+func TestResolveFiles_ListOutput_Empty(t *testing.T) {
+	moldFS := fstest.MapFS{
+		"agents/coding.md": &fstest.MapFile{Data: []byte("agent")},
+	}
+
+	output := map[string]any{
+		"agents": []any{},
+	}
+
+	_, err := ResolveFiles(output, moldFS)
+	if err == nil {
+		t.Fatal("expected error for empty list, got nil")
+	}
+}
+
+func TestResolveFiles_ListOutput_InvalidEntry(t *testing.T) {
+	moldFS := fstest.MapFS{
+		"agents/coding.md": &fstest.MapFile{Data: []byte("agent")},
+	}
+
+	output := map[string]any{
+		"agents": []any{42},
+	}
+
+	_, err := ResolveFiles(output, moldFS)
+	if err == nil {
+		t.Fatal("expected error for non-string non-map list entry")
+	}
+}
+
 func TestResolveFiles_ExcludesReservedDirs(t *testing.T) {
 	moldFS := fstest.MapFS{
 		"commands/hello.md": &fstest.MapFile{Data: []byte("hello")},


### PR DESCRIPTION
## Description

Adds support for fan-out output mappings: a single source directory or file can render to multiple destinations in one cast, with optional per-destination `set` values that inject template context for that render pass only. This lets a mold serve multiple AI tools (Claude Code, OpenCode, Cursor, etc.) from a single source file plus a shared ingot body, eliminating the duplicated wrapper-file workaround documented in #130.

The list form is additive — existing string and map output values still work unchanged.

```yaml
output:
  agents:
    - dest: .claude/agents
      set: { agent.current_target: claude }
    - dest: .opencode/agents
      set: { agent.current_target: opencode }
```

## Related Issue

Closes #135

## Testing

- 7 new tests in `pkg/mold/output_test.go` covering list-of-strings, list-of-maps with `set`, mixed entries with `process: false`, file-level fan-out, empty/invalid list errors, and an end-to-end render verifying `set` values reach `ProcessTemplate`.
- 3 new tests in `pkg/mold/flux_test.go` for the new `MergeSet` helper (dotted-key expansion with base immutability, nested-map merge, top-level scalar override).
- Full suite passes with `-race`; `go vet`, `gofmt`, and `golangci-lint run ./...` all clean.

## UAT

In a mold with a fan-out output mapping like the example above, run `ailloy forge .` (or `ailloy cast`) and confirm: the agent source renders to each listed destination, and `{{ .agent.current_target }}` resolves to the per-destination value in each output.

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [x] I have updated documentation (if applicable)
- [x] My commits have DCO sign-off (`git commit -s`)