### PR TITLE
feat: add cast --force to bypass ailloy.lock and upgrade to latest

### DIFF
--- a/internal/commands/ailloy.lock
+++ b/internal/commands/ailloy.lock
@@ -4,4 +4,4 @@ molds:
   source: github.com/nimble-giant/nimble-mold
   version: v0.1.10
   commit: 2347a626798553252668a15dc98dd020ab9a9c0c
-  timestamp: 2026-05-02T00:40:36.838055Z
+  timestamp: 2026-05-02T03:53:51.012636Z

--- a/internal/commands/cast.go
+++ b/internal/commands/cast.go
@@ -37,6 +37,7 @@ Use -g/--global to install into the user's home directory (~/) instead.`,
 var (
 	withWorkflows bool
 	castGlobal    bool
+	castForce     bool
 	castSetFlags  []string
 	castValFiles  []string
 )
@@ -46,6 +47,7 @@ func init() {
 
 	castCmd.Flags().BoolVarP(&castGlobal, "global", "g", false, "install into user home directory (~/) instead of current project")
 	castCmd.Flags().BoolVar(&withWorkflows, "with-workflows", false, "include GitHub Actions workflow blanks")
+	castCmd.Flags().BoolVar(&castForce, "force", false, "ignore ailloy.lock and resolve to the latest available version")
 	castCmd.Flags().StringArrayVar(&castSetFlags, "set", nil, "override flux variable (format: key=value, can be repeated)")
 	castCmd.Flags().StringArrayVarP(&castValFiles, "values", "f", nil, "flux value files (can be repeated, later files override earlier)")
 }
@@ -65,6 +67,9 @@ func resolveMoldReader(args []string) (*blanks.MoldReader, error) {
 			var resolveOpts []foundry.ResolveOption
 			if castGlobal {
 				resolveOpts = append(resolveOpts, foundry.WithoutLock())
+			}
+			if castForce {
+				resolveOpts = append(resolveOpts, foundry.WithForceLatest())
 			}
 			fsys, root, err := foundry.ResolveWithRoot(args[0], resolveOpts...)
 			if err != nil {

--- a/pkg/foundry/foundry.go
+++ b/pkg/foundry/foundry.go
@@ -11,7 +11,8 @@ import (
 type ResolveOption func(*resolveConfig)
 
 type resolveConfig struct {
-	skipLock bool
+	skipLock    bool
+	forceLatest bool
 }
 
 // WithoutLock disables reading and writing the ailloy.lock file during resolution.
@@ -19,6 +20,16 @@ type resolveConfig struct {
 func WithoutLock() ResolveOption {
 	return func(c *resolveConfig) {
 		c.skipLock = true
+	}
+}
+
+// WithForceLatest bypasses the locked-version short-circuit so resolution
+// always consults the remote and picks the latest matching version. The
+// resolved version is still written back to the lock file (unlike WithoutLock),
+// so subsequent casts pick up the upgrade.
+func WithForceLatest() ResolveOption {
+	return func(c *resolveConfig) {
+		c.forceLatest = true
 	}
 }
 
@@ -52,9 +63,10 @@ func ResolveWith(ref *Reference, git GitRunner, opts ...ResolveOption) (fs.FS, s
 		opt(&cfg)
 	}
 
-	// Read existing lock file.
+	// Read existing lock file. Skip the locked-version short-circuit when
+	// --force was passed so the remote is always consulted.
 	var resolved *ResolvedVersion
-	if !cfg.skipLock {
+	if !cfg.skipLock && !cfg.forceLatest {
 		lock, err := ReadLockFile(LockFileName)
 		if err != nil {
 			log.Printf("warning: reading lock file: %v", err)

--- a/pkg/foundry/foundry_test.go
+++ b/pkg/foundry/foundry_test.go
@@ -67,6 +67,17 @@ func TestLockedSatisfies(t *testing.T) {
 	}
 }
 
+func TestWithForceLatest_SetsForceLatestFlag(t *testing.T) {
+	var cfg resolveConfig
+	WithForceLatest()(&cfg)
+	if !cfg.forceLatest {
+		t.Fatal("WithForceLatest should set forceLatest to true")
+	}
+	if cfg.skipLock {
+		t.Error("WithForceLatest should not affect skipLock — lock writes must still happen so the upgrade is persisted")
+	}
+}
+
 func TestWithoutLock_SkipsLockFileIO(t *testing.T) {
 	// Set up: chdir to a temp dir so any lock file write would land here.
 	dir := t.TempDir()


### PR DESCRIPTION
## Description

Adds a `--force` flag to `ailloy cast` that bypasses the locked-version short-circuit and resolves to the latest available version from the SCM source. The new version is written back to `ailloy.lock` so subsequent casts pick up the upgrade — collapsing the previous two-step `ailloy recast` + `ailloy cast` upgrade into a single command. Implemented as a new `foundry.WithForceLatest()` `ResolveOption` so it composes cleanly with the existing `--global` (`WithoutLock()`) plumbing.

## Related Issue

N/A

## Testing

- New unit test `TestWithForceLatest_SetsForceLatestFlag` in `pkg/foundry/foundry_test.go`.
- `go build ./...`, `go test ./...`, `go vet ./...`, and `gofmt -l .` all clean (also enforced by lefthook pre-push, which passed).
- `ailloy cast --help` shows the new flag with the expected description.

## UAT

In a project with an existing `ailloy.lock` pinning an older mold version:

```
ailloy cast github.com/nimble-giant/nimble-mold          # uses locked version (unchanged behavior)
ailloy cast github.com/nimble-giant/nimble-mold --force  # upgrades to latest tag and rewrites ailloy.lock
```

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [ ] I have updated documentation (if applicable)
- [x] My commits have DCO sign-off (`git commit -s`)