### PR TITLE
refactor: drop unused version field from foundry index entries

### DIFF
--- a/docs/foundry.md
+++ b/docs/foundry.md
@@ -296,7 +296,6 @@ molds:
     source: github.com/my-org/mold
     description: "AI workflow blanks"
     tags: ["workflows", "claude"]
-    version: "v1.0.0"
 ```
 
 ### Fields
@@ -313,7 +312,6 @@ molds:
 | `molds[].source` | Yes | Mold source reference (`host/owner/repo`) |
 | `molds[].description` | No | Short description for search results |
 | `molds[].tags` | No | Searchable tags/categories |
-| `molds[].version` | No | Latest known version (informational only) |
 
 ### Hosting a Foundry Index
 

--- a/pkg/foundry/index/index.go
+++ b/pkg/foundry/index/index.go
@@ -29,7 +29,6 @@ type MoldEntry struct {
 	Source      string   `yaml:"source"`
 	Description string   `yaml:"description,omitempty"`
 	Tags        []string `yaml:"tags,omitempty"`
-	Version     string   `yaml:"version,omitempty"`
 }
 
 // ParseIndex parses raw YAML bytes into an Index.

--- a/pkg/foundry/index/index_test.go
+++ b/pkg/foundry/index/index_test.go
@@ -27,7 +27,6 @@ molds:
     source: github.com/test/my-mold
     description: "A test mold"
     tags: ["test", "example"]
-    version: v1.0.0
 `,
 			want: Index{
 				APIVersion:  "v1",
@@ -41,7 +40,6 @@ molds:
 						Source:      "github.com/test/my-mold",
 						Description: "A test mold",
 						Tags:        []string{"test", "example"},
-						Version:     "v1.0.0",
 					},
 				},
 			},


### PR DESCRIPTION
## Description

The `version` field on `MoldEntry` in the foundry index was documented as informational only and never read by the resolver or cast path — version pinning already happens via `@<ref>` arguments and the lockfile. The field looked authoritative in `foundry.yaml` but did nothing, so it was a footgun for foundry maintainers. Dropped the field from the struct, schema docs, and test fixture so the index schema only exposes things that actually do something.

## Related Issue

n/a

## Testing

`go build ./...` and `go test ./pkg/foundry/... ./internal/commands/...` both pass locally; pre-push hook (lint + build + race tests) also green.

## UAT

A `foundry.yaml` that still has `version:` lines on entries will continue to parse (unknown YAML keys are ignored); installs from such an index resolve the same way they did before. Confirm `ailloy foundry search` / `ailloy cast <foundry-mold>` behave identically against github.com/kriscoleman/replicated-foundry.

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [x] I have updated documentation (if applicable)
- [ ] My commits have DCO sign-off (`git commit -s`)