### PR TITLE
feat: default to https when adding a foundry without a protocol

### DIFF
--- a/docs/foundry.md
+++ b/docs/foundry.md
@@ -160,6 +160,10 @@ Register, list, update, and remove foundry indexes:
 
 ```bash
 # Register a foundry index (fetches and validates the index)
+# Bare references default to https://, mirroring `ailloy cast`.
+ailloy foundry add github.com/nimble-giant/ailloy-foundry-index
+
+# Explicit schemes (https://, http://, git@) are still accepted as-is.
 ailloy foundry add https://github.com/nimble-giant/ailloy-foundry-index
 
 # List all registered foundry indexes and their status
@@ -320,13 +324,13 @@ molds:
 **As a git repository** (recommended for versioned indexes):
 
 1. Create a repository with a `foundry.yaml` at the root
-2. Users register it with: `ailloy foundry add https://github.com/my-org/my-foundry-index`
+2. Users register it with: `ailloy foundry add github.com/my-org/my-foundry-index` (bare references default to `https://`; the fully qualified URL works too)
 3. Updates are fetched with: `ailloy foundry update`
 
 **As a static YAML file** (for simple hosting):
 
 1. Host a `foundry.yaml` file at a stable URL
-2. Users register it with: `ailloy foundry add https://example.com/foundry.yaml`
+2. Users register it with: `ailloy foundry add https://example.com/foundry.yaml` (a bare `example.com/foundry.yaml` is also accepted and defaults to `https://`)
 3. URLs ending in `.yaml` or `.yml` are automatically detected as static files
 
 ### Submitting to the Official Index

--- a/internal/commands/ailloy.lock
+++ b/internal/commands/ailloy.lock
@@ -4,4 +4,4 @@ molds:
   source: github.com/nimble-giant/nimble-mold
   version: v0.1.10
   commit: 2347a626798553252668a15dc98dd020ab9a9c0c
-  timestamp: 2026-05-02T01:47:14.168227Z
+  timestamp: 2026-05-02T19:31:10.630001Z

--- a/internal/commands/foundry.go
+++ b/internal/commands/foundry.go
@@ -44,6 +44,10 @@ var foundryAddCmd = &cobra.Command{
 The URL can be a git repository containing a foundry.yaml at its root,
 or a raw URL to a YAML file (detected by .yaml/.yml extension).
 
+Bare references like "github.com/owner/repo" default to https://, the
+same way ailloy cast resolves shorthand sources. Explicit https://,
+http://, and git@ schemes are kept as-is.
+
 The index is fetched, validated, and cached locally. The registration
 is saved to ~/.ailloy/config.yaml.`,
 	Args: cobra.ExactArgs(1),

--- a/internal/commands/foundry.go
+++ b/internal/commands/foundry.go
@@ -169,7 +169,7 @@ func runFoundrySearch(_ *cobra.Command, args []string) error {
 }
 
 func runFoundryAdd(_ *cobra.Command, args []string) error {
-	url := args[0]
+	url := index.NormalizeFoundryURL(args[0])
 
 	cfg, err := index.LoadConfig()
 	if err != nil {

--- a/internal/commands/foundry_core.go
+++ b/internal/commands/foundry_core.go
@@ -25,6 +25,8 @@ type AddFoundryResult struct {
 func AddFoundryCore(cfg *index.Config, url string) (AddFoundryResult, error) {
 	var res AddFoundryResult
 
+	url = index.NormalizeFoundryURL(url)
+
 	if existing := cfg.FindFoundry(url); existing != nil {
 		res.Entry = *existing
 		res.AlreadyExists = true

--- a/pkg/foundry/index/config.go
+++ b/pkg/foundry/index/config.go
@@ -206,6 +206,24 @@ func (c *Config) FindFoundry(nameOrURL string) *FoundryEntry {
 	return nil
 }
 
+// NormalizeFoundryURL ensures a foundry URL has an explicit protocol so that
+// `ailloy foundry add github.com/owner/repo` works the same as the fully
+// qualified `https://github.com/owner/repo`. SSH shorthand (git@host:path) and
+// URLs that already carry a scheme are returned unchanged.
+func NormalizeFoundryURL(url string) string {
+	trimmed := strings.TrimSpace(url)
+	if trimmed == "" {
+		return trimmed
+	}
+	if strings.HasPrefix(trimmed, "git@") {
+		return trimmed
+	}
+	if strings.Contains(trimmed, "://") {
+		return trimmed
+	}
+	return "https://" + trimmed
+}
+
 // DetectType determines whether a URL is a git repo or a raw YAML file.
 func DetectType(url string) string {
 	lower := strings.ToLower(url)

--- a/pkg/foundry/index/config_test.go
+++ b/pkg/foundry/index/config_test.go
@@ -312,6 +312,30 @@ func TestHasOfficialFoundry(t *testing.T) {
 	}
 }
 
+func TestNormalizeFoundryURL(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"github.com/owner/repo", "https://github.com/owner/repo"},
+		{"  github.com/owner/repo  ", "https://github.com/owner/repo"},
+		{"https://github.com/owner/repo", "https://github.com/owner/repo"},
+		{"http://example.com/foundry.yaml", "http://example.com/foundry.yaml"},
+		{"ssh://git@github.com/owner/repo.git", "ssh://git@github.com/owner/repo.git"},
+		{"git@github.com:owner/repo.git", "git@github.com:owner/repo.git"},
+		{"example.com/index.yaml", "https://example.com/index.yaml"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := NormalizeFoundryURL(tt.in); got != tt.want {
+				t.Errorf("NormalizeFoundryURL(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDetectType(t *testing.T) {
 	tests := []struct {
 		url  string


### PR DESCRIPTION
## Description

`ailloy foundry add` now accepts shorthand sources like `github.com/owner/repo`, mirroring how `ailloy cast` resolves bare references. A new `index.NormalizeFoundryURL` helper prepends `https://` when no scheme is present, leaves explicit schemes and `git@` SSH shorthand untouched, and runs before the dedupe check so the same foundry can't be registered twice under both forms.

## Related Issue

n/a

## Testing

- `go test ./pkg/foundry/index/... ./internal/commands/...`
- `go vet ./...`
- New `TestNormalizeFoundryURL` covers bare hostnames, whitespace, http/https, ssh:// scheme, and `git@` shorthand.

## UAT

Run `ailloy foundry add github.com/<owner>/<repo>` (without a scheme) and confirm the foundry registers and the printed URL is `https://github.com/<owner>/<repo>`. Re-running with the fully qualified URL should report "Foundry already registered" rather than creating a duplicate. The TUI's add-foundry flow should behave the same way since both paths share `AddFoundryCore`.

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [ ] I have updated documentation (if applicable)
- [x] My commits have DCO sign-off (`git commit -s`)