### PR TITLE
fix: clean up empty directories left by skipped renders

### DIFF
--- a/internal/commands/cast.go
+++ b/internal/commands/cast.go
@@ -227,6 +227,9 @@ func castProject(reader *blanks.MoldReader) error {
 		return fmt.Errorf("failed to copy files: %w", err)
 	}
 
+	// Drop directories that ended up empty after skipped renders (#145).
+	dirs = cleanupEmptyDirs(dirs, destPrefix)
+
 	// Record where blanks were installed (non-fatal if this fails).
 	if destPrefix == "" {
 		if err := writeInstallState(dirs); err != nil {
@@ -306,6 +309,52 @@ func castProject(reader *blanks.MoldReader) error {
 	}
 
 	return nil
+}
+
+// cleanupEmptyDirs removes any directories from dirs (and their ancestors up
+// to destPrefix or the working-directory root) that ended up empty after the
+// render pass. Multi-destination output mappings can leave behind empty
+// directories when target guards skip every file at one destination (#145).
+// Returns the subset of input dirs that still exist after cleanup.
+func cleanupEmptyDirs(dirs []string, destPrefix string) []string {
+	stop := destPrefix
+	if stop == "" {
+		stop = "."
+	}
+
+	candidates := make(map[string]bool)
+	for _, d := range dirs {
+		for cur := d; cur != stop && cur != "." && cur != string(filepath.Separator) && cur != ""; cur = filepath.Dir(cur) {
+			candidates[cur] = true
+		}
+	}
+
+	ordered := make([]string, 0, len(candidates))
+	for d := range candidates {
+		ordered = append(ordered, d)
+	}
+	// Deepest paths first so children are removed before their parents.
+	sort.Slice(ordered, func(i, j int) bool {
+		return len(ordered[i]) > len(ordered[j])
+	})
+
+	for _, d := range ordered {
+		entries, err := os.ReadDir(d)
+		if err != nil {
+			continue
+		}
+		if len(entries) == 0 {
+			_ = os.Remove(d)
+		}
+	}
+
+	remaining := make([]string, 0, len(dirs))
+	for _, d := range dirs {
+		if info, err := os.Stat(d); err == nil && info.IsDir() {
+			remaining = append(remaining, d)
+		}
+	}
+	return remaining
 }
 
 // installState represents the .ailloy/state.yaml file that records where blanks were installed.

--- a/internal/commands/cast_integration_test.go
+++ b/internal/commands/cast_integration_test.go
@@ -250,6 +250,120 @@ func TestCopyResolvedFiles_SkipsEmptyRenderedFiles(t *testing.T) {
 	}
 }
 
+func TestCleanupEmptyDirs_RemovesEmptyAndAncestors(t *testing.T) {
+	tmp := t.TempDir()
+
+	emptyLeaf := filepath.Join(tmp, ".claude", "agents")
+	keepLeaf := filepath.Join(tmp, ".opencode", "agents")
+	if err := os.MkdirAll(emptyLeaf, 0750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.MkdirAll(keepLeaf, 0750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(keepLeaf, "agent.md"), []byte("hi"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	dirs := []string{emptyLeaf, keepLeaf}
+	remaining := cleanupEmptyDirs(dirs, tmp)
+
+	if _, err := os.Stat(emptyLeaf); !os.IsNotExist(err) {
+		t.Errorf("expected empty leaf %s to be removed, got err=%v", emptyLeaf, err)
+	}
+	if _, err := os.Stat(filepath.Join(tmp, ".claude")); !os.IsNotExist(err) {
+		t.Errorf("expected empty ancestor .claude to be removed")
+	}
+	if _, err := os.Stat(keepLeaf); err != nil {
+		t.Errorf("expected non-empty leaf %s to remain: %v", keepLeaf, err)
+	}
+	if _, err := os.Stat(tmp); err != nil {
+		t.Errorf("expected destPrefix %s to remain: %v", tmp, err)
+	}
+
+	if len(remaining) != 1 || remaining[0] != keepLeaf {
+		t.Errorf("expected remaining=[%s], got %v", keepLeaf, remaining)
+	}
+}
+
+func TestCleanupEmptyDirs_PreservesNonEmptyAncestors(t *testing.T) {
+	tmp := t.TempDir()
+
+	leaf := filepath.Join(tmp, ".claude", "agents")
+	if err := os.MkdirAll(leaf, 0750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Pre-existing sibling content under .claude/ that the cast did not produce.
+	sibling := filepath.Join(tmp, ".claude", "settings.json")
+	if err := os.WriteFile(sibling, []byte("{}"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	cleanupEmptyDirs([]string{leaf}, tmp)
+
+	if _, err := os.Stat(leaf); !os.IsNotExist(err) {
+		t.Errorf("expected empty leaf to be removed")
+	}
+	if _, err := os.Stat(filepath.Join(tmp, ".claude")); err != nil {
+		t.Errorf("expected non-empty ancestor .claude to remain: %v", err)
+	}
+}
+
+func TestCopyResolvedFiles_RemovesEmptyMultiDestDirs(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	moldFS := fstest.MapFS{
+		"agents/foo.md": &fstest.MapFile{
+			Data: []byte("{{- if eq .target \"opencode\" -}}# foo{{- end -}}"),
+		},
+	}
+	reader := blanks.NewMoldReader(moldFS)
+
+	resolved := []mold.ResolvedFile{
+		{
+			SrcPath:  "agents/foo.md",
+			DestPath: ".claude/agents/foo.md",
+			Process:  true,
+			Set:      map[string]any{"target": "claude"},
+		},
+		{
+			SrcPath:  "agents/foo.md",
+			DestPath: ".opencode/agents/foo.md",
+			Process:  true,
+			Set:      map[string]any{"target": "opencode"},
+		},
+	}
+
+	dirs := []string{".claude/agents", ".opencode/agents"}
+	for _, d := range dirs {
+		if err := os.MkdirAll(d, 0750); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+
+	if err := copyResolvedFiles(reader, nil, map[string]any{}, resolved); err != nil {
+		t.Fatalf("copyResolvedFiles failed: %v", err)
+	}
+
+	remaining := cleanupEmptyDirs(dirs, "")
+
+	if _, err := os.Stat(".claude"); !os.IsNotExist(err) {
+		t.Errorf("expected .claude to be removed (all renders empty)")
+	}
+	if _, err := os.Stat(".opencode/agents/foo.md"); err != nil {
+		t.Errorf("expected .opencode/agents/foo.md to be written: %v", err)
+	}
+
+	if len(remaining) != 1 || remaining[0] != ".opencode/agents" {
+		t.Errorf("expected remaining=[.opencode/agents], got %v", remaining)
+	}
+}
+
 func TestIntegration_CastProject_DirectoryCreation(t *testing.T) {
 	tmpDir := t.TempDir()
 	origDir, _ := os.Getwd()


### PR DESCRIPTION
## Description

When a multi-destination output mapping (e.g. `output.agents` with `dest: .claude/agents` + `dest: .opencode/agents`) had every file at one destination skipped via target guards, ailloy left an empty directory behind. After the file-writing loop, `cast` now walks each rendered directory and its ancestors and removes any that ended up empty (stopping at the project root or `--global` `destPrefix`). Pre-existing sibling content under a shared ancestor is preserved because `os.Remove` only removes empty directories.

## Related Issue

Fixes #145

## Testing

`go build ./...`, `go vet ./...`, `golangci-lint run`, and `go test ./... -race -count=1` all pass. Three new tests cover the behavior: empty leaves and their newly-empty ancestors are removed; ancestors with sibling content are preserved; and an end-to-end multi-dest render scenario reproduces the issue and verifies the empty destination disappears while the populated one survives.

## UAT

In a mold with a multi-destination output mapping where target guards skip every file at one destination (see the reproduction in #145), run `ailloy cast` — only the destination(s) with actual rendered content should remain on disk.

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [ ] I have updated documentation (if applicable)
- [x] My commits have DCO sign-off (`git commit -s`)