### PR TITLE
docs: restructure README in CNCF documentation style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,218 +1,231 @@
+<div align="center">
+
+<img src=".assets/Ailloy%20the%20Blacksmith%20Innovator.png" alt="Ailloy" width="280" />
+
 # Ailloy
+
+**The package manager for AI instructions.**
 
 [![CI](https://github.com/nimble-giant/ailloy/actions/workflows/ci.yml/badge.svg)](https://github.com/nimble-giant/ailloy/actions/workflows/ci.yml)
 [![Security](https://github.com/nimble-giant/ailloy/actions/workflows/security.yml/badge.svg)](https://github.com/nimble-giant/ailloy/actions/workflows/security.yml)
 [![Release](https://github.com/nimble-giant/ailloy/actions/workflows/release.yml/badge.svg)](https://github.com/nimble-giant/ailloy/actions/workflows/release.yml)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE.md)
 
-![Ailloy Mascot](.assets/Ailloy%20the%20Blacksmith%20Innovator.png)
+Find, create, and share reusable AI workflow packages — the way [Helm](https://helm.sh/) manages Kubernetes applications.
 
-**Ailloy is the package manager for AI instructions.** It helps you find, create, and share reusable AI workflow packages — the same way [Helm](https://helm.sh/) manages Kubernetes applications. Molds are to Ailloy what charts are to Helm: versioned, configurable packages that can be installed into any project or workload.
+[**Quick Start**](#quick-start) · [**Documentation**](docs/) · [**Official Mold**](https://github.com/nimble-giant/nimble-mold) · [**Contributing**](#contributing)
 
-Ailloy gives teams a reproducible pipeline for authoring, packaging, and distributing AI-assisted development workflows.
+</div>
 
-Like in metallurgy — where combining two elements yields a stronger alloy — Ailloy represents the fusion of human development practices with AI assistance.
+---
 
-![Ailloy with Claude Integration](.assets/Friendly%20Ailloy%20with%20Glowing%20Orb.png)
+## Why Ailloy
+
+- **Reproducible** — Versioned, configurable mold packages with Helm-style value precedence. Same mold, same flux values, same output every time.
+- **Tool-agnostic** — Works with any AI coding tool that reads file-based instructions: Claude Code, Cursor, Windsurf, GitHub Copilot, and [more](https://agents.md). The `output:` mapping in `flux.yaml` decides where blanks land.
+- **Helm-style ergonomics** — `cast`, `forge`, `smelt`, `temper`. If you know `helm install` and `helm template`, you already know the shape.
 
 ## What is Ailloy?
 
-Ailloy is the best way to find, create, and share AI instruction packages. Like Helm for Kubernetes, it provides:
+Ailloy compiles, packages, and distributes AI-assisted development workflows. **Molds** are to Ailloy what charts are to Helm: versioned, configurable packages that can be installed into any project.
 
-- **Manage Complexity**: Molds describe complete AI workflows — commands, skills, GitHub Actions — with a single `mold.yaml` manifest and configurable flux variables
-- **Easy Updates**: Override defaults at install time with `--set` flags or layered value files, following Helm-style precedence
-- **Simple Sharing**: Package molds into distributable tarballs or self-contained binaries with `ailloy smelt`, then share them across teams and projects
+Like in metallurgy — combining elements yields a stronger alloy — Ailloy fuses human development practices with AI assistance.
 
-### The Ailloy Pipeline
+| Helm | Ailloy | What it does |
+|------|--------|--------------|
+| `helm template` | `ailloy forge` | Dry-run render of blanks with flux values |
+| `helm install` | `ailloy cast` | Compile and install blanks into a project |
+| `helm package` | `ailloy smelt` | Bundle a mold into a tarball or binary |
+| `helm lint` | `ailloy temper` | Validate mold structure and templates |
+| — | `ailloy anneal` | Interactive wizard to set flux variables |
+| — | `ailloy assay` | Lint rendered AI instruction files |
 
-| Step | Command | Helm Equivalent | What It Does |
-|------|---------|-----------------|--------------|
-| Author | — | — | Write instruction templates (blanks) with Go `text/template` syntax |
-| Configure | `ailloy anneal` | — | Interactive wizard to set flux variables |
-| Preview | `ailloy forge` | `helm template` | Dry-run render of blanks with flux values |
-| Install | `ailloy cast` | `helm install` | Compile and install blanks into a project |
-| Package | `ailloy smelt` | `helm package` | Bundle a mold into a tarball or binary |
-| Validate | `ailloy temper` | `helm lint` | Validate mold structure, manifests, and templates |
-| Lint | `ailloy assay` | — | Lint rendered AI instruction files against best practices |
+## How It Works
 
-Ailloy works with any AI coding tool that supports file-based instructions — Claude Code, Cursor, Windsurf, GitHub Copilot, and [many others](https://agents.md). The `output:` mapping in `flux.yaml` determines where blanks are installed, making molds portable across tools.
+<img src=".assets/Friendly%20Ailloy%20with%20Glowing%20Orb.png" alt="Ailloy mascot" width="180" align="right" />
+
+The Ailloy pipeline is a small set of composable steps. Author once, configure per project, render and install anywhere.
+
+| Step | Command | Description |
+|------|---------|-------------|
+| Author | — | Write instruction templates (blanks) with Go `text/template` syntax |
+| Configure | `ailloy anneal` | Interactive wizard to set flux variables |
+| Preview | `ailloy forge` | Dry-run render of blanks with flux values |
+| Install | `ailloy cast` | Compile and install blanks into a project |
+| Package | `ailloy smelt` | Bundle a mold into a tarball or binary |
+| Validate | `ailloy temper` | Validate mold structure, manifests, and templates |
+| Lint | `ailloy assay` | Lint rendered AI instruction files against best practices |
+
+<br clear="right" />
 
 ## Quick Start
 
-Get started in minutes:
+<img src=".assets/Ailloy%20Winking%20with%20Orb%20and%20Hammer.png" alt="Ailloy ready to help" width="200" align="right" />
 
-![Ailloy Ready to Help](.assets/Ailloy%20Winking%20with%20Orb%20and%20Hammer.png)
+### 1. Install
 
-### Installation
-
-#### Quick Install (Recommended)
-
-Download the latest pre-built binary for your platform:
+<details>
+<summary><strong>Quick install (recommended)</strong></summary>
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/nimble-giant/ailloy/main/install.sh | bash
 ```
 
-#### Go Install
+</details>
 
-If you have Go installed:
+<details>
+<summary><strong>Go install</strong></summary>
 
 ```bash
 go install github.com/nimble-giant/ailloy/cmd/ailloy@latest
 ```
 
-#### Build from Source
+</details>
+
+<details>
+<summary><strong>Build from source</strong></summary>
 
 ```bash
 git clone https://github.com/nimble-giant/ailloy
 cd ailloy
-make build
+make build   # binary at ./bin/ailloy
 ```
 
-The binary will be available at `./bin/ailloy`.
+</details>
 
-### Cast a Mold into a Project
+### 2. Cast a mold
 
-Molds can be resolved directly from git repositories — no local clone required:
+Molds resolve directly from git — no clone required:
 
 ```bash
-# Install blanks from the official mold (resolves latest tag from GitHub)
+# Install blanks from the official mold (latest tag)
 ailloy cast github.com/nimble-giant/nimble-mold
 
-# Pin to a specific version
+# Pin to a version, or use a semver range
 ailloy cast github.com/nimble-giant/nimble-mold@v0.1.10
-
-# Semver constraints (caret, tilde, range)
 ailloy cast github.com/nimble-giant/nimble-mold@^0.1.0
 
 # Include GitHub Actions workflow blanks
 ailloy cast github.com/nimble-giant/nimble-mold --with-workflows
 
-# Override flux values at install time
+# Override flux at install time
 ailloy cast github.com/nimble-giant/nimble-mold --set project.organization=mycompany
-
-# Local mold directories still work
-ailloy cast ./my-local-mold
 ```
 
-### Configure Flux Variables
+### 3. Configure flux variables
 
 ```bash
-# Interactive wizard — reads flux.schema.yaml from a mold
+# Interactive wizard
 ailloy anneal github.com/nimble-giant/nimble-mold -o flux-overrides.yaml
 
-# Scripted mode
-ailloy anneal --set project.organization=mycompany --set project.board=Engineering -o flux-overrides.yaml
-
-# Use overrides with cast
+# Use the overrides
 ailloy cast github.com/nimble-giant/nimble-mold -f flux-overrides.yaml
 ```
 
-### Working with Blanks
+<br clear="right" />
 
-```bash
-# List available blanks
-ailloy mold list
+## Commands
 
-# View a specific blank
-ailloy mold show create-issue
-```
+<details>
+<summary><strong><code>cast</code> · <code>forge</code></strong> — install and preview molds</summary>
 
-## Available Commands
+**`ailloy cast [mold-ref]`** (alias: `install`) — Render and install blanks. Accepts a local path or `host/owner/repo[@version][//subpath]`.
 
-### `ailloy cast [mold-ref]`
+- `-g, --global` — Install into `~/` instead of the current project
+- `--with-workflows` — Include GitHub Actions workflow blanks
+- `--set key=value` — Override flux variables (repeatable)
+- `-f, --values file` — Layer flux value files (repeatable)
 
-Install rendered blanks from a mold into the current project (alias: `install`). Accepts a local directory path or a remote git reference (`host/owner/repo[@version][//subpath]`):
+**`ailloy forge [mold-ref]`** (aliases: `blank`, `template`) — Dry-run render of mold blanks.
 
-- `-g, --global`: Install into user home directory (`~/`) instead of current project
-- `--with-workflows`: Include GitHub Actions workflow blanks
-- `--set key=value`: Override flux variables (can be repeated)
-- `-f, --values file`: Layer additional flux value files (can be repeated)
+- `-o, --output dir` — Write to a directory instead of stdout
+- `--set`, `-f` — Same as `cast`
 
-### `ailloy forge [mold-ref]`
+</details>
 
-Dry-run render of mold blanks (aliases: `blank`, `template`). Accepts a local directory path or a remote git reference:
+<details>
+<summary><strong><code>mold</code> · <code>ingot</code></strong> — manage blanks and template components</summary>
 
-- `-o, --output dir`: Write rendered files to a directory instead of stdout
-- `--set key=value`: Set flux values (can be repeated)
-- `-f, --values file`: Layer additional flux value files (can be repeated)
+**`ailloy mold`** — Manage AI command blanks.
 
-### `ailloy mold`
+- `list` — Show all available blanks
+- `show <blank-name>` — Display blank content
+- `get <reference>` — Download a mold to local cache without installing
 
-Manage AI command blanks:
+**`ailloy ingot`** — Reusable template components.
 
-- `list`: Show all available blanks
-- `show <blank-name>`: Display blank content
-- `get <reference>`: Download a mold to local cache without installing (validates `mold.yaml`, prints cache path)
+- `get <reference>` — Download to local cache
+- `add <reference>` — Install into the project's `.ailloy/ingots/`
 
-### `ailloy anneal [mold-ref]`
+</details>
 
-Dynamic, mold-aware wizard to configure flux variables (alias: `configure`). Reads `flux.schema.yaml` from the mold to generate type-driven prompts with optional discovery commands. Accepts a local directory path or a remote git reference:
+<details>
+<summary><strong><code>anneal</code></strong> — configure flux variables</summary>
 
-- `-s, --set key=value`: Set flux variable in scripted mode (can be repeated)
-- `-o, --output file`: Write flux YAML to file (default: stdout)
+**`ailloy anneal [mold-ref]`** (alias: `configure`) — Mold-aware wizard. Reads `flux.schema.yaml` to generate type-driven prompts with optional discovery commands.
 
-### `ailloy smelt [mold-dir]`
+- `-s, --set key=value` — Set in scripted mode (repeatable)
+- `-o, --output file` — Write flux YAML to file (default: stdout)
 
-Package a mold into a distributable format (alias: `package`):
+</details>
 
-- `-o, --output-format`: Output format: `tar` (default) or `binary`
-- `--output dir`: Output directory (default: current directory)
+<details>
+<summary><strong><code>smelt</code></strong> — package molds for distribution</summary>
 
-### `ailloy assay [path]`
+**`ailloy smelt [mold-dir]`** (alias: `package`) — Package a mold into a distributable format.
 
-Lint rendered AI instruction files against best practices (alias: `lint`):
+- `-o, --output-format` — `tar` (default) or `binary`
+- `--output dir` — Output directory
+
+</details>
+
+<details>
+<summary><strong><code>assay</code> · <code>temper</code></strong> — lint and validate</summary>
+
+**`ailloy assay [path]`** (alias: `lint`) — Lint rendered AI instruction files.
 
 - Auto-detects CLAUDE.md, AGENTS.md, Cursor rules, Copilot instructions, and more
-- Checks content quality, cross-references, and platform-specific schema validation
-- Supports `--format json|markdown` for CI, `--fail-on warning|suggestion` for exit code control
-- Configure via `.ailloyrc.yaml` — generate a starter config with `--init`
+- `--format json|markdown` for CI · `--fail-on warning|suggestion` for exit control
+- Configure via `.ailloyrc.yaml` (`--init` for a starter)
 
-### `ailloy temper [path]`
+**`ailloy temper [path]`** (alias: `validate`) — Validate a mold or ingot package.
 
-Validate a mold or ingot package (alias: `validate`):
+- Checks structural integrity, manifests, file references, template syntax, flux schema
+- `--lint` — Render and run assay on output before casting
+- `--set`, `-f`, `--format`, `--fail-on`, `--max-lines`
 
-- Checks structural integrity, manifest fields, file references, template syntax, and flux schema consistency
-- Reports errors (blocking) and warnings (informational)
-- `--lint`: Also render blanks and run assay (lint) on the output — catches content issues before casting
-- `--set key=value`, `-f, --values file`: Provide flux values for rendering (same as forge/cast)
-- `--format`, `--fail-on`, `--max-lines`: Control assay output and failure threshold
+</details>
 
-### `ailloy foundry`
+<details>
+<summary><strong><code>foundry</code></strong> — discover and manage mold registries</summary>
 
-Discover and manage mold registries. See the [Remote Molds guide](docs/foundry.md) for details:
+See the [Remote Molds guide](docs/foundry.md).
 
-- `search <query>`: Search registered foundry indexes and GitHub Topics for molds
-- `add <url>`: Register a foundry index (git repo or static YAML URL)
-- `list`: List all registered foundry indexes and their status
-- `remove <name|url>`: Remove a registered foundry index
-- `update`: Refresh all cached foundry indexes from their sources
+- `search <query>` — Search registered indexes and GitHub Topics
+- `add <url>` — Register a foundry index (git repo or static YAML URL)
+- `list` — List registered indexes and their status
+- `remove <name|url>` — Remove a registered index
+- `update` — Refresh all cached indexes
 
-### `ailloy ingot`
+</details>
 
-Manage reusable template components (ingots):
+<details>
+<summary><strong><code>plugin</code></strong> — Claude Code plugin generation</summary>
 
-- `get <reference>`: Download an ingot to the local cache without installing
-- `add <reference>`: Download and install an ingot into the project's `.ailloy/ingots/` directory
+Currently Claude Code specific; the core pipeline is tool-agnostic.
 
-### `ailloy plugin`
+- `generate` — Generate plugin from blanks (`--mold`, `--output`, `--watch`, `--force`)
+- `update [path]` — Update existing plugin
+- `validate [path]` — Validate plugin structure
 
-Generate and manage Claude Code plugins (currently Claude Code specific; the core pipeline is tool-agnostic):
+</details>
 
-- `generate`: Generate plugin from blanks (`--mold`, `--output`, `--watch`, `--force`)
-- `update [path]`: Update existing plugin (`--mold`, `--force`)
-- `validate [path]`: Validate plugin structure
-
-### Bidirectional Commands
-
-All compound commands support both noun-verb and verb-noun ordering:
+<details>
+<summary><strong>Bidirectional commands</strong> — noun-verb or verb-noun</summary>
 
 ```bash
-# These are equivalent
 ailloy foundry search blueprint    # noun-verb
 ailloy search foundry blueprint    # verb-noun
-
-ailloy foundry list                # noun-verb
-ailloy list foundry                # verb-noun
 
 ailloy mold get github.com/org/repo
 ailloy get mold github.com/org/repo
@@ -221,19 +234,15 @@ ailloy ingot add github.com/org/repo
 ailloy add ingot github.com/org/repo
 ```
 
+</details>
+
 ## Blanks
 
-Blanks are Markdown instruction templates that define AI coding tool commands, skills, and workflows. Each blank lives in a mold directory and is compiled with flux variables when you run `ailloy cast` or `ailloy forge`.
+Blanks are Markdown instruction templates — commands, skills, or workflows — that compile with flux variables when you `cast` or `forge` a mold.
 
-There are three types of blanks:
-
-- **Commands** (`commands/`) — Commands users invoke explicitly (e.g., `/brainstorm`, `/create-issue`)
-- **Skills** (`skills/`) — Proactive workflows your AI coding tool uses automatically based on context
-- **Workflows** (`workflows/`) — GitHub Actions YAML files, installed with `--with-workflows`
-
-### Creating a Blank
-
-Add a Markdown file to your mold's `commands/` or `skills/` directory. Reference flux variables with Go [text/template](https://pkg.go.dev/text/template) syntax:
+- **Commands** (`commands/`) — Invoked explicitly (e.g., `/brainstorm`, `/create-issue`)
+- **Skills** (`skills/`) — Proactive workflows the AI tool uses based on context
+- **Workflows** (`workflows/`) — GitHub Actions YAML, installed with `--with-workflows`
 
 ```markdown
 # Deploy Checklist
@@ -248,58 +257,54 @@ Update the status field ({{ .ore.status.field_id }}) after each step.
 {{end}}
 ```
 
-### Working with Blanks
-
-```bash
-# List installed blanks
-ailloy mold list
-
-# View a specific blank
-ailloy mold show create-issue
-
-# Preview rendered output (dry run)
-ailloy forge ./my-mold
-
-# Install into current project
-ailloy cast ./my-mold
-```
-
-The [official mold](https://github.com/nimble-giant/nimble-mold) provides pre-built blanks for common SDLC tasks (issue management, PR workflows, code review) and is a good reference for blank structure and conventions.
-
-For the full guide on creating blanks, template syntax, and ingot includes, see the [Blanks guide](docs/blanks.md). For packaging and distributing molds, see the [Packaging Molds guide](docs/smelt.md).
+The [official mold](https://github.com/nimble-giant/nimble-mold) ships pre-built blanks for SDLC tasks (issue management, PR workflows, code review) and is a good reference. For the full guide, see [docs/blanks.md](docs/blanks.md). For packaging, see [docs/smelt.md](docs/smelt.md).
 
 ## Configuration
 
-Ailloy uses **flux** — YAML variable files that configure how blanks are rendered. Each mold ships with a `flux.yaml` containing defaults, and you can override values at multiple layers.
+Ailloy uses **flux** — YAML variable files that configure how blanks render.
 
-### Flux Value Precedence
-
-When blanks are rendered with `forge` or `cast`, flux values are resolved in this order (lowest to highest priority):
+**Precedence** (lowest → highest):
 
 1. `mold.yaml` `flux:` schema defaults
-2. `flux.yaml` defaults (shipped with the mold)
-3. `-f` value files (left to right, later files override earlier)
-4. `--set` flags (highest priority)
+2. `flux.yaml` defaults shipped with the mold
+3. `-f` value files (left to right)
+4. `--set` flags
 
-### Configuring Flux Values
+For the full guide, see [docs/flux.md](docs/flux.md). For the wizard, see [docs/anneal.md](docs/anneal.md).
 
-```bash
-# Interactive wizard — reads schema from mold, generates a flux YAML file
-ailloy anneal github.com/nimble-giant/nimble-mold -o my-overrides.yaml
+## Status
 
-# Scripted mode
-ailloy anneal --set project.organization=mycompany -o my-overrides.yaml
+> **Alpha** — Ailloy is an early-stage package manager for AI instructions. The core toolchain is functional and used in production by the maintainers, but APIs and on-disk formats may change before 1.0.
 
-# Use overrides when casting
-ailloy cast github.com/nimble-giant/nimble-mold -f my-overrides.yaml
+<details>
+<summary><strong>What's shipped</strong></summary>
 
-# Or override inline
-ailloy cast github.com/nimble-giant/nimble-mold --set project.organization=mycompany
-```
+- Mold casting and forging with flux variable rendering
+- Blank management and viewing
+- Flux-based configuration with Helm-style value precedence
+- Conditional blank rendering with ore model-aware context
+- Mold packaging (tarball and self-contained binary)
+- Mold/ingot validation and linting
+- Claude Code plugin generation from blanks
+- Workflow blanks for GitHub Actions
+- Automatic GitHub Project field discovery via GraphQL
+- Interactive wizard with `charmbracelet/huh` for guided configuration
+- SCM-native mold resolution from git repos with semver constraints and local caching
+- Foundry search and discovery via GitHub Topics and SCM-agnostic foundry indexes
+- Ingot package management with bidirectional CLI commands
 
-For the full guide on flux variables, schemas, and value layering, see the [Flux Variables guide](docs/flux.md). For the interactive wizard, see the [Anneal guide](docs/anneal.md).
+</details>
 
-## Project Structure
+<details>
+<summary><strong>What's planned</strong></summary>
+
+- Additional AI provider support
+- Advanced workflow automation
+
+</details>
+
+<details>
+<summary><strong>Project structure</strong></summary>
 
 ```text
 /cmd/ailloy          # CLI tool entry point
@@ -307,7 +312,7 @@ For the full guide on flux variables, schemas, and value layering, see the [Flux
   /commands          # CLI command implementations (cast, forge, smelt, etc.)
 /pkg
   /blanks            # MoldReader abstraction (reads mold directories)
-  /foundry           # SCM-native mold resolution, caching, and version management
+  /foundry           # SCM-native mold resolution, caching, version management
   /github            # GitHub ProjectV2 discovery via gh API GraphQL
   /mold              # Template engine, flux loading, ingot resolution
   /plugin            # Plugin generation pipeline
@@ -317,101 +322,63 @@ For the full guide on flux variables, schemas, and value layering, see the [Flux
 /docs                # Documentation
 ```
 
-## Current Status
-
-**Alpha Stage**: Ailloy is an early-stage package manager for AI instructions. The toolchain provides:
-
-- ✅ Mold casting and forging with flux variable rendering
-- ✅ Blank management and viewing
-- ✅ Flux-based configuration with Helm-style value precedence
-- ✅ Conditional blank rendering with ore model-aware context
-- ✅ Mold packaging (tarball and self-contained binary)
-- ✅ Mold/ingot validation and linting
-- ✅ Claude Code plugin generation from blanks
-- ✅ Workflow blanks for GitHub Actions
-- ✅ Automatic GitHub Project field discovery via GraphQL
-- ✅ Interactive wizard with charmbracelet/huh for guided configuration
-- ✅ SCM-native mold resolution from git repos with semver constraints and local caching
-- ✅ Foundry search and discovery via GitHub Topics and SCM-agnostic foundry indexes
-- ✅ Ingot package management (get, add) with bidirectional CLI commands
-- 🔄 Additional AI provider support (planned)
-- 🔄 Advanced workflow automation (planned)
+</details>
 
 ## Contributing
 
-This is an evolving project — community input welcome! As AI development practices mature, Ailloy aims to be the standard package manager for AI instructions, the way Helm became the standard for Kubernetes.
+Community input welcome. As AI development practices mature, Ailloy aims to be the standard package manager for AI instructions — the way Helm became the standard for Kubernetes.
 
 ### Prerequisites
 
-**Option 1: Flox (Recommended)**
-
-[Flox](https://flox.dev/) provides a reproducible development environment with all dependencies:
+**Recommended:** [Flox](https://flox.dev/) provides a reproducible dev environment with all dependencies.
 
 ```bash
-# Install Flox (one-time)
-curl -fsSL https://flox.dev/install | bash
-
-# Activate the development environment
+curl -fsSL https://flox.dev/install | bash    # one-time
 flox activate
-
-# Verify dependencies
 make check-deps
 ```
 
-**Option 2: Manual Installation**
+<details>
+<summary><strong>Manual installation</strong></summary>
 
-If you prefer to manage dependencies manually:
-
-| Dependency | Purpose | Installation |
-|------------|---------|--------------|
+| Dependency | Purpose | Install |
+|------------|---------|---------|
 | [Go 1.24+](https://go.dev/dl/) | Build the CLI | `brew install go` |
 | [golangci-lint](https://golangci-lint.run/) | Linting | `brew install golangci-lint` |
 | [lefthook](https://github.com/evilmartians/lefthook) | Git hooks | `brew install lefthook` |
-| [Docker](https://www.docker.com/) | Required for local CI | [Docker Desktop](https://www.docker.com/products/docker-desktop/) |
+| [Docker](https://www.docker.com/) | Local CI | [Docker Desktop](https://www.docker.com/products/docker-desktop/) |
 | [act](https://github.com/nektos/act) | Run GitHub Actions locally | `brew install act` |
 | [gh](https://cli.github.com/) | GitHub CLI | `brew install gh` |
 
-### Development Setup
+</details>
+
+### Development setup
 
 ```bash
-# Clone the repository
 git clone https://github.com/nimble-giant/ailloy
 cd ailloy
-
-# Activate Flox environment (or install deps manually)
-flox activate
-
-# Install git hooks (runs checks automatically on commit/push)
-make hooks
-
-# Build the project
+flox activate          # or install deps manually
+make hooks             # install git hooks
 make build
-
-# Run tests
 make test
-
-# Run linter
 make lint
-
-# Run CI locally (requires Docker)
-make ci
+make ci                # full CI run locally (requires Docker)
 ```
 
-### To Contribute
+### Submitting changes
 
 1. Fork the repository
 2. Create a feature branch
 3. Add blanks or improve CLI functionality
-4. Ensure tests pass: `make test`
-5. Ensure linting passes: `make lint`
-6. Submit a pull request
+4. Ensure `make test` and `make lint` pass
+5. Submit a pull request
 
 ## Contributors
 
 <a href="https://github.com/nimble-giant/ailloy/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=nimble-giant/ailloy" />
+  <img src="https://contrib.rocks/image?repo=nimble-giant/ailloy" alt="Contributors" />
 </a>
 
 ## License
 
-Apache License 2.0 - see [LICENSE.md](LICENSE.md) for details.
+Apache License 2.0 — see [LICENSE.md](LICENSE.md).

--- a/internal/commands/ailloy.lock
+++ b/internal/commands/ailloy.lock
@@ -4,4 +4,4 @@ molds:
   source: github.com/nimble-giant/nimble-mold
   version: v0.1.10
   commit: 2347a626798553252668a15dc98dd020ab9a9c0c
-  timestamp: 2026-05-01T21:48:50.232097Z
+  timestamp: 2026-05-02T00:40:36.838055Z


### PR DESCRIPTION
## Description

Rewrites the root README in a Cilium/Argo-style format: marketing-forward hero with logo, badges, and quick-nav links; a tightened Why/What/How structure for evaluators; a collapsible command reference so the doc stays scannable; and the existing mascot images redistributed throughout the doc (hero, How It Works, Quick Start) instead of clustering at the top. Also dedupes the "Working with Blanks" block, deduplicates flux configuration between Quick Start and Configuration, and trims the command reference from ~100 lines to ~40 under `<details>` sections.

## Related Issue

Follow-up tracked in #143 (brand-consistent mascot regeneration against a locked style guide).

## Testing

Rendered the README locally and verified all section anchors, image paths, and `<details>` toggles work as expected.

## UAT

Visit the PR's Files Changed tab and view the README in rendered mode — confirm the hero, How It Works float, and Quick Start float render correctly, and that the collapsible command sections expand cleanly.

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [ ] I have added tests (if applicable)
- [x] I have updated documentation (if applicable)
- [x] My commits have DCO sign-off (`git commit -s`)