### PR TITLE
fix: include mold source root in ingot search path (#140)

### DIFF
--- a/internal/commands/ailloy.lock
+++ b/internal/commands/ailloy.lock
@@ -4,4 +4,4 @@ molds:
   source: github.com/nimble-giant/nimble-mold
   version: v0.1.10
   commit: 2347a626798553252668a15dc98dd020ab9a9c0c
-  timestamp: 2026-05-01T20:00:40.616798Z
+  timestamp: 2026-05-01T21:48:50.232097Z

--- a/internal/commands/cast.go
+++ b/internal/commands/cast.go
@@ -66,11 +66,11 @@ func resolveMoldReader(args []string) (*blanks.MoldReader, error) {
 			if castGlobal {
 				resolveOpts = append(resolveOpts, foundry.WithoutLock())
 			}
-			fsys, err := foundry.Resolve(args[0], resolveOpts...)
+			fsys, root, err := foundry.ResolveWithRoot(args[0], resolveOpts...)
 			if err != nil {
 				return nil, fmt.Errorf("resolving remote mold: %w", err)
 			}
-			return blanks.NewMoldReader(fsys), nil
+			return blanks.NewMoldReaderFromFS(fsys, root), nil
 		}
 		return blanks.NewMoldReaderFromPath(args[0])
 	}
@@ -410,7 +410,7 @@ func copyResolvedFiles(reader *blanks.MoldReader, manifest *mold.Mold, flux map[
 	}
 
 	// Build ingot resolver
-	resolver := buildIngotResolver(flux)
+	resolver := buildIngotResolver(flux, reader.Root())
 	opts := []mold.TemplateOption{mold.WithIngotResolver(resolver)}
 
 	for _, rf := range resolved {

--- a/internal/commands/forge.go
+++ b/internal/commands/forge.go
@@ -123,7 +123,7 @@ func runForge(_ *cobra.Command, args []string) error {
 	}
 
 	// Build ingot resolver
-	resolver := buildIngotResolver(flux)
+	resolver := buildIngotResolver(flux, reader.Root())
 	opts := []mold.TemplateOption{mold.WithIngotResolver(resolver)}
 
 	// Load ignore patterns from .ailloyignore and mold.yaml.
@@ -183,9 +183,16 @@ func runForge(_ *cobra.Command, args []string) error {
 }
 
 // buildIngotResolver creates an IngotResolver with the standard search path order:
-// current directory (mold-local), project .ailloy/, global ~/.ailloy/.
-func buildIngotResolver(flux map[string]any) *mold.IngotResolver {
-	searchPaths := []string{"."}
+// mold source root (so bundled ingots are found when casting from a remote or
+// path mold), current directory (mold-local), project .ailloy/, global ~/.ailloy/.
+// moldRoot may be empty when the mold has no on-disk root (e.g., embedded molds).
+func buildIngotResolver(flux map[string]any, moldRoot string) *mold.IngotResolver {
+	var searchPaths []string
+
+	if moldRoot != "" {
+		searchPaths = append(searchPaths, moldRoot)
+	}
+	searchPaths = append(searchPaths, ".")
 
 	if _, err := os.Stat(".ailloy"); err == nil {
 		searchPaths = append(searchPaths, ".ailloy")
@@ -234,11 +241,11 @@ func writeForgeFiles(files []renderedFile, outputDir string) error {
 func resolveForgeReader(args []string) (*blanks.MoldReader, error) {
 	if len(args) >= 1 {
 		if foundry.IsRemoteReference(args[0]) {
-			fsys, err := foundry.Resolve(args[0])
+			fsys, root, err := foundry.ResolveWithRoot(args[0])
 			if err != nil {
 				return nil, fmt.Errorf("resolving remote mold: %w", err)
 			}
-			return blanks.NewMoldReader(fsys), nil
+			return blanks.NewMoldReaderFromFS(fsys, root), nil
 		}
 		return blanks.NewMoldReaderFromPath(args[0])
 	}

--- a/internal/commands/forge_test.go
+++ b/internal/commands/forge_test.go
@@ -1,0 +1,162 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nimble-giant/ailloy/pkg/blanks"
+	"github.com/nimble-giant/ailloy/pkg/mold"
+)
+
+// TestBuildIngotResolver_PrependsMoldRoot is a regression test for issue #140:
+// when a mold is cast from a path or remote source, its bundled ingots/ directory
+// (located at the mold's source root) must be searched, not just the destination CWD.
+func TestBuildIngotResolver_PrependsMoldRoot(t *testing.T) {
+	moldDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(moldDir, "ingots"), 0750); err != nil {
+		t.Fatalf("creating ingots dir: %v", err)
+	}
+	const ingotContent = "Hello from bundled ingot"
+	if err := os.WriteFile(filepath.Join(moldDir, "ingots", "greeting.md"),
+		[]byte(ingotContent), 0644); err != nil {
+		t.Fatalf("writing ingot: %v", err)
+	}
+
+	// Run from a different CWD — the destination directory in a real cast.
+	destDir := t.TempDir()
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(destDir); err != nil {
+		t.Fatalf("chdir to dest: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	resolver := buildIngotResolver(map[string]any{}, moldDir)
+
+	got, err := resolver.Resolve("greeting")
+	if err != nil {
+		t.Fatalf("Resolve(\"greeting\"): %v", err)
+	}
+	if !strings.Contains(got, ingotContent) {
+		t.Errorf("resolved content = %q, want it to contain %q", got, ingotContent)
+	}
+}
+
+// TestBuildIngotResolver_NoMoldRootFallsBackToCWD ensures the existing behavior
+// (search "." when no mold root is known) still works for the embedded-mold case.
+func TestBuildIngotResolver_NoMoldRootFallsBackToCWD(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "ingots"), 0750); err != nil {
+		t.Fatalf("creating ingots dir: %v", err)
+	}
+	const ingotContent = "Local ingot content"
+	if err := os.WriteFile(filepath.Join(dir, "ingots", "local.md"),
+		[]byte(ingotContent), 0644); err != nil {
+		t.Fatalf("writing ingot: %v", err)
+	}
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	resolver := buildIngotResolver(map[string]any{}, "")
+
+	got, err := resolver.Resolve("local")
+	if err != nil {
+		t.Fatalf("Resolve(\"local\"): %v", err)
+	}
+	if !strings.Contains(got, ingotContent) {
+		t.Errorf("resolved content = %q, want it to contain %q", got, ingotContent)
+	}
+}
+
+// TestCastFromPath_ResolvesBundledIngot is a higher-level regression test for
+// issue #140: casting a path-based mold from a different CWD must find the
+// mold's bundled ingots, not silently fail with "ingot not found".
+func TestCastFromPath_ResolvesBundledIngot(t *testing.T) {
+	moldDir := t.TempDir()
+
+	mustWrite(t, filepath.Join(moldDir, "mold.yaml"), `apiVersion: v1
+kind: mold
+name: test-mold
+version: 0.1.0
+`)
+	mustWrite(t, filepath.Join(moldDir, "flux.yaml"), `output:
+  agents: agents
+`)
+	if err := os.MkdirAll(filepath.Join(moldDir, "ingots"), 0750); err != nil {
+		t.Fatalf("creating ingots dir: %v", err)
+	}
+	const ingotContent = "Bundled ingot content"
+	mustWrite(t, filepath.Join(moldDir, "ingots", "greeting.md"), ingotContent)
+
+	if err := os.MkdirAll(filepath.Join(moldDir, "agents"), 0750); err != nil {
+		t.Fatalf("creating agents dir: %v", err)
+	}
+	mustWrite(t, filepath.Join(moldDir, "agents", "test.md"), `{{ingot "greeting"}}`+"\n")
+
+	// chdir to a different destination directory.
+	destDir := t.TempDir()
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(destDir); err != nil {
+		t.Fatalf("chdir to dest: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	reader, err := blanks.NewMoldReaderFromPath(moldDir)
+	if err != nil {
+		t.Fatalf("NewMoldReaderFromPath: %v", err)
+	}
+	if reader.Root() != moldDir {
+		t.Fatalf("reader.Root() = %q, want %q", reader.Root(), moldDir)
+	}
+
+	flux, err := reader.LoadFluxDefaults()
+	if err != nil {
+		t.Fatalf("LoadFluxDefaults: %v", err)
+	}
+
+	resolver := buildIngotResolver(flux, reader.Root())
+	opts := []mold.TemplateOption{mold.WithIngotResolver(resolver)}
+
+	resolved, err := mold.ResolveFiles(flux["output"], reader.FS())
+	if err != nil {
+		t.Fatalf("ResolveFiles: %v", err)
+	}
+	if len(resolved) == 0 {
+		t.Fatal("expected at least one resolved file")
+	}
+
+	for _, rf := range resolved {
+		content, err := os.ReadFile(filepath.Join(moldDir, rf.SrcPath))
+		if err != nil {
+			t.Fatalf("reading %s: %v", rf.SrcPath, err)
+		}
+		rendered, err := mold.ProcessTemplate(string(content), flux, opts...)
+		if err != nil {
+			t.Fatalf("rendering %s: %v", rf.SrcPath, err)
+		}
+		if !strings.Contains(rendered, ingotContent) {
+			t.Errorf("rendered %s = %q, want it to contain %q", rf.SrcPath, rendered, ingotContent)
+		}
+	}
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+}

--- a/internal/commands/recast.go
+++ b/internal/commands/recast.go
@@ -103,7 +103,7 @@ func runRecast(_ *cobra.Command, args []string) error {
 			fetcher, fErr := foundry.NewFetcher(git)
 			if fErr == nil {
 				// Fetch the new version into cache.
-				_, _ = fetcher.Fetch(ref, resolved)
+				_, _, _ = fetcher.Fetch(ref, resolved)
 			}
 
 			lock.UpsertEntry(foundry.LockEntry{

--- a/internal/commands/temper.go
+++ b/internal/commands/temper.go
@@ -153,7 +153,7 @@ func runTemperLint(moldDir string) error {
 	}
 
 	// Build ingot resolver and render files
-	resolver := buildIngotResolver(flux)
+	resolver := buildIngotResolver(flux, reader.Root())
 	opts := []mold.TemplateOption{mold.WithIngotResolver(resolver)}
 
 	resolved, err := mold.ResolveFiles(flux["output"], reader.FS())

--- a/internal/commands/temper_integration_test.go
+++ b/internal/commands/temper_integration_test.go
@@ -21,7 +21,7 @@ func TestIntegration_TemperLint_RendersAndLints(t *testing.T) {
 	}
 
 	// Build ingot resolver and resolve files
-	resolver := buildIngotResolver(flux)
+	resolver := buildIngotResolver(flux, reader.Root())
 	opts := []mold.TemplateOption{mold.WithIngotResolver(resolver)}
 
 	resolved, err := mold.ResolveFiles(flux["output"], reader.FS())
@@ -69,7 +69,7 @@ func TestIntegration_TemperLint_WriteRenderedFiles_CreatesDirectories(t *testing
 	reader := testMoldReader(t)
 	flux := testFlux(t, reader)
 
-	resolver := buildIngotResolver(flux)
+	resolver := buildIngotResolver(flux, reader.Root())
 	opts := []mold.TemplateOption{mold.WithIngotResolver(resolver)}
 
 	resolved, err := mold.ResolveFiles(flux["output"], reader.FS())
@@ -201,7 +201,7 @@ func TestWriteRenderedFiles_RendersTemplates(t *testing.T) {
 	reader := testMoldReader(t)
 	flux := testFlux(t, reader)
 
-	resolver := buildIngotResolver(flux)
+	resolver := buildIngotResolver(flux, reader.Root())
 	opts := []mold.TemplateOption{mold.WithIngotResolver(resolver)}
 
 	resolved, err := mold.ResolveFiles(flux["output"], reader.FS())

--- a/pkg/blanks/blanks.go
+++ b/pkg/blanks/blanks.go
@@ -11,11 +11,20 @@ import (
 // MoldReader reads mold content from any fs.FS implementation.
 type MoldReader struct {
 	fsys fs.FS
+	root string
 }
 
-// NewMoldReader creates a MoldReader from an fs.FS.
+// NewMoldReader creates a MoldReader from an fs.FS. The mold has no on-disk
+// root path (e.g., embedded or in-memory).
 func NewMoldReader(fsys fs.FS) *MoldReader {
 	return &MoldReader{fsys: fsys}
+}
+
+// NewMoldReaderFromFS creates a MoldReader from an fs.FS that is known to be
+// rooted at an on-disk directory. The root is used to locate sibling
+// directories (e.g., bundled ingots) during template rendering.
+func NewMoldReaderFromFS(fsys fs.FS, root string) *MoldReader {
+	return &MoldReader{fsys: fsys, root: root}
 }
 
 // NewMoldReaderFromPath creates a MoldReader rooted at a filesystem directory.
@@ -27,12 +36,18 @@ func NewMoldReaderFromPath(moldDir string) (*MoldReader, error) {
 	if !info.IsDir() {
 		return nil, fmt.Errorf("mold path %q is not a directory", moldDir)
 	}
-	return &MoldReader{fsys: os.DirFS(moldDir)}, nil
+	return &MoldReader{fsys: os.DirFS(moldDir), root: moldDir}, nil
 }
 
 // FS returns the underlying filesystem.
 func (r *MoldReader) FS() fs.FS {
 	return r.fsys
+}
+
+// Root returns the on-disk path the mold is rooted at, or an empty string
+// for readers backed by an in-memory or embedded filesystem.
+func (r *MoldReader) Root() string {
+	return r.root
 }
 
 // LoadManifest loads and parses the mold.yaml manifest.

--- a/pkg/foundry/fetcher.go
+++ b/pkg/foundry/fetcher.go
@@ -30,16 +30,16 @@ func NewFetcherWithCacheDir(git GitRunner, cacheDir string) *Fetcher {
 }
 
 // Fetch resolves and extracts a mold version, returning an fs.FS rooted at
-// the (possibly subpath-navigated) mold directory.
-func (f *Fetcher) Fetch(ref *Reference, resolved *ResolvedVersion) (fs.FS, error) {
+// the (possibly subpath-navigated) mold directory along with its on-disk root.
+func (f *Fetcher) Fetch(ref *Reference, resolved *ResolvedVersion) (fs.FS, string, error) {
 	if err := f.ensureBareClone(ref); err != nil {
-		return nil, fmt.Errorf("ensuring bare clone: %w", err)
+		return nil, "", fmt.Errorf("ensuring bare clone: %w", err)
 	}
 
 	vDir := VersionDir(f.cacheDir, ref, resolved.Tag)
 	if !hasMoldManifestInDir(vDir, ref.Subpath) {
 		if err := f.checkoutVersion(ref, resolved); err != nil {
-			return nil, fmt.Errorf("checking out version: %w", err)
+			return nil, "", fmt.Errorf("checking out version: %w", err)
 		}
 	}
 
@@ -96,7 +96,8 @@ func (f *Fetcher) checkoutVersion(ref *Reference, resolved *ResolvedVersion) err
 }
 
 // navigateSubpath applies the //subpath and validates the mold manifest exists.
-func (f *Fetcher) navigateSubpath(ref *Reference, resolved *ResolvedVersion) (fs.FS, error) {
+// It returns the resulting fs.FS and the on-disk root path.
+func (f *Fetcher) navigateSubpath(ref *Reference, resolved *ResolvedVersion) (fs.FS, string, error) {
 	vDir := VersionDir(f.cacheDir, ref, resolved.Tag)
 	root := vDir
 
@@ -104,27 +105,27 @@ func (f *Fetcher) navigateSubpath(ref *Reference, resolved *ResolvedVersion) (fs
 		// Safety: ensure subpath doesn't escape the version directory.
 		absVersion, err := filepath.Abs(vDir)
 		if err != nil {
-			return nil, fmt.Errorf("resolving version path: %w", err)
+			return nil, "", fmt.Errorf("resolving version path: %w", err)
 		}
 		absTarget, err := filepath.Abs(filepath.Join(vDir, ref.Subpath))
 		if err != nil {
-			return nil, fmt.Errorf("resolving subpath: %w", err)
+			return nil, "", fmt.Errorf("resolving subpath: %w", err)
 		}
 		if !strings.HasPrefix(absTarget, absVersion+string(filepath.Separator)) {
-			return nil, fmt.Errorf("subpath %q escapes version directory", ref.Subpath)
+			return nil, "", fmt.Errorf("subpath %q escapes version directory", ref.Subpath)
 		}
 		root = absTarget
 	}
 
 	if _, err := os.Stat(root); os.IsNotExist(err) {
-		return nil, fmt.Errorf("subpath %q does not exist in %s@%s", ref.Subpath, ref.CacheKey(), resolved.Tag)
+		return nil, "", fmt.Errorf("subpath %q does not exist in %s@%s", ref.Subpath, ref.CacheKey(), resolved.Tag)
 	}
 
 	if !hasMoldManifest(root) {
-		return nil, fmt.Errorf("no mold.yaml or ingot.yaml found at %s@%s//%s", ref.CacheKey(), resolved.Tag, ref.Subpath)
+		return nil, "", fmt.Errorf("no mold.yaml or ingot.yaml found at %s@%s//%s", ref.CacheKey(), resolved.Tag, ref.Subpath)
 	}
 
-	return os.DirFS(root), nil
+	return os.DirFS(root), root, nil
 }
 
 // hasMoldManifestInDir checks the version dir (with optional subpath) for a manifest.

--- a/pkg/foundry/fetcher_test.go
+++ b/pkg/foundry/fetcher_test.go
@@ -106,7 +106,7 @@ func TestFetcher_Fetch(t *testing.T) {
 	ref := &Reference{Host: "github.com", Owner: "owner", Repo: "repo"}
 	resolved := &ResolvedVersion{Tag: "v1.0.0", Commit: "abc123"}
 
-	fsys, err := fetcher.Fetch(ref, resolved)
+	fsys, _, err := fetcher.Fetch(ref, resolved)
 	if err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}
@@ -159,7 +159,7 @@ func TestFetcher_Fetch_Subpath(t *testing.T) {
 	ref := &Reference{Host: "github.com", Owner: "owner", Repo: "repo", Subpath: "molds/claude"}
 	resolved := &ResolvedVersion{Tag: "v1.0.0", Commit: "abc123"}
 
-	fsys, err := fetcher.Fetch(ref, resolved)
+	fsys, _, err := fetcher.Fetch(ref, resolved)
 	if err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}
@@ -216,7 +216,7 @@ func TestFetcher_Fetch_CacheHit(t *testing.T) {
 	}
 
 	fetcher := NewFetcherWithCacheDir(git, cacheDir)
-	fsys, err := fetcher.Fetch(ref, resolved)
+	fsys, _, err := fetcher.Fetch(ref, resolved)
 	if err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}

--- a/pkg/foundry/foundry.go
+++ b/pkg/foundry/foundry.go
@@ -27,9 +27,17 @@ func WithoutLock() ResolveOption {
 // from remote tags, fetches/caches the mold, updates the lock, and returns
 // an fs.FS rooted at the mold directory.
 func Resolve(rawRef string, opts ...ResolveOption) (fs.FS, error) {
+	fsys, _, err := ResolveWithRoot(rawRef, opts...)
+	return fsys, err
+}
+
+// ResolveWithRoot is like Resolve but also returns the on-disk root path
+// of the resolved mold. The root path is needed by callers that resolve
+// sibling directories (e.g., bundled ingots) during template rendering.
+func ResolveWithRoot(rawRef string, opts ...ResolveOption) (fs.FS, string, error) {
 	ref, err := ParseReference(rawRef)
 	if err != nil {
-		return nil, fmt.Errorf("parsing reference: %w", err)
+		return nil, "", fmt.Errorf("parsing reference: %w", err)
 	}
 
 	git := DefaultGitRunner()
@@ -37,7 +45,8 @@ func Resolve(rawRef string, opts ...ResolveOption) (fs.FS, error) {
 }
 
 // ResolveWith is like Resolve but accepts an injectable GitRunner (for testing).
-func ResolveWith(ref *Reference, git GitRunner, opts ...ResolveOption) (fs.FS, error) {
+// It returns the resolved fs.FS and the on-disk root path.
+func ResolveWith(ref *Reference, git GitRunner, opts ...ResolveOption) (fs.FS, string, error) {
 	var cfg resolveConfig
 	for _, opt := range opts {
 		opt(&cfg)
@@ -65,7 +74,7 @@ func ResolveWith(ref *Reference, git GitRunner, opts ...ResolveOption) (fs.FS, e
 	if resolved == nil {
 		v, resolveErr := ResolveVersion(ref, git)
 		if resolveErr != nil {
-			return nil, fmt.Errorf("resolving version: %w", resolveErr)
+			return nil, "", fmt.Errorf("resolving version: %w", resolveErr)
 		}
 		resolved = v
 	}
@@ -73,12 +82,12 @@ func ResolveWith(ref *Reference, git GitRunner, opts ...ResolveOption) (fs.FS, e
 	// Fetch (clone/cache).
 	fetcher, err := NewFetcher(git)
 	if err != nil {
-		return nil, fmt.Errorf("creating fetcher: %w", err)
+		return nil, "", fmt.Errorf("creating fetcher: %w", err)
 	}
 
-	fsys, err := fetcher.Fetch(ref, resolved)
+	fsys, root, err := fetcher.Fetch(ref, resolved)
 	if err != nil {
-		return nil, fmt.Errorf("fetching mold: %w", err)
+		return nil, "", fmt.Errorf("fetching mold: %w", err)
 	}
 
 	// Update lock file.
@@ -88,7 +97,7 @@ func ResolveWith(ref *Reference, git GitRunner, opts ...ResolveOption) (fs.FS, e
 		}
 	}
 
-	return fsys, nil
+	return fsys, root, nil
 }
 
 // lockedSatisfies checks whether the locked entry still satisfies the


### PR DESCRIPTION
## Description

Casting or forging a path/remote mold failed to resolve `{{ingot "name"}}` references to the mold's own bundled `ingots/` directory because `buildIngotResolver` hardcoded `"."` (the destination CWD) as the first search path. `MoldReader` now tracks the on-disk root, `foundry.ResolveWithRoot` surfaces the cache root for remote molds, and `buildIngotResolver` prepends that root before falling back to CWD/`.ailloy/`/`~/.ailloy/`.

## Related Issue

Fixes #140

## Testing

`go build`, `go vet`, and full `go test ./...` pass. Added `forge_test.go` with regression tests covering both the resolver fallback path and an end-to-end path-mold + bundled ingot render. Manually reproduced the issue's exact scenario (cast `/tmp/test-mold` from a separate destination) and confirmed the bundled ingot now renders.

## UAT

Create a mold dir with an `ingots/greeting.md` and an agent template using `{{ingot "greeting"}}`, then `cd` to a different directory and run `ailloy cast <mold-dir>`; the rendered output should contain the ingot content instead of erroring with `ingot "greeting" not found`.

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [ ] I have updated documentation (if applicable)
- [x] My commits have DCO sign-off (`git commit -s`)