### PR TITLE
feat: add Homebrew installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,15 @@ The Ailloy pipeline is a small set of composable steps. Author once, configure p
 ### 1. Install
 
 <details>
+<summary><strong>Homebrew (macOS, Linux)</strong></summary>
+
+```bash
+brew install nimble-giant/tap/ailloy
+```
+
+</details>
+
+<details>
 <summary><strong>Quick install (recommended)</strong></summary>
 
 ```bash

--- a/homebrew-tap/.github/workflows/update-formulas.yml
+++ b/homebrew-tap/.github/workflows/update-formulas.yml
@@ -1,0 +1,31 @@
+name: Update formulas
+
+on:
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  ailloy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update ailloy formula
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./scripts/update-ailloy.sh
+
+      - name: Commit if changed
+        run: |
+          if [[ -n "$(git status --porcelain Formula/ailloy.rb)" ]]; then
+            version=$(grep -E '^\s*version "' Formula/ailloy.rb | head -1 | sed -E 's/.*version "([^"]+)".*/\1/')
+            git config user.name  "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add Formula/ailloy.rb
+            git commit -m "ailloy ${version}"
+            git push
+          fi

--- a/homebrew-tap/Formula/ailloy.rb
+++ b/homebrew-tap/Formula/ailloy.rb
@@ -1,0 +1,38 @@
+class Ailloy < Formula
+  desc "Package manager for AI instructions"
+  homepage "https://github.com/nimble-giant/ailloy"
+  version "0.6.18"
+  license "Apache-2.0"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/nimble-giant/ailloy/releases/download/v#{version}/ailloy-darwin-arm64"
+      sha256 "d410762b53f1111790328fb136c95dd77b73e37a795ea00b1754939a872427eb"
+    end
+    on_intel do
+      url "https://github.com/nimble-giant/ailloy/releases/download/v#{version}/ailloy-darwin-amd64"
+      sha256 "e99c75c95f88d37730d509ac48395d1420440cdf9a470a10167c71e92f7746d6"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/nimble-giant/ailloy/releases/download/v#{version}/ailloy-linux-arm64"
+      sha256 "8857e704891c1f54531fdb5561f099001a01e1713c1884467fead35a132513e6"
+    end
+    on_intel do
+      url "https://github.com/nimble-giant/ailloy/releases/download/v#{version}/ailloy-linux-amd64"
+      sha256 "639cc758beed3c6eb0164f495a3c0033d728f29fdeb555daa3ea0e2caddd1c5d"
+    end
+  end
+
+  def install
+    suffix = OS.mac? ? "darwin" : "linux"
+    arch = Hardware::CPU.arm? ? "arm64" : "amd64"
+    bin.install "ailloy-#{suffix}-#{arch}" => "ailloy"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/ailloy --version")
+  end
+end

--- a/homebrew-tap/README.md
+++ b/homebrew-tap/README.md
@@ -1,0 +1,36 @@
+# homebrew-tap
+
+Homebrew tap for [nimble-giant](https://github.com/nimble-giant) projects.
+
+## Usage
+
+```sh
+brew install nimble-giant/tap/ailloy
+```
+
+Or, equivalently:
+
+```sh
+brew tap nimble-giant/tap
+brew install ailloy
+```
+
+## Formulas
+
+| Formula | Description |
+| --- | --- |
+| [ailloy](Formula/ailloy.rb) | Package manager for AI instructions |
+
+## Maintenance
+
+Formulas are updated automatically by `.github/workflows/update-formulas.yml`, which runs hourly and on manual dispatch. The workflow polls each upstream project's latest GitHub release, recomputes SHA256s from the release's `checksums.txt`, and commits the updated formula using the workflow's built-in `GITHUB_TOKEN`.
+
+To force an immediate refresh:
+
+```sh
+gh workflow run "Update formulas" --repo nimble-giant/homebrew-tap
+```
+
+## Bootstrapping (this repo)
+
+This tap was bootstrapped from `homebrew-tap/` in [nimble-giant/ailloy](https://github.com/nimble-giant/ailloy). To re-bootstrap or seed a new tap, copy the contents of that directory into the root of an empty `homebrew-tap` repo and push.

--- a/homebrew-tap/scripts/update-ailloy.sh
+++ b/homebrew-tap/scripts/update-ailloy.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="nimble-giant/ailloy"
+FORMULA="Formula/ailloy.rb"
+
+cd "$(dirname "$0")/.."
+
+tag=$(gh release view --repo "$REPO" --json tagName --jq .tagName)
+version="${tag#v}"
+
+current=""
+if [[ -f "$FORMULA" ]]; then
+  current=$(grep -E '^\s*version "' "$FORMULA" | head -1 | sed -E 's/.*version "([^"]+)".*/\1/')
+fi
+
+if [[ "$current" == "$version" ]]; then
+  echo "ailloy formula already at $version"
+  exit 0
+fi
+
+echo "Updating ailloy formula: ${current:-none} -> $version"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+gh release download "$tag" --repo "$REPO" --pattern checksums.txt --dir "$tmp"
+
+sha_for() {
+  local name="$1"
+  local sha
+  sha=$(awk -v n="$name" '$2 == n { print $1 }' "$tmp/checksums.txt")
+  if [[ -z "$sha" ]]; then
+    echo "error: no sha256 for $name in checksums.txt" >&2
+    exit 1
+  fi
+  printf '%s' "$sha"
+}
+
+darwin_arm64=$(sha_for "ailloy-darwin-arm64")
+darwin_amd64=$(sha_for "ailloy-darwin-amd64")
+linux_arm64=$(sha_for "ailloy-linux-arm64")
+linux_amd64=$(sha_for "ailloy-linux-amd64")
+
+mkdir -p Formula
+cat > "$FORMULA" <<EOF
+class Ailloy < Formula
+  desc "Package manager for AI instructions"
+  homepage "https://github.com/nimble-giant/ailloy"
+  version "$version"
+  license "Apache-2.0"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/nimble-giant/ailloy/releases/download/v#{version}/ailloy-darwin-arm64"
+      sha256 "$darwin_arm64"
+    end
+    on_intel do
+      url "https://github.com/nimble-giant/ailloy/releases/download/v#{version}/ailloy-darwin-amd64"
+      sha256 "$darwin_amd64"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/nimble-giant/ailloy/releases/download/v#{version}/ailloy-linux-arm64"
+      sha256 "$linux_arm64"
+    end
+    on_intel do
+      url "https://github.com/nimble-giant/ailloy/releases/download/v#{version}/ailloy-linux-amd64"
+      sha256 "$linux_amd64"
+    end
+  end
+
+  def install
+    suffix = OS.mac? ? "darwin" : "linux"
+    arch = Hardware::CPU.arm? ? "arm64" : "amd64"
+    bin.install "ailloy-#{suffix}-#{arch}" => "ailloy"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/ailloy --version")
+  end
+end
+EOF
+
+echo "Wrote $FORMULA at version $version"


### PR DESCRIPTION
## Description

Adds a Homebrew install path: `brew install nimble-giant/tap/ailloy`. Bootstraps a `homebrew-tap/` directory containing the initial multi-platform formula (macOS + Linux, arm64 + amd64, pinned to v0.6.18 with SHAs from `checksums.txt`), an updater script, and a scheduled GitHub Actions workflow for the tap repo. The tap repo (https://github.com/nimble-giant/homebrew-tap) self-updates hourly via its own `GITHUB_TOKEN`, so no PAT or App token is needed in this repo.

## Related Issue

N/A

## Testing

- `ruby -c` syntax-clean on the formula
- Hand-written formula is byte-identical to script-generated output (no spurious diff on first CI run)
- Updater script no-ops when version already current
- First scheduled-workflow dispatch ran green on the tap repo

## UAT

```sh
brew install nimble-giant/tap/ailloy
ailloy --version   # 0.6.18
```

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [x] I have updated documentation (if applicable)
- [x] My commits have DCO sign-off (`git commit -s`)