### PR TITLE
feat: make ailloy.lock opt-in via ailloy quench

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,8 +43,8 @@ Key CLI commands for working with molds:
 - **temper** (`validate`): Validate a mold or ingot package; use `--assay` (alias: `--lint`) to also render and assay output
 - **anneal** (`configure`): Configure flux variables interactively
 - **smelt** (`package`): Package a mold for distribution
-- **recast**: Re-render and update previously cast blanks
-- **quench**: Lock flux variables to prevent re-rendering
+- **recast**: Re-resolve installed molds to newer versions; refreshes `.ailloy/installed.yaml` and (if present) `ailloy.lock`
+- **quench**: Opt in to `ailloy.lock` by pinning everything in `.ailloy/installed.yaml`; supports `--verify` (CI drift check) and `--global`
 
 ## Usage
 

--- a/docs/foundry.md
+++ b/docs/foundry.md
@@ -96,7 +96,7 @@ Both subpaths share the same version tag and bare clone cache.
 - Tag releases with semver: `git tag v1.0.0 && git push --tags`
 - Use caret constraints (`@^1.0.0`) for consumers who want compatible updates
 - Breaking changes (new required flux vars, renamed output paths) should bump the major version
-- The `ailloy.lock` file pins consumers to exact commits — they won't get new versions unless they delete the lock or change the constraint
+- Consumers can opt in to commit-SHA pinning by running `ailloy quench` to create an `ailloy.lock` — once locked, they won't get new versions until they `recast` or delete the lock
 
 ### Private Repositories
 
@@ -482,11 +482,25 @@ Resolved molds are cached at `~/.ailloy/cache/` to avoid re-cloning on every inv
 
 On subsequent runs, if a version directory already exists and contains a `mold.yaml` (or `ingot.yaml`), the cached snapshot is used without re-extracting. The bare clone is still fetched to pick up new tags.
 
-## Lock File
+## Installed Manifest
 
-When a remote mold is resolved, an `ailloy.lock` file is created (or updated) in the current directory. This pins the exact version and commit SHA so that subsequent runs use the same resolution.
+Every `ailloy cast` and `ailloy ingot add` writes provenance for the installed mold into `.ailloy/installed.yaml`. This file is the source of truth for `recast` and `quench`, and should be committed to git.
 
-### Format
+```yaml
+apiVersion: v1
+molds:
+  - name: nimble-mold
+    source: github.com/nimble-giant/nimble-mold
+    version: v0.1.10
+    commit: 2347a626798553252668a15dc98dd020ab9a9c0c
+    castAt: 2026-02-21T19:30:00Z
+```
+
+## Lock File (opt-in)
+
+`ailloy.lock` is **opt-in**: it is created only by `ailloy quench`. Once the file exists, `cast`, `ingot add`, and `recast` keep it updated automatically. New projects get no lock until they quench; existing projects with an `ailloy.lock` continue to work — the lock is honored and updated as before.
+
+The lock pins each mold to an exact commit SHA. Because git is content-addressable, any tampering on the upstream side is rejected by git itself when the SHA is fetched. Local edits to rendered blanks are expected and not flagged as drift.
 
 ```yaml
 apiVersion: v1
@@ -498,17 +512,20 @@ molds:
     timestamp: 2026-02-21T19:30:00Z
 ```
 
-### Lock Behavior
+### Typical opt-in flow
 
-- **Locked + Latest/Constraint**: uses the locked version (run `ailloy recast` to re-resolve)
-- **Locked + Exact**: uses the lock if versions match, otherwise re-resolves
-- **Branch/SHA pins**: always re-resolve (lock is updated but not consulted)
+```bash
+ailloy cast github.com/nimble-giant/nimble-mold     # writes .ailloy/installed.yaml
+ailloy quench                                         # creates ailloy.lock pinning everything
+ailloy quench --verify                                # CI: exit non-zero if pins drift
+ailloy recast                                         # update everything; refreshes both files
+```
 
 ### Lifecycle Commands
 
 #### Recast (alias: upgrade)
 
-Re-resolve locked dependencies to their latest available versions:
+Re-resolve installed dependencies to their latest available versions. Recast drives off `.ailloy/installed.yaml`; if `ailloy.lock` exists, it is refreshed too.
 
 ```bash
 # Update all dependencies
@@ -519,19 +536,32 @@ ailloy recast nimble-mold
 
 # Preview changes without applying
 ailloy recast --dry-run
+
+# Operate on ~/.ailloy/installed.yaml and ~/ailloy.lock
+ailloy recast --global
 ```
 
-Recast fetches the latest semver tags from each dependency's remote, compares with the currently locked version, and updates `ailloy.lock` with the new resolution. A summary of changes is printed showing old and new versions.
+Recast fetches the latest semver tags from each dependency's remote, compares with the currently installed version, and updates the manifest (and lock, if present) with the new resolution. A summary of changes is printed showing old and new versions.
 
 #### Quench (alias: lock)
 
-Confirm that all dependencies are pinned to exact versions:
+Create or refresh `ailloy.lock` from the installed manifest, pinning every entry to an exact commit SHA.
 
 ```bash
+# Create or refresh ailloy.lock from .ailloy/installed.yaml
 ailloy quench
+
+# Update a single mold's pin (requires existing lock)
+ailloy quench nimble-mold
+
+# CI-friendly read-only check; exit non-zero on drift
+ailloy quench --verify
+
+# Operate on ~/.ailloy/installed.yaml and ~/ailloy.lock
+ailloy quench --global
 ```
 
-Quench verifies that every entry in `ailloy.lock` has an exact version and commit SHA pinned. Subsequent `cast` operations will use only these locked versions until the lock is updated via `recast`.
+Quench verifies manifest↔lock consistency before writing. Once the lock exists, subsequent `cast` and `ingot add` operations append to it automatically.
 
 ## Authentication
 

--- a/docs/helm-users.md
+++ b/docs/helm-users.md
@@ -16,7 +16,8 @@ This guide maps what you already know to Ailloy terminology, shows every command
 | `--set` / `-f` | `--set` / `-f` | Same flags, same layering semantics |
 | Repository | Foundry | Where packages are discovered and resolved from |
 | Subchart / Dependency | Ingot | Reusable template partials included via `{{ingot "name"}}` |
-| `Chart.lock` | `ailloy.lock` | Pins dependencies to exact versions and commits |
+| `Chart.lock` | `ailloy.lock` (opt-in, via `ailloy quench`) | Pins dependencies to exact versions and commits |
+| — | `.ailloy/installed.yaml` | Always-on manifest of cast molds — provenance for `recast` / `quench` |
 | — | Output mapping | Maps source directories to destination paths (no Helm equivalent) |
 | — | Anneal | Interactive configuration wizard (no Helm equivalent) |
 
@@ -237,10 +238,21 @@ helm package ./my-chart             ailloy smelt ./my-mold     ailloy package ./
 
 ### Dependencies and lock files
 
-Both tools pin dependency versions in a lock file. Ailloy's `ailloy.lock` captures the exact commit SHA alongside the version:
+Both tools pin dependency versions in a lock file, but Ailloy's `ailloy.lock` is **opt-in** rather than auto-generated. Cast always writes a provenance manifest at `.ailloy/installed.yaml` (commit it to git like `package.json`), but the lock file is created only when you run `ailloy quench`. Once it exists, `cast`, `ingot add`, and `recast` keep it in sync automatically. `ailloy quench --verify` is the CI-friendly drift check.
 
 ```yaml
-# ailloy.lock
+# .ailloy/installed.yaml — always written by cast/ingot add
+apiVersion: v1
+molds:
+  - name: nimble-mold
+    source: github.com/nimble-giant/nimble-mold
+    version: v0.1.10
+    commit: 2347a626798553252668a15dc98dd020ab9a9c0c
+    castAt: 2026-02-21T19:30:00Z
+```
+
+```yaml
+# ailloy.lock — created only by `ailloy quench`
 apiVersion: v1
 molds:
   - name: nimble-mold

--- a/internal/commands/ailloy.lock
+++ b/internal/commands/ailloy.lock
@@ -1,7 +1,0 @@
-apiVersion: v1
-molds:
-- name: nimble-mold
-  source: github.com/nimble-giant/nimble-mold
-  version: v0.1.10
-  commit: 2347a626798553252668a15dc98dd020ab9a9c0c
-  timestamp: 2026-05-02T19:31:10.630001Z

--- a/internal/commands/cast.go
+++ b/internal/commands/cast.go
@@ -93,25 +93,27 @@ func validatePluginFlags() error {
 	return nil
 }
 
+// resolvedRemote holds metadata about the most recently resolved remote mold.
+// Used to populate the installed manifest after a successful cast.
+var resolvedRemote *foundry.ResolveResult
+
 // resolveMoldReader creates a MoldReader from args or the embedded mold.
 // The returned source is the foundry cache key (e.g. "github.com/owner/repo")
 // for remote references, or "" for local dirs and embedded molds.
 func resolveMoldReader(args []string) (*blanks.MoldReader, string, error) {
+	resolvedRemote = nil
 	if len(args) >= 1 {
 		if foundry.IsRemoteReference(args[0]) {
 			var resolveOpts []foundry.ResolveOption
 			if castGlobal {
 				resolveOpts = append(resolveOpts, foundry.WithLockPath(globalLockPath()))
 			}
-			fsys, root, err := foundry.ResolveWithRoot(args[0], resolveOpts...)
+			fsys, result, err := foundry.ResolveWithMetadata(args[0], resolveOpts...)
 			if err != nil {
 				return nil, "", fmt.Errorf("resolving remote mold: %w", err)
 			}
-			source := ""
-			if ref, perr := foundry.ParseReference(args[0]); perr == nil {
-				source = ref.CacheKey()
-			}
-			return blanks.NewMoldReaderFromFS(fsys, root), source, nil
+			resolvedRemote = result
+			return blanks.NewMoldReaderFromFS(fsys, result.Root), result.Ref.CacheKey(), nil
 		}
 		reader, err := blanks.NewMoldReaderFromPath(args[0])
 		return reader, "", err
@@ -271,6 +273,13 @@ func castProject(reader *blanks.MoldReader, source string) error {
 
 	// Drop directories that ended up empty after skipped renders (#145).
 	dirs = cleanupEmptyDirs(dirs, destPrefix)
+
+	// Record the cast in the installed manifest (provenance for `recast` / `quench`).
+	if resolvedRemote != nil {
+		if err := recordInstalled(resolvedRemote, castGlobal); err != nil {
+			log.Printf("warning: failed to update installed manifest: %v", err)
+		}
+	}
 
 	// Record where blanks were installed (non-fatal if this fails).
 	if destPrefix == "" {
@@ -572,4 +581,29 @@ func copyResolvedFiles(reader *blanks.MoldReader, manifest *mold.Mold, flux map[
 	}
 
 	return nil
+}
+
+// recordInstalled upserts the just-cast mold into the installed manifest.
+func recordInstalled(result *foundry.ResolveResult, global bool) error {
+	path := manifestPathFor(global)
+	if path == "" {
+		return nil // global path unresolvable — silently skip rather than write to cwd
+	}
+	manifest, err := foundry.ReadInstalledManifest(path)
+	if err != nil {
+		// Fall back to a fresh manifest on parse error so we don't lose the cast record.
+		manifest = nil
+	}
+	if manifest == nil {
+		manifest = &foundry.InstalledManifest{APIVersion: "v1"}
+	}
+	manifest.UpsertEntry(foundry.InstalledEntry{
+		Name:    result.Ref.Repo,
+		Source:  result.Ref.CacheKey(),
+		Subpath: result.Ref.Subpath,
+		Version: result.Resolved.Tag,
+		Commit:  result.Resolved.Commit,
+		CastAt:  time.Now().UTC(),
+	})
+	return foundry.WriteInstalledManifest(path, manifest)
 }

--- a/internal/commands/cast.go
+++ b/internal/commands/cast.go
@@ -101,7 +101,7 @@ func resolveMoldReader(args []string) (*blanks.MoldReader, string, error) {
 		if foundry.IsRemoteReference(args[0]) {
 			var resolveOpts []foundry.ResolveOption
 			if castGlobal {
-				resolveOpts = append(resolveOpts, foundry.WithoutLock())
+				resolveOpts = append(resolveOpts, foundry.WithLockPath(globalLockPath()))
 			}
 			fsys, root, err := foundry.ResolveWithRoot(args[0], resolveOpts...)
 			if err != nil {

--- a/internal/commands/cast.go
+++ b/internal/commands/cast.go
@@ -591,7 +591,7 @@ func recordInstalled(result *foundry.ResolveResult, global bool) error {
 	}
 	manifest, err := foundry.ReadInstalledManifest(path)
 	if err != nil {
-		// Fall back to a fresh manifest on parse error so we don't lose the cast record.
+		log.Printf("warning: corrupt installed manifest at %s, resetting: %v", path, err)
 		manifest = nil
 	}
 	if manifest == nil {

--- a/internal/commands/cast.go
+++ b/internal/commands/cast.go
@@ -286,15 +286,26 @@ func castProject(reader *blanks.MoldReader, source string) error {
 		if err := writeInstallState(dirs); err != nil {
 			log.Printf("warning: failed to write install state: %v", err)
 		}
+	}
 
-		// Backfill the lock entry's Files manifest so uninstall knows what to remove.
-		if source != "" {
+	// Backfill the manifest entry's Files list so uninstall knows what to remove.
+	// The manifest is always written (regardless of --global), so this works
+	// for both project and global installs.
+	if source != "" {
+		manifestPath := manifestPathFor(castGlobal)
+		if manifestPath != "" {
 			installed := make([]foundry.InstalledFile, 0, len(filesToCast))
 			for _, f := range filesToCast {
 				sum, _ := hashFile(f.DestPath)
-				installed = append(installed, foundry.InstalledFile{RelPath: f.DestPath, SHA256: sum})
+				rel := f.DestPath
+				if destPrefix != "" {
+					if r, rerr := filepath.Rel(destPrefix, f.DestPath); rerr == nil {
+						rel = r
+					}
+				}
+				installed = append(installed, foundry.InstalledFile{RelPath: rel, SHA256: sum})
 			}
-			if err := foundry.RecordInstalledFiles(foundry.LockFileName, source, installed); err != nil {
+			if err := foundry.RecordInstalledFiles(manifestPath, source, installed); err != nil {
 				log.Printf("warning: recording installed files: %v", err)
 			}
 		}

--- a/internal/commands/cast_core.go
+++ b/internal/commands/cast_core.go
@@ -172,7 +172,7 @@ func openMoldReaderForCore(ref string, global bool) (*blanks.MoldReader, string,
 	if foundry.IsRemoteReference(ref) {
 		var resolveOpts []foundry.ResolveOption
 		if global {
-			resolveOpts = append(resolveOpts, foundry.WithoutLock())
+			resolveOpts = append(resolveOpts, foundry.WithLockPath(globalLockPath()))
 		}
 		fsys, root, err := foundry.ResolveWithRoot(ref, resolveOpts...)
 		if err != nil {

--- a/internal/commands/cast_core.go
+++ b/internal/commands/cast_core.go
@@ -58,9 +58,13 @@ func CastMold(_ context.Context, ref string, opts CastOptions) (CastResult, erro
 	log.SetOutput(io.Discard)
 	defer log.SetOutput(prevLog)
 
-	reader, source, err := openMoldReaderForCore(ref, opts.Global)
+	reader, remoteResult, err := openMoldReaderForCore(ref, opts.Global)
 	if err != nil {
 		return res, err
+	}
+	source := ""
+	if remoteResult != nil {
+		source = remoteResult.Ref.CacheKey()
 	}
 	res.Source = source
 
@@ -150,14 +154,30 @@ func CastMold(_ context.Context, ref string, opts CastOptions) (CastResult, erro
 		return res, fmt.Errorf("copying files: %w", err)
 	}
 
-	if destPrefix == "" && source != "" {
-		installed := make([]foundry.InstalledFile, 0, len(filesToCast))
-		for _, f := range filesToCast {
-			sum, _ := hashFile(f.DestPath)
-			installed = append(installed, foundry.InstalledFile{RelPath: f.DestPath, SHA256: sum})
+	if remoteResult != nil {
+		manifestPath := manifestPathFor(opts.Global)
+		if manifestPath != "" {
+			// Upsert the manifest entry with provenance, then backfill Files
+			// + FileHashes. Mirrors what cast.go does via recordInstalled +
+			// RecordInstalledFiles.
+			if err := recordInstalled(remoteResult, opts.Global); err != nil {
+				log.Printf("warning: failed to update installed manifest: %v", err)
+			} else {
+				installed := make([]foundry.InstalledFile, 0, len(filesToCast))
+				for _, f := range filesToCast {
+					sum, _ := hashFile(f.DestPath)
+					rel := f.DestPath
+					if destPrefix != "" {
+						if r, rerr := filepath.Rel(destPrefix, f.DestPath); rerr == nil {
+							rel = r
+						}
+					}
+					installed = append(installed, foundry.InstalledFile{RelPath: rel, SHA256: sum})
+				}
+				res.FilesCast = installed
+				_ = foundry.RecordInstalledFiles(manifestPath, source, installed)
+			}
 		}
-		res.FilesCast = installed
-		_ = foundry.RecordInstalledFiles(foundry.LockFileName, source, installed)
 	}
 
 	return res, nil
@@ -165,27 +185,26 @@ func CastMold(_ context.Context, ref string, opts CastOptions) (CastResult, erro
 
 // openMoldReaderForCore is the CastMold-flavored counterpart to
 // resolveMoldReader; it accepts a single ref string instead of args.
-func openMoldReaderForCore(ref string, global bool) (*blanks.MoldReader, string, error) {
+// The returned *foundry.ResolveResult is populated for remote refs (so the
+// caller can record provenance in the installed manifest) and nil for local
+// refs.
+func openMoldReaderForCore(ref string, global bool) (*blanks.MoldReader, *foundry.ResolveResult, error) {
 	if ref == "" {
-		return nil, "", fmt.Errorf("ref required")
+		return nil, nil, fmt.Errorf("ref required")
 	}
 	if foundry.IsRemoteReference(ref) {
 		var resolveOpts []foundry.ResolveOption
 		if global {
 			resolveOpts = append(resolveOpts, foundry.WithLockPath(globalLockPath()))
 		}
-		fsys, root, err := foundry.ResolveWithRoot(ref, resolveOpts...)
+		fsys, result, err := foundry.ResolveWithMetadata(ref, resolveOpts...)
 		if err != nil {
-			return nil, "", fmt.Errorf("resolving remote mold: %w", err)
+			return nil, nil, fmt.Errorf("resolving remote mold: %w", err)
 		}
-		source := ""
-		if parsed, perr := foundry.ParseReference(ref); perr == nil {
-			source = parsed.CacheKey()
-		}
-		return blanks.NewMoldReaderFromFS(fsys, root), source, nil
+		return blanks.NewMoldReaderFromFS(fsys, result.Root), result, nil
 	}
 	reader, err := blanks.NewMoldReaderFromPath(ref)
-	return reader, "", err
+	return reader, nil, err
 }
 
 // layerFluxForCore mirrors loadCastFlux but is parameterized so CastMold

--- a/internal/commands/ingot.go
+++ b/internal/commands/ingot.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"io/fs"
+	"log"
 	"os"
 	"path/filepath"
 
@@ -110,7 +111,7 @@ func runIngotAdd(_ *cobra.Command, args []string) error {
 	fmt.Println(styles.WorkingBanner("Adding ingot..."))
 	fmt.Println()
 
-	fsys, err := foundry.Resolve(ref)
+	fsys, result, err := foundry.ResolveWithMetadata(ref)
 	if err != nil {
 		return fmt.Errorf("resolving ingot: %w", err)
 	}
@@ -157,6 +158,10 @@ func runIngotAdd(_ *cobra.Command, args []string) error {
 	fmt.Println()
 	fmt.Println(styles.SuccessStyle.Render("Ingot added: ") + styles.AccentStyle.Render(ingot.Name+" "+ingot.Version))
 	fmt.Println(styles.InfoStyle.Render("Installed to: ") + styles.CodeStyle.Render(destDir))
+
+	if err := recordInstalled(result, false); err != nil {
+		log.Printf("warning: failed to update installed manifest: %v", err)
+	}
 
 	return nil
 }

--- a/internal/commands/paths.go
+++ b/internal/commands/paths.go
@@ -18,20 +18,24 @@ func projectManifestPath() string {
 }
 
 // globalLockPath returns the lock path under the user's home directory.
-// Mirrors `cast --global`'s install location.
+// Mirrors `cast --global`'s install location. Returns "" if the home directory
+// cannot be resolved — callers treat that as "no lock," avoiding a silent fall
+// back to a relative path that could accidentally read or write the project's
+// lock during a global cast.
 func globalLockPath() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return foundry.LockFileName
+		return ""
 	}
 	return filepath.Join(home, foundry.LockFileName)
 }
 
 // globalManifestPath returns the installed-manifest path under the user's home.
+// Returns "" if the home directory cannot be resolved.
 func globalManifestPath() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return foundry.InstalledManifestPath
+		return ""
 	}
 	return filepath.Join(home, foundry.InstalledManifestPath)
 }

--- a/internal/commands/paths.go
+++ b/internal/commands/paths.go
@@ -1,0 +1,53 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/nimble-giant/ailloy/pkg/foundry"
+)
+
+// projectLockPath returns the lock path inside the current project.
+func projectLockPath() string {
+	return foundry.LockFileName
+}
+
+// projectManifestPath returns the installed-manifest path inside the current project.
+func projectManifestPath() string {
+	return foundry.InstalledManifestPath
+}
+
+// globalLockPath returns the lock path under the user's home directory.
+// Mirrors `cast --global`'s install location.
+func globalLockPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return foundry.LockFileName
+	}
+	return filepath.Join(home, foundry.LockFileName)
+}
+
+// globalManifestPath returns the installed-manifest path under the user's home.
+func globalManifestPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return foundry.InstalledManifestPath
+	}
+	return filepath.Join(home, foundry.InstalledManifestPath)
+}
+
+// lockPathFor returns the project or global lock path based on the global flag.
+func lockPathFor(global bool) string {
+	if global {
+		return globalLockPath()
+	}
+	return projectLockPath()
+}
+
+// manifestPathFor returns the project or global manifest path based on the global flag.
+func manifestPathFor(global bool) string {
+	if global {
+		return globalManifestPath()
+	}
+	return projectManifestPath()
+}

--- a/internal/commands/paths_test.go
+++ b/internal/commands/paths_test.go
@@ -42,6 +42,9 @@ func TestLockAndManifestPathsByGlobalFlag(t *testing.T) {
 	if got := manifestPathFor(false); got != filepath.Join(".ailloy", "installed.yaml") {
 		t.Errorf("manifestPathFor(false) = %q", got)
 	}
+	if _, err := os.UserHomeDir(); err != nil {
+		t.Skipf("no home dir, skipping global-flag assertions: %v", err)
+	}
 	if got := lockPathFor(true); !filepath.IsAbs(got) {
 		t.Errorf("lockPathFor(true) = %q, want absolute path", got)
 	}

--- a/internal/commands/paths_test.go
+++ b/internal/commands/paths_test.go
@@ -1,0 +1,51 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestProjectPaths(t *testing.T) {
+	if got := projectLockPath(); got != "ailloy.lock" {
+		t.Errorf("projectLockPath() = %q, want ailloy.lock", got)
+	}
+	if got := projectManifestPath(); got != filepath.Join(".ailloy", "installed.yaml") {
+		t.Errorf("projectManifestPath() = %q", got)
+	}
+}
+
+func TestGlobalPaths(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("no home dir: %v", err)
+	}
+	wantLock := filepath.Join(home, "ailloy.lock")
+	gotLock := globalLockPath()
+	if gotLock != wantLock {
+		t.Errorf("globalLockPath() = %q, want %q", gotLock, wantLock)
+	}
+	if !strings.HasPrefix(gotLock, home) {
+		t.Errorf("globalLockPath() = %q should be under home %q", gotLock, home)
+	}
+	wantManifest := filepath.Join(home, ".ailloy", "installed.yaml")
+	if got := globalManifestPath(); got != wantManifest {
+		t.Errorf("globalManifestPath() = %q, want %q", got, wantManifest)
+	}
+}
+
+func TestLockAndManifestPathsByGlobalFlag(t *testing.T) {
+	if got := lockPathFor(false); got != "ailloy.lock" {
+		t.Errorf("lockPathFor(false) = %q", got)
+	}
+	if got := manifestPathFor(false); got != filepath.Join(".ailloy", "installed.yaml") {
+		t.Errorf("manifestPathFor(false) = %q", got)
+	}
+	if got := lockPathFor(true); !filepath.IsAbs(got) {
+		t.Errorf("lockPathFor(true) = %q, want absolute path", got)
+	}
+	if got := manifestPathFor(true); !filepath.IsAbs(got) {
+		t.Errorf("manifestPathFor(true) = %q, want absolute path", got)
+	}
+}

--- a/internal/commands/quench.go
+++ b/internal/commands/quench.go
@@ -57,7 +57,13 @@ func runQuench(_ *cobra.Command, args []string) error {
 			styles.CodeStyle.Render("ailloy cast"))
 	}
 
-	// Filter to a single ref if provided.
+	// Read the existing lock up front so we can both verify against it and
+	// reject scoped quench when there's nothing to scope into.
+	existingLock, _ := foundry.ReadLockFile(lockPath)
+
+	// Filter to a single ref if provided. Scoped quench requires an existing
+	// lock — otherwise we'd silently drop every other manifest entry by writing
+	// a single-entry lock. Tell the user to run `ailloy quench` first.
 	entries := manifest.Molds
 	if len(args) == 1 {
 		ref, err := foundry.ParseReference(args[0])
@@ -70,6 +76,11 @@ func runQuench(_ *cobra.Command, args []string) error {
 				args[0],
 				styles.CodeStyle.Render("ailloy cast "+args[0]))
 		}
+		if existingLock == nil {
+			return fmt.Errorf("no %s present — run %s (without arguments) first to opt in",
+				styles.CodeStyle.Render(lockPath),
+				styles.CodeStyle.Render("ailloy quench"))
+		}
 		entries = []foundry.InstalledEntry{*match}
 	}
 
@@ -81,7 +92,6 @@ func runQuench(_ *cobra.Command, args []string) error {
 	fmt.Println()
 
 	// Verification phase: manifest <-> lock consistency.
-	existingLock, _ := foundry.ReadLockFile(lockPath)
 	failures := verifyManifestAgainstLock(entries, existingLock)
 	for _, msg := range failures {
 		fmt.Printf("  %s %s\n", styles.WarningStyle.Render("!"), msg)
@@ -119,14 +129,10 @@ func runQuench(_ *cobra.Command, args []string) error {
 			Subpath:   entry.Subpath,
 			Timestamp: time.Now().UTC(),
 		})
-		commitShort := resolved.Commit
-		if len(commitShort) > 7 {
-			commitShort = commitShort[:7]
-		}
 		fmt.Printf("  %s  %s @ %s\n",
 			styles.FoxBullet(entry.Name),
 			styles.CodeStyle.Render(resolved.Tag),
-			styles.CodeStyle.Render(commitShort),
+			styles.CodeStyle.Render(shortSHA(resolved.Commit)),
 		)
 	}
 
@@ -164,16 +170,15 @@ func verifyManifestAgainstLock(entries []foundry.InstalledEntry, lock *foundry.L
 			failures = append(failures, fmt.Sprintf("%s is in installed manifest but missing from lock", entry.Name))
 			continue
 		}
-		if locked.Commit != entry.Commit {
+		if locked.Version == "" || locked.Commit == "" {
+			failures = append(failures, fmt.Sprintf("%s lock entry is missing version or commit", entry.Name))
+		} else if locked.Commit != entry.Commit {
 			failures = append(failures,
 				fmt.Sprintf("%s commit drift: manifest=%s lock=%s",
 					entry.Name,
 					shortSHA(entry.Commit),
 					shortSHA(locked.Commit),
 				))
-		}
-		if locked.Version == "" || locked.Commit == "" {
-			failures = append(failures, fmt.Sprintf("%s lock entry is missing version or commit", entry.Name))
 		}
 	}
 	return failures

--- a/internal/commands/quench.go
+++ b/internal/commands/quench.go
@@ -29,21 +29,15 @@ without writing.`,
 var (
 	quenchVerify bool
 	quenchGlobal bool
-	quenchRescan bool
 )
 
 func init() {
 	rootCmd.AddCommand(quenchCmd)
 	quenchCmd.Flags().BoolVar(&quenchVerify, "verify", false, "check pins without writing (CI-friendly)")
 	quenchCmd.Flags().BoolVarP(&quenchGlobal, "global", "g", false, "operate on the global manifest/lock under ~/")
-	quenchCmd.Flags().BoolVar(&quenchRescan, "rescan", false, "best-effort scan for previously cast molds without an installed manifest")
 }
 
 func runQuench(_ *cobra.Command, args []string) error {
-	if quenchRescan {
-		return runRescan(quenchGlobal)
-	}
-
 	manifestPath := manifestPathFor(quenchGlobal)
 	lockPath := lockPathFor(quenchGlobal)
 
@@ -151,7 +145,7 @@ func runQuench(_ *cobra.Command, args []string) error {
 	fmt.Println()
 	fmt.Printf("%s %d dependencies pinned in %s.\n",
 		styles.SuccessStyle.Render("Locked:"),
-		len(newLock.Molds),
+		len(entries),
 		styles.CodeStyle.Render(lockPath),
 	)
 	fmt.Printf("Run %s to update to newer versions.\n", styles.CodeStyle.Render("ailloy recast"))
@@ -204,20 +198,4 @@ func referenceFromInstalledEntry(entry *foundry.InstalledEntry) (*foundry.Refere
 		Subpath: entry.Subpath,
 		Type:    foundry.Latest,
 	}, nil
-}
-
-// runRescan is a best-effort migration helper for users who have previously
-// cast blanks but no installed manifest. v1 implementation: print guidance
-// only — directing users to re-cast each mold once.
-func runRescan(_ bool) error {
-	fmt.Println(styles.WorkingBanner("Rescan: detecting previously cast molds..."))
-	fmt.Println()
-	fmt.Println(styles.WarningStyle.Render("Rescan is a placeholder in this release."))
-	fmt.Println("Until a fuller scan is implemented, please re-run " +
-		styles.CodeStyle.Render("ailloy cast <ref>") +
-		" once for each mold you previously installed.")
-	fmt.Println("Each cast will populate " +
-		styles.CodeStyle.Render(".ailloy/installed.yaml") +
-		" automatically.")
-	return nil
 }

--- a/internal/commands/quench.go
+++ b/internal/commands/quench.go
@@ -2,6 +2,8 @@ package commands
 
 import (
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/nimble-giant/ailloy/pkg/foundry"
 	"github.com/nimble-giant/ailloy/pkg/styles"
@@ -9,68 +11,208 @@ import (
 )
 
 var quenchCmd = &cobra.Command{
-	Use:     "quench",
+	Use:     "quench [reference]",
 	Aliases: []string{"lock"},
-	Short:   "Pin all dependencies to exact versions",
-	Long: `Pin all dependencies to their current exact versions (alias: lock).
+	Short:   "Pin installed molds to exact versions (creates ailloy.lock)",
+	Long: `Pin installed molds to exact versions and verify integrity (alias: lock).
 
-Ensures all dependencies in ailloy.lock are pinned to exact version and commit
-SHAs. Subsequent cast operations will use only these locked versions until
-the lock is updated via recast.`,
+Creates or refreshes ailloy.lock by pinning each mold in .ailloy/installed.yaml
+to its current resolved version and commit. Once ailloy.lock exists, subsequent
+'cast', 'ingot add', and 'recast' will keep it in sync automatically.
+
+Pass a reference to quench a single mold. Use --verify to check existing pins
+without writing.`,
+	Args: cobra.MaximumNArgs(1),
 	RunE: runQuench,
 }
 
+var (
+	quenchVerify bool
+	quenchGlobal bool
+	quenchRescan bool
+)
+
 func init() {
 	rootCmd.AddCommand(quenchCmd)
+	quenchCmd.Flags().BoolVar(&quenchVerify, "verify", false, "check pins without writing (CI-friendly)")
+	quenchCmd.Flags().BoolVarP(&quenchGlobal, "global", "g", false, "operate on the global manifest/lock under ~/")
+	quenchCmd.Flags().BoolVar(&quenchRescan, "rescan", false, "best-effort scan for previously cast molds without an installed manifest")
 }
 
-func runQuench(_ *cobra.Command, _ []string) error {
-	lock, err := foundry.ReadLockFile(foundry.LockFileName)
-	if err != nil {
-		return fmt.Errorf("reading lock file: %w", err)
-	}
-	if lock == nil || len(lock.Molds) == 0 {
-		return fmt.Errorf("no lock file found — run %s first to resolve dependencies", styles.CodeStyle.Render("ailloy cast"))
+func runQuench(_ *cobra.Command, args []string) error {
+	if quenchRescan {
+		return runRescan(quenchGlobal)
 	}
 
-	fmt.Println(styles.WorkingBanner("Quenching dependencies..."))
+	manifestPath := manifestPathFor(quenchGlobal)
+	lockPath := lockPathFor(quenchGlobal)
+
+	manifest, err := foundry.ReadInstalledManifest(manifestPath)
+	if err != nil {
+		return fmt.Errorf("reading installed manifest: %w", err)
+	}
+	if manifest == nil || len(manifest.Molds) == 0 {
+		return fmt.Errorf("no installed manifest found at %s — run %s first",
+			styles.CodeStyle.Render(manifestPath),
+			styles.CodeStyle.Render("ailloy cast"))
+	}
+
+	// Filter to a single ref if provided.
+	entries := manifest.Molds
+	if len(args) == 1 {
+		ref, err := foundry.ParseReference(args[0])
+		if err != nil {
+			return fmt.Errorf("parsing reference: %w", err)
+		}
+		match := manifest.FindBySource(ref.CacheKey())
+		if match == nil {
+			return fmt.Errorf("mold %q not found in installed manifest — run %s first",
+				args[0],
+				styles.CodeStyle.Render("ailloy cast "+args[0]))
+		}
+		entries = []foundry.InstalledEntry{*match}
+	}
+
+	if quenchVerify {
+		fmt.Println(styles.WorkingBanner("Verifying pins..."))
+	} else {
+		fmt.Println(styles.WorkingBanner("Quenching dependencies..."))
+	}
 	fmt.Println()
 
-	// Verify each entry has exact version and commit pinned.
-	allPinned := true
-	for _, entry := range lock.Molds {
-		if entry.Version == "" || entry.Commit == "" {
-			fmt.Printf("  %s %s is missing version or commit pin\n",
-				styles.WarningStyle.Render("!"),
-				entry.Name,
-			)
-			allPinned = false
+	// Verification phase: manifest <-> lock consistency.
+	existingLock, _ := foundry.ReadLockFile(lockPath)
+	failures := verifyManifestAgainstLock(entries, existingLock)
+	for _, msg := range failures {
+		fmt.Printf("  %s %s\n", styles.WarningStyle.Render("!"), msg)
+	}
+	if len(failures) > 0 && quenchVerify {
+		fmt.Println()
+		return fmt.Errorf("verification failed (%d issue(s))", len(failures))
+	}
+
+	if quenchVerify {
+		fmt.Println()
+		fmt.Println(styles.SuccessStyle.Render("All pins verified."))
+		return nil
+	}
+
+	// Resolve current versions and write a fresh lock.
+	git := foundry.DefaultGitRunner()
+	newLock := &foundry.LockFile{APIVersion: "v1"}
+	for _, entry := range entries {
+		ref, err := referenceFromInstalledEntry(&entry)
+		if err != nil {
+			fmt.Printf("  %s skipping %s: %v\n", styles.WarningStyle.Render("!"), entry.Name, err)
 			continue
 		}
-
-		commitShort := entry.Commit
+		resolved, err := foundry.ResolveVersion(ref, git)
+		if err != nil {
+			fmt.Printf("  %s skipping %s: %v\n", styles.WarningStyle.Render("!"), entry.Name, err)
+			continue
+		}
+		newLock.UpsertEntry(foundry.LockEntry{
+			Name:      entry.Name,
+			Source:    entry.Source,
+			Version:   resolved.Tag,
+			Commit:    resolved.Commit,
+			Subpath:   entry.Subpath,
+			Timestamp: time.Now().UTC(),
+		})
+		commitShort := resolved.Commit
 		if len(commitShort) > 7 {
 			commitShort = commitShort[:7]
 		}
 		fmt.Printf("  %s  %s @ %s\n",
 			styles.FoxBullet(entry.Name),
-			styles.CodeStyle.Render(entry.Version),
+			styles.CodeStyle.Render(resolved.Tag),
 			styles.CodeStyle.Render(commitShort),
 		)
 	}
 
-	fmt.Println()
-
-	if !allPinned {
-		return fmt.Errorf("some dependencies are not fully pinned — run %s to re-resolve", styles.CodeStyle.Render("ailloy recast"))
+	// If quench was scoped to a single ref AND a lock already exists, merge into it.
+	if len(args) == 1 && existingLock != nil {
+		for _, e := range newLock.Molds {
+			existingLock.UpsertEntry(e)
+		}
+		newLock = existingLock
 	}
 
-	fmt.Printf("%s All %d dependencies are pinned to exact versions.\n",
-		styles.SuccessStyle.Render("Locked:"),
-		len(lock.Molds),
-	)
-	fmt.Println()
-	fmt.Printf("Run %s to update to newer versions.\n", styles.CodeStyle.Render("ailloy recast"))
+	if err := foundry.WriteLockFile(lockPath, newLock); err != nil {
+		return fmt.Errorf("writing lock file: %w", err)
+	}
 
+	fmt.Println()
+	fmt.Printf("%s %d dependencies pinned in %s.\n",
+		styles.SuccessStyle.Render("Locked:"),
+		len(newLock.Molds),
+		styles.CodeStyle.Render(lockPath),
+	)
+	fmt.Printf("Run %s to update to newer versions.\n", styles.CodeStyle.Render("ailloy recast"))
+	return nil
+}
+
+// verifyManifestAgainstLock returns human-readable failure messages.
+func verifyManifestAgainstLock(entries []foundry.InstalledEntry, lock *foundry.LockFile) []string {
+	var failures []string
+	if lock == nil {
+		return nil // no lock to verify against — first quench scenario
+	}
+	for _, entry := range entries {
+		locked := lock.FindEntry(entry.Source)
+		if locked == nil {
+			failures = append(failures, fmt.Sprintf("%s is in installed manifest but missing from lock", entry.Name))
+			continue
+		}
+		if locked.Commit != entry.Commit {
+			failures = append(failures,
+				fmt.Sprintf("%s commit drift: manifest=%s lock=%s",
+					entry.Name,
+					shortSHA(entry.Commit),
+					shortSHA(locked.Commit),
+				))
+		}
+		if locked.Version == "" || locked.Commit == "" {
+			failures = append(failures, fmt.Sprintf("%s lock entry is missing version or commit", entry.Name))
+		}
+	}
+	return failures
+}
+
+func shortSHA(s string) string {
+	if len(s) > 7 {
+		return s[:7]
+	}
+	return s
+}
+
+// referenceFromInstalledEntry reconstructs a Latest-typed Reference for re-resolution.
+func referenceFromInstalledEntry(entry *foundry.InstalledEntry) (*foundry.Reference, error) {
+	parts := strings.SplitN(entry.Source, "/", 3)
+	if len(parts) < 3 {
+		return nil, fmt.Errorf("invalid source %q: expected host/owner/repo", entry.Source)
+	}
+	return &foundry.Reference{
+		Host:    parts[0],
+		Owner:   parts[1],
+		Repo:    parts[2],
+		Subpath: entry.Subpath,
+		Type:    foundry.Latest,
+	}, nil
+}
+
+// runRescan is a best-effort migration helper for users who have previously
+// cast blanks but no installed manifest. v1 implementation: print guidance
+// only — directing users to re-cast each mold once.
+func runRescan(_ bool) error {
+	fmt.Println(styles.WorkingBanner("Rescan: detecting previously cast molds..."))
+	fmt.Println()
+	fmt.Println(styles.WarningStyle.Render("Rescan is a placeholder in this release."))
+	fmt.Println("Until a fuller scan is implemented, please re-run " +
+		styles.CodeStyle.Render("ailloy cast <ref>") +
+		" once for each mold you previously installed.")
+	fmt.Println("Each cast will populate " +
+		styles.CodeStyle.Render(".ailloy/installed.yaml") +
+		" automatically.")
 	return nil
 }

--- a/internal/commands/quench_test.go
+++ b/internal/commands/quench_test.go
@@ -63,3 +63,21 @@ func TestVerifyManifestAgainstLock_AllPresent(t *testing.T) {
 		t.Errorf("expected no failures, got %v", got)
 	}
 }
+
+// Drift on an entry whose lock row is missing version/commit should report the
+// "missing version or commit" message only, not also the drift message.
+func TestVerifyManifestAgainstLock_BlankLockEntryDoesNotDoubleReport(t *testing.T) {
+	entries := []foundry.InstalledEntry{
+		{Name: "a", Source: "github.com/x/a", Commit: "abc"},
+	}
+	lock := &foundry.LockFile{
+		APIVersion: "v1",
+		Molds: []foundry.LockEntry{
+			{Name: "a", Source: "github.com/x/a", Version: "", Commit: "", Timestamp: time.Now()},
+		},
+	}
+	failures := verifyManifestAgainstLock(entries, lock)
+	if len(failures) != 1 {
+		t.Fatalf("expected exactly 1 failure (no double-report), got %d: %v", len(failures), failures)
+	}
+}

--- a/internal/commands/quench_test.go
+++ b/internal/commands/quench_test.go
@@ -1,0 +1,65 @@
+package commands
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nimble-giant/ailloy/pkg/foundry"
+)
+
+func TestVerifyManifestAgainstLock_NoLock(t *testing.T) {
+	entries := []foundry.InstalledEntry{
+		{Name: "a", Source: "github.com/x/a", Commit: "abc"},
+	}
+	if got := verifyManifestAgainstLock(entries, nil); got != nil {
+		t.Errorf("expected nil failures with no lock, got %v", got)
+	}
+}
+
+func TestVerifyManifestAgainstLock_CommitDrift(t *testing.T) {
+	entries := []foundry.InstalledEntry{
+		{Name: "a", Source: "github.com/x/a", Commit: "aaaaaaa1"},
+	}
+	lock := &foundry.LockFile{
+		APIVersion: "v1",
+		Molds: []foundry.LockEntry{
+			{Name: "a", Source: "github.com/x/a", Version: "v1.0.0", Commit: "bbbbbbb2", Timestamp: time.Now()},
+		},
+	}
+	failures := verifyManifestAgainstLock(entries, lock)
+	if len(failures) != 1 {
+		t.Fatalf("expected 1 failure, got %d: %v", len(failures), failures)
+	}
+}
+
+func TestVerifyManifestAgainstLock_MissingFromLock(t *testing.T) {
+	entries := []foundry.InstalledEntry{
+		{Name: "a", Source: "github.com/x/a", Commit: "abc"},
+		{Name: "b", Source: "github.com/x/b", Commit: "def"},
+	}
+	lock := &foundry.LockFile{
+		APIVersion: "v1",
+		Molds: []foundry.LockEntry{
+			{Name: "a", Source: "github.com/x/a", Version: "v1.0.0", Commit: "abc", Timestamp: time.Now()},
+		},
+	}
+	failures := verifyManifestAgainstLock(entries, lock)
+	if len(failures) != 1 {
+		t.Fatalf("expected 1 failure for missing b, got %d: %v", len(failures), failures)
+	}
+}
+
+func TestVerifyManifestAgainstLock_AllPresent(t *testing.T) {
+	entries := []foundry.InstalledEntry{
+		{Name: "a", Source: "github.com/x/a", Commit: "abc"},
+	}
+	lock := &foundry.LockFile{
+		APIVersion: "v1",
+		Molds: []foundry.LockEntry{
+			{Name: "a", Source: "github.com/x/a", Version: "v1.0.0", Commit: "abc", Timestamp: time.Now()},
+		},
+	}
+	if got := verifyManifestAgainstLock(entries, lock); got != nil {
+		t.Errorf("expected no failures, got %v", got)
+	}
+}

--- a/internal/commands/recast.go
+++ b/internal/commands/recast.go
@@ -12,25 +12,28 @@ import (
 var recastCmd = &cobra.Command{
 	Use:     "recast [name]",
 	Aliases: []string{"upgrade"},
-	Short:   "Re-resolve dependencies to newer versions",
-	Long: `Re-resolve dependencies to newer versions (alias: upgrade).
+	Short:   "Re-resolve installed molds to newer versions",
+	Long: `Re-resolve installed molds to newer versions (alias: upgrade).
 
-Fetches the latest available versions for all locked dependencies (or a single
-named dependency) from their SCM sources and updates ailloy.lock.
+Reads .ailloy/installed.yaml and refreshes each mold to its latest matching
+version. If ailloy.lock exists, also updates lock entries in lockstep.
 
 Use --dry-run to preview changes without applying them.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runRecast,
 }
 
-var recastDryRun bool
+var (
+	recastDryRun bool
+	recastGlobal bool
+)
 
 func init() {
 	rootCmd.AddCommand(recastCmd)
 	recastCmd.Flags().BoolVar(&recastDryRun, "dry-run", false, "preview changes without applying")
+	recastCmd.Flags().BoolVarP(&recastGlobal, "global", "g", false, "operate on the global manifest/lock under ~/")
 }
 
-// recastChange records a version change for a single dependency.
 type recastChange struct {
 	Name       string
 	Source     string
@@ -41,24 +44,27 @@ type recastChange struct {
 }
 
 func runRecast(_ *cobra.Command, args []string) error {
-	lock, err := foundry.ReadLockFile(foundry.LockFileName)
+	manifestPath := manifestPathFor(recastGlobal)
+	lockPath := lockPathFor(recastGlobal)
+
+	manifest, err := foundry.ReadInstalledManifest(manifestPath)
 	if err != nil {
-		return fmt.Errorf("reading lock file: %w", err)
+		return fmt.Errorf("reading installed manifest: %w", err)
 	}
-	if lock == nil || len(lock.Molds) == 0 {
-		return fmt.Errorf("no lock file found — run %s first", styles.CodeStyle.Render("ailloy cast"))
+	if manifest == nil || len(manifest.Molds) == 0 {
+		return fmt.Errorf("no installed manifest at %s — run %s first",
+			styles.CodeStyle.Render(manifestPath),
+			styles.CodeStyle.Render("ailloy cast"))
 	}
 
-	// Filter to a single dependency if name provided.
-	var entries []foundry.LockEntry
+	// Optional name filter.
+	entries := manifest.Molds
 	if len(args) == 1 {
-		entry := lock.FindEntryByName(args[0])
-		if entry == nil {
-			return fmt.Errorf("dependency %q not found in lock file", args[0])
+		match := manifest.FindByName(args[0])
+		if match == nil {
+			return fmt.Errorf("mold %q not found in installed manifest", args[0])
 		}
-		entries = []foundry.LockEntry{*entry}
-	} else {
-		entries = lock.Molds
+		entries = []foundry.InstalledEntry{*match}
 	}
 
 	if recastDryRun {
@@ -71,24 +77,24 @@ func runRecast(_ *cobra.Command, args []string) error {
 	git := foundry.DefaultGitRunner()
 	var changes []recastChange
 
+	// Read existing lock (if any) so we can update it in lockstep.
+	existingLock, _ := foundry.ReadLockFile(lockPath)
+
 	for _, entry := range entries {
-		ref, err := foundry.ReferenceFromEntry(&entry)
+		ref, err := referenceFromInstalledEntry(&entry)
 		if err != nil {
-			fmt.Printf("%s skipping %s: %v\n", styles.WarningStyle.Render("⚠️"), entry.Name, err)
+			fmt.Printf("%s skipping %s: %v\n", styles.WarningStyle.Render("!"), entry.Name, err)
 			continue
 		}
-
 		resolved, err := foundry.ResolveVersion(ref, git)
 		if err != nil {
-			fmt.Printf("%s skipping %s: %v\n", styles.WarningStyle.Render("⚠️"), entry.Name, err)
+			fmt.Printf("%s skipping %s: %v\n", styles.WarningStyle.Render("!"), entry.Name, err)
 			continue
 		}
-
 		if resolved.Tag == entry.Version && resolved.Commit == entry.Commit {
 			fmt.Println(styles.InfoStyle.Render("  ") + entry.Name + " is already up to date (" + styles.CodeStyle.Render(entry.Version) + ")")
 			continue
 		}
-
 		changes = append(changes, recastChange{
 			Name:       entry.Name,
 			Source:     entry.Source,
@@ -99,21 +105,30 @@ func runRecast(_ *cobra.Command, args []string) error {
 		})
 
 		if !recastDryRun {
-			// Invalidate cached version so next cast fetches fresh content.
-			fetcher, fErr := foundry.NewFetcher(git)
-			if fErr == nil {
-				// Fetch the new version into cache.
+			fetcher, ferr := foundry.NewFetcher(git)
+			if ferr == nil {
 				_, _, _ = fetcher.Fetch(ref, resolved)
 			}
 
-			lock.UpsertEntry(foundry.LockEntry{
-				Name:      entry.Name,
-				Source:    entry.Source,
-				Version:   resolved.Tag,
-				Commit:    resolved.Commit,
-				Subpath:   entry.Subpath,
-				Timestamp: time.Now().UTC(),
+			manifest.UpsertEntry(foundry.InstalledEntry{
+				Name:    entry.Name,
+				Source:  entry.Source,
+				Subpath: entry.Subpath,
+				Version: resolved.Tag,
+				Commit:  resolved.Commit,
+				CastAt:  time.Now().UTC(),
 			})
+
+			if existingLock != nil {
+				existingLock.UpsertEntry(foundry.LockEntry{
+					Name:      entry.Name,
+					Source:    entry.Source,
+					Version:   resolved.Tag,
+					Commit:    resolved.Commit,
+					Subpath:   entry.Subpath,
+					Timestamp: time.Now().UTC(),
+				})
+			}
 		}
 	}
 
@@ -123,14 +138,17 @@ func runRecast(_ *cobra.Command, args []string) error {
 		return nil
 	}
 
-	// Write updated lock file.
 	if !recastDryRun {
-		if err := foundry.WriteLockFile(foundry.LockFileName, lock); err != nil {
-			return fmt.Errorf("writing lock file: %w", err)
+		if err := foundry.WriteInstalledManifest(manifestPath, manifest); err != nil {
+			return fmt.Errorf("writing installed manifest: %w", err)
+		}
+		if existingLock != nil {
+			if err := foundry.WriteLockFile(lockPath, existingLock); err != nil {
+				return fmt.Errorf("writing lock file: %w", err)
+			}
 		}
 	}
 
-	// Print change summary.
 	fmt.Println()
 	if recastDryRun {
 		fmt.Println(styles.InfoStyle.Render("Changes that would be applied:"))
@@ -153,6 +171,5 @@ func runRecast(_ *cobra.Command, args []string) error {
 	} else {
 		fmt.Println(styles.SuccessBanner("Recast complete!"))
 	}
-
 	return nil
 }

--- a/internal/commands/recast.go
+++ b/internal/commands/recast.go
@@ -106,8 +106,15 @@ func runRecast(_ *cobra.Command, args []string) error {
 
 		if !recastDryRun {
 			fetcher, ferr := foundry.NewFetcher(git)
-			if ferr == nil {
-				_, _, _ = fetcher.Fetch(ref, resolved)
+			if ferr != nil {
+				fmt.Printf("%s skipping %s: fetcher: %v\n", styles.WarningStyle.Render("!"), entry.Name, ferr)
+				changes = changes[:len(changes)-1]
+				continue
+			}
+			if _, _, fetchErr := fetcher.Fetch(ref, resolved); fetchErr != nil {
+				fmt.Printf("%s skipping %s: fetch: %v\n", styles.WarningStyle.Render("!"), entry.Name, fetchErr)
+				changes = changes[:len(changes)-1]
+				continue
 			}
 
 			manifest.UpsertEntry(foundry.InstalledEntry{

--- a/internal/commands/uninstall.go
+++ b/internal/commands/uninstall.go
@@ -3,8 +3,6 @@ package commands
 import (
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"github.com/nimble-giant/ailloy/pkg/foundry"
 	"github.com/nimble-giant/ailloy/pkg/styles"
@@ -22,8 +20,10 @@ var uninstallCmd = &cobra.Command{
 	Short: "Remove a casted mold from this project (or ~/ with -g)",
 	Long: `Uninstall a previously casted mold by source identifier (e.g. github.com/owner/repo).
 
-Removes the files listed in the mold's lockfile entry, prunes any empty
-directories, and drops the entry from ailloy.lock.
+Removes the files listed in the mold's installed manifest entry, prunes any
+empty directories, and drops the entry from .ailloy/installed.yaml. If
+ailloy.lock exists alongside the manifest, the matching lock entry is also
+removed.
 
 Files modified since they were cast are retained unless --force is given.
 Files claimed by another casted mold are retained automatically.`,
@@ -41,12 +41,12 @@ func init() {
 func runUninstall(_ *cobra.Command, args []string) error {
 	source := args[0]
 
-	lockPath, err := uninstallLockPath(uninstallGlobal)
-	if err != nil {
-		return err
+	manifestPath := manifestPathFor(uninstallGlobal)
+	if manifestPath == "" {
+		return fmt.Errorf("cannot determine installed manifest path")
 	}
 
-	res, err := foundry.UninstallMold(lockPath, source, foundry.UninstallOptions{
+	res, err := foundry.UninstallMold(manifestPath, source, foundry.UninstallOptions{
 		Force:  uninstallForce,
 		DryRun: uninstallDryRun,
 	})
@@ -88,15 +88,4 @@ func runUninstall(_ *cobra.Command, args []string) error {
 		fmt.Println(styles.SubtleStyle.Render(fmt.Sprintf("  Already absent: %d file(s)", len(res.NotFound))))
 	}
 	return nil
-}
-
-func uninstallLockPath(global bool) (string, error) {
-	if !global {
-		return foundry.LockFileName, nil
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("cannot determine home directory: %w", err)
-	}
-	return filepath.Join(home, foundry.LockFileName), nil
 }

--- a/internal/tui/foundries/data/inventory.go
+++ b/internal/tui/foundries/data/inventory.go
@@ -8,7 +8,7 @@ import (
 	"github.com/nimble-giant/ailloy/pkg/foundry/index"
 )
 
-// Scope identifies which lockfile a casted mold lives in.
+// Scope identifies which manifest a casted mold lives in.
 type Scope string
 
 const (
@@ -16,29 +16,29 @@ const (
 	ScopeGlobal  Scope = "global"
 )
 
-// InventoryItem represents one casted mold seen in a lockfile.
+// InventoryItem represents one casted mold seen in an installed manifest.
 type InventoryItem struct {
-	Scope    Scope
-	LockPath string
-	Entry    foundry.LockEntry
-	Verified bool
-	Foundry  string // foundry name, "" if unknown
+	Scope        Scope
+	ManifestPath string // path to .ailloy/installed.yaml that backs this entry
+	Entry        foundry.InstalledEntry
+	Verified     bool
+	Foundry      string // foundry name, "" if unknown
 }
 
-// LoadInventory reads the project lockfile (./ailloy.lock) and the global
-// lockfile (~/ailloy.lock) and merges their entries into a single slice.
-// Verified status is determined by looking up each entry's source against
-// cfg's effective foundries.
+// LoadInventory reads the project installed manifest (./.ailloy/installed.yaml)
+// and the global manifest (~/.ailloy/installed.yaml) and merges their entries
+// into a single slice. Verified status is determined by looking up each entry's
+// source against cfg's effective foundries.
 func LoadInventory(cfg *index.Config) ([]InventoryItem, error) {
 	var out []InventoryItem
 
-	add := func(scope Scope, lockPath string) {
-		lock, err := foundry.ReadLockFile(lockPath)
-		if err != nil || lock == nil {
+	add := func(scope Scope, manifestPath string) {
+		m, err := foundry.ReadInstalledManifest(manifestPath)
+		if err != nil || m == nil {
 			return
 		}
-		for _, e := range lock.Molds {
-			item := InventoryItem{Scope: scope, LockPath: lockPath, Entry: e}
+		for _, e := range m.Molds {
+			item := InventoryItem{Scope: scope, ManifestPath: manifestPath, Entry: e}
 			if f := cfg.FoundryForSource(e.Source); f != nil {
 				item.Foundry = f.Name
 				item.Verified = index.IsOfficialFoundry(f.URL)
@@ -47,9 +47,9 @@ func LoadInventory(cfg *index.Config) ([]InventoryItem, error) {
 		}
 	}
 
-	add(ScopeProject, foundry.LockFileName)
+	add(ScopeProject, foundry.InstalledManifestPath)
 	if home, err := os.UserHomeDir(); err == nil {
-		add(ScopeGlobal, filepath.Join(home, foundry.LockFileName))
+		add(ScopeGlobal, filepath.Join(home, foundry.InstalledManifestPath))
 	}
 	return out, nil
 }

--- a/internal/tui/foundries/installed/model.go
+++ b/internal/tui/foundries/installed/model.go
@@ -127,7 +127,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 
 func uninstallCmd(it data.InventoryItem) tea.Cmd {
 	return func() tea.Msg {
-		res, err := foundry.UninstallMold(it.LockPath, it.Entry.Source, foundry.UninstallOptions{})
+		res, err := foundry.UninstallMold(it.ManifestPath, it.Entry.Source, foundry.UninstallOptions{})
 		return uninstallDoneMsg{source: it.Entry.Source, res: res, err: err}
 	}
 }

--- a/pkg/foundry/foundry.go
+++ b/pkg/foundry/foundry.go
@@ -94,12 +94,18 @@ func shouldUseLock(path string) bool {
 }
 
 // Resolve is the main entry point for SCM-native mold resolution.
+// It parses a raw reference, optionally consults an existing ailloy.lock,
+// resolves the version from remote tags when not locked, fetches/caches the
+// mold, updates the lock if one already exists, and returns an fs.FS rooted
+// at the mold directory.
 func Resolve(rawRef string, opts ...ResolveOption) (fs.FS, error) {
 	fsys, _, err := ResolveWithRoot(rawRef, opts...)
 	return fsys, err
 }
 
-// ResolveWithRoot is like Resolve but also returns the on-disk root path.
+// ResolveWithRoot is like Resolve but also returns the on-disk root path of
+// the resolved mold. The root path is needed by callers that resolve sibling
+// directories (e.g., bundled ingots) during template rendering.
 func ResolveWithRoot(rawRef string, opts ...ResolveOption) (fs.FS, string, error) {
 	ref, err := ParseReference(rawRef)
 	if err != nil {

--- a/pkg/foundry/foundry.go
+++ b/pkg/foundry/foundry.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/fs"
 	"log"
+	"os"
 	"path/filepath"
 	"sort"
 	"time"
@@ -61,58 +62,71 @@ func RecordInstalledFiles(lockPath, source string, files []InstalledFile) error 
 type ResolveOption func(*resolveConfig)
 
 type resolveConfig struct {
-	skipLock bool
+	// lockPath is the path to the lock file. The lock is *only* used (read &
+	// updated) when a file already exists at this path. Resolve never creates
+	// the lock — that is the job of `ailloy quench`.
+	lockPath string
 }
 
-// WithoutLock disables reading and writing the ailloy.lock file during resolution.
-// Use this for global installs where a project-local lock file is not appropriate.
-func WithoutLock() ResolveOption {
-	return func(c *resolveConfig) {
-		c.skipLock = true
+// applyResolveDefaults sets the default lockPath. Exposed for tests.
+func applyResolveDefaults(c *resolveConfig) {
+	if c.lockPath == "" {
+		c.lockPath = LockFileName
 	}
 }
 
+// WithLockPath overrides the lock file path used by Resolve. Use this for
+// global installs (which use a path under ~/) or in tests.
+func WithLockPath(path string) ResolveOption {
+	return func(c *resolveConfig) {
+		c.lockPath = path
+	}
+}
+
+// shouldUseLock returns true when a lock file exists at the configured path.
+// Lock reads/writes are gated on file presence — opt-in via `ailloy quench`.
+func shouldUseLock(path string) bool {
+	if path == "" {
+		return false
+	}
+	_, err := os.Stat(path)
+	return err == nil
+}
+
 // Resolve is the main entry point for SCM-native mold resolution.
-// It parses a raw reference, checks the lock file, resolves the version
-// from remote tags, fetches/caches the mold, updates the lock, and returns
-// an fs.FS rooted at the mold directory.
 func Resolve(rawRef string, opts ...ResolveOption) (fs.FS, error) {
 	fsys, _, err := ResolveWithRoot(rawRef, opts...)
 	return fsys, err
 }
 
-// ResolveWithRoot is like Resolve but also returns the on-disk root path
-// of the resolved mold. The root path is needed by callers that resolve
-// sibling directories (e.g., bundled ingots) during template rendering.
+// ResolveWithRoot is like Resolve but also returns the on-disk root path.
 func ResolveWithRoot(rawRef string, opts ...ResolveOption) (fs.FS, string, error) {
 	ref, err := ParseReference(rawRef)
 	if err != nil {
 		return nil, "", fmt.Errorf("parsing reference: %w", err)
 	}
-
 	git := DefaultGitRunner()
 	return ResolveWith(ref, git, opts...)
 }
 
-// ResolveWith is like Resolve but accepts an injectable GitRunner (for testing).
-// It returns the resolved fs.FS and the on-disk root path.
+// ResolveWith resolves a parsed reference using the given GitRunner.
 func ResolveWith(ref *Reference, git GitRunner, opts ...ResolveOption) (fs.FS, string, error) {
 	var cfg resolveConfig
 	for _, opt := range opts {
 		opt(&cfg)
 	}
+	applyResolveDefaults(&cfg)
 
-	// Read existing lock file.
+	useLock := shouldUseLock(cfg.lockPath)
+
+	// Read existing lock file if present.
 	var resolved *ResolvedVersion
-	if !cfg.skipLock {
-		lock, err := ReadLockFile(LockFileName)
+	if useLock {
+		lock, err := ReadLockFile(cfg.lockPath)
 		if err != nil {
 			log.Printf("warning: reading lock file: %v", err)
 		}
-
-		// Check lock for a pinned version.
 		if entry := lock.FindEntry(ref.CacheKey()); entry != nil && ref.Type != Branch && ref.Type != SHA {
-			// Use locked version if it satisfies the reference.
 			if lockedSatisfies(ref, entry) {
 				resolved = &ResolvedVersion{Tag: entry.Version, Commit: entry.Commit}
 				log.Printf("using locked version %s@%s", ref.CacheKey(), entry.Version)
@@ -120,7 +134,7 @@ func ResolveWith(ref *Reference, git GitRunner, opts ...ResolveOption) (fs.FS, s
 		}
 	}
 
-	// Resolve version from remote if not locked.
+	// Resolve from remote if not locked.
 	if resolved == nil {
 		v, resolveErr := ResolveVersion(ref, git)
 		if resolveErr != nil {
@@ -134,15 +148,14 @@ func ResolveWith(ref *Reference, git GitRunner, opts ...ResolveOption) (fs.FS, s
 	if err != nil {
 		return nil, "", fmt.Errorf("creating fetcher: %w", err)
 	}
-
 	fsys, root, err := fetcher.Fetch(ref, resolved)
 	if err != nil {
 		return nil, "", fmt.Errorf("fetching mold: %w", err)
 	}
 
-	// Update lock file.
-	if !cfg.skipLock {
-		if err := updateLock(ref, resolved); err != nil {
+	// Update lock only if it already exists.
+	if useLock {
+		if err := updateLockAt(cfg.lockPath, ref, resolved); err != nil {
 			log.Printf("warning: updating lock file: %v", err)
 		}
 	}
@@ -150,10 +163,6 @@ func ResolveWith(ref *Reference, git GitRunner, opts ...ResolveOption) (fs.FS, s
 	return fsys, root, nil
 }
 
-// lockedSatisfies checks whether the locked entry still satisfies the
-// requested reference. For Latest and Constraint types, the lock is always
-// used (user must delete lock to get newer versions). For Exact, the locked
-// version must match.
 func lockedSatisfies(ref *Reference, entry *LockEntry) bool {
 	switch ref.Type {
 	case Latest, Constraint:
@@ -165,17 +174,15 @@ func lockedSatisfies(ref *Reference, entry *LockEntry) bool {
 	}
 }
 
-// updateLock reads the current lock file, upserts the resolved entry, and
-// writes it back.
-func updateLock(ref *Reference, resolved *ResolvedVersion) error {
-	lock, err := ReadLockFile(LockFileName)
+// updateLockAt reads, upserts, and writes the lock at the given path.
+func updateLockAt(path string, ref *Reference, resolved *ResolvedVersion) error {
+	lock, err := ReadLockFile(path)
 	if err != nil {
 		lock = nil
 	}
 	if lock == nil {
 		lock = &LockFile{APIVersion: "v1"}
 	}
-
 	lock.UpsertEntry(LockEntry{
 		Name:      ref.Repo,
 		Source:    ref.CacheKey(),
@@ -184,6 +191,5 @@ func updateLock(ref *Reference, resolved *ResolvedVersion) error {
 		Subpath:   ref.Subpath,
 		Timestamp: time.Now().UTC(),
 	})
-
-	return WriteLockFile(LockFileName, lock)
+	return WriteLockFile(path, lock)
 }

--- a/pkg/foundry/foundry.go
+++ b/pkg/foundry/foundry.go
@@ -117,6 +117,35 @@ func ResolveWithRoot(rawRef string, opts ...ResolveOption) (fs.FS, string, error
 
 // ResolveWith resolves a parsed reference using the given GitRunner.
 func ResolveWith(ref *Reference, git GitRunner, opts ...ResolveOption) (fs.FS, string, error) {
+	fsys, result, err := resolveWithMeta(ref, git, opts...)
+	if err != nil {
+		return nil, "", err
+	}
+	return fsys, result.Root, nil
+}
+
+// ResolveResult captures resolution outputs callers need to record provenance.
+type ResolveResult struct {
+	Ref      *Reference
+	Resolved ResolvedVersion
+	Root     string
+}
+
+// ResolveWithMetadata is like Resolve but returns provenance details for the
+// caller to record in the installed manifest.
+func ResolveWithMetadata(rawRef string, opts ...ResolveOption) (fs.FS, *ResolveResult, error) {
+	ref, err := ParseReference(rawRef)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parsing reference: %w", err)
+	}
+	git := DefaultGitRunner()
+	fsys, result, err := resolveWithMeta(ref, git, opts...)
+	return fsys, result, err
+}
+
+// resolveWithMeta is the internal implementation; mirrors ResolveWith but also
+// returns the ResolvedVersion alongside the fs.FS.
+func resolveWithMeta(ref *Reference, git GitRunner, opts ...ResolveOption) (fs.FS, *ResolveResult, error) {
 	var cfg resolveConfig
 	for _, opt := range opts {
 		opt(&cfg)
@@ -125,7 +154,6 @@ func ResolveWith(ref *Reference, git GitRunner, opts ...ResolveOption) (fs.FS, s
 
 	useLock := shouldUseLock(cfg.lockPath)
 
-	// Read existing lock file if present.
 	var resolved *ResolvedVersion
 	if useLock {
 		lock, err := ReadLockFile(cfg.lockPath)
@@ -140,33 +168,30 @@ func ResolveWith(ref *Reference, git GitRunner, opts ...ResolveOption) (fs.FS, s
 		}
 	}
 
-	// Resolve from remote if not locked.
 	if resolved == nil {
 		v, resolveErr := ResolveVersion(ref, git)
 		if resolveErr != nil {
-			return nil, "", fmt.Errorf("resolving version: %w", resolveErr)
+			return nil, nil, fmt.Errorf("resolving version: %w", resolveErr)
 		}
 		resolved = v
 	}
 
-	// Fetch (clone/cache).
 	fetcher, err := NewFetcher(git)
 	if err != nil {
-		return nil, "", fmt.Errorf("creating fetcher: %w", err)
+		return nil, nil, fmt.Errorf("creating fetcher: %w", err)
 	}
 	fsys, root, err := fetcher.Fetch(ref, resolved)
 	if err != nil {
-		return nil, "", fmt.Errorf("fetching mold: %w", err)
+		return nil, nil, fmt.Errorf("fetching mold: %w", err)
 	}
 
-	// Update lock only if it already exists.
 	if useLock {
 		if err := updateLockAt(cfg.lockPath, ref, resolved); err != nil {
 			log.Printf("warning: updating lock file: %v", err)
 		}
 	}
 
-	return fsys, root, nil
+	return fsys, &ResolveResult{Ref: ref, Resolved: *resolved, Root: root}, nil
 }
 
 func lockedSatisfies(ref *Reference, entry *LockEntry) bool {

--- a/pkg/foundry/foundry.go
+++ b/pkg/foundry/foundry.go
@@ -132,7 +132,8 @@ type ResolveResult struct {
 }
 
 // ResolveWithMetadata is like Resolve but returns provenance details for the
-// caller to record in the installed manifest.
+// caller to record in the installed manifest. On error, the returned
+// *ResolveResult is always nil.
 func ResolveWithMetadata(rawRef string, opts ...ResolveOption) (fs.FS, *ResolveResult, error) {
 	ref, err := ParseReference(rawRef)
 	if err != nil {
@@ -140,7 +141,10 @@ func ResolveWithMetadata(rawRef string, opts ...ResolveOption) (fs.FS, *ResolveR
 	}
 	git := DefaultGitRunner()
 	fsys, result, err := resolveWithMeta(ref, git, opts...)
-	return fsys, result, err
+	if err != nil {
+		return nil, nil, err
+	}
+	return fsys, result, nil
 }
 
 // resolveWithMeta is the internal implementation; mirrors ResolveWith but also

--- a/pkg/foundry/foundry.go
+++ b/pkg/foundry/foundry.go
@@ -12,25 +12,28 @@ import (
 
 // InstalledFile carries the metadata recorded for one cast file.
 type InstalledFile struct {
-	RelPath string // path relative to the lockfile dir, forward-slash separated
+	RelPath string // path relative to the manifest dir, forward-slash separated
 	SHA256  string // hex-encoded sha256 of file content at install time
 }
 
 // RecordInstalledFiles backfills the Files list and FileHashes map on the
-// lock entry whose Source matches. Hashes are sha256 hex of the file content
-// at install time, used by UninstallMold to detect user modifications.
-func RecordInstalledFiles(lockPath, source string, files []InstalledFile) error {
-	lock, err := ReadLockFile(lockPath)
+// installed-manifest entry whose Source matches. Hashes are sha256 hex of the
+// file content at install time, used by UninstallMold to detect user
+// modifications. Provenance lives on the manifest (always written by cast)
+// rather than the lock so uninstall stays available when the user has not
+// opted into ailloy.lock.
+func RecordInstalledFiles(manifestPath, source string, files []InstalledFile) error {
+	m, err := ReadInstalledManifest(manifestPath)
 	if err != nil {
-		return fmt.Errorf("reading lock file: %w", err)
+		return fmt.Errorf("reading installed manifest: %w", err)
 	}
-	if lock == nil {
-		return fmt.Errorf("lock file %s does not exist", lockPath)
+	if m == nil {
+		return fmt.Errorf("installed manifest %s does not exist", manifestPath)
 	}
 
-	entry := lock.FindEntry(source)
+	entry := m.FindBySource(source)
 	if entry == nil {
-		return fmt.Errorf("no lock entry for source %q", source)
+		return fmt.Errorf("no installed manifest entry for source %q", source)
 	}
 
 	seen := make(map[string]struct{}, len(files))
@@ -55,7 +58,7 @@ func RecordInstalledFiles(lockPath, source string, files []InstalledFile) error 
 		entry.FileHashes = nil
 	}
 
-	return WriteLockFile(lockPath, lock)
+	return WriteInstalledManifest(manifestPath, m)
 }
 
 // ResolveOption configures optional behaviour for Resolve.

--- a/pkg/foundry/foundry_test.go
+++ b/pkg/foundry/foundry_test.go
@@ -137,13 +137,13 @@ func TestWithLockPath_OverridesDefault(t *testing.T) {
 
 func TestRecordInstalledFiles(t *testing.T) {
 	dir := t.TempDir()
-	lockPath := filepath.Join(dir, "ailloy.lock")
+	manifestPath := filepath.Join(dir, ".ailloy", "installed.yaml")
 
-	seed := &LockFile{
+	seed := &InstalledManifest{
 		APIVersion: "v1",
-		Molds:      []LockEntry{{Name: "test", Source: "github.com/x/y", Version: "v1", Commit: "c1"}},
+		Molds:      []InstalledEntry{{Name: "test", Source: "github.com/x/y", Version: "v1", Commit: "c1"}},
 	}
-	if err := WriteLockFile(lockPath, seed); err != nil {
+	if err := WriteInstalledManifest(manifestPath, seed); err != nil {
 		t.Fatal(err)
 	}
 
@@ -153,11 +153,11 @@ func TestRecordInstalledFiles(t *testing.T) {
 		{RelPath: "a/dir/x.md", SHA256: "hash-a"},
 	}
 
-	if err := RecordInstalledFiles(lockPath, "github.com/x/y", files); err != nil {
+	if err := RecordInstalledFiles(manifestPath, "github.com/x/y", files); err != nil {
 		t.Fatalf("RecordInstalledFiles: %v", err)
 	}
 
-	loaded, err := ReadLockFile(lockPath)
+	loaded, err := ReadInstalledManifest(manifestPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -171,20 +171,20 @@ func TestRecordInstalledFiles(t *testing.T) {
 	}
 }
 
-func TestRecordInstalledFiles_NoLockFile(t *testing.T) {
-	err := RecordInstalledFiles("/nonexistent/ailloy.lock", "github.com/x/y", []InstalledFile{{RelPath: "a"}})
+func TestRecordInstalledFiles_NoManifest(t *testing.T) {
+	err := RecordInstalledFiles("/nonexistent/.ailloy/installed.yaml", "github.com/x/y", []InstalledFile{{RelPath: "a"}})
 	if err == nil {
-		t.Error("expected error for missing lockfile")
+		t.Error("expected error for missing manifest")
 	}
 }
 
 func TestRecordInstalledFiles_EntryNotFound(t *testing.T) {
 	dir := t.TempDir()
-	lockPath := filepath.Join(dir, "ailloy.lock")
-	if err := WriteLockFile(lockPath, &LockFile{APIVersion: "v1"}); err != nil {
+	manifestPath := filepath.Join(dir, ".ailloy", "installed.yaml")
+	if err := WriteInstalledManifest(manifestPath, &InstalledManifest{APIVersion: "v1"}); err != nil {
 		t.Fatal(err)
 	}
-	err := RecordInstalledFiles(lockPath, "github.com/missing/repo", []InstalledFile{{RelPath: "a"}})
+	err := RecordInstalledFiles(manifestPath, "github.com/missing/repo", []InstalledFile{{RelPath: "a"}})
 	if err == nil {
 		t.Error("expected error when entry not found")
 	}

--- a/pkg/foundry/foundry_test.go
+++ b/pkg/foundry/foundry_test.go
@@ -68,8 +68,7 @@ func TestLockedSatisfies(t *testing.T) {
 	}
 }
 
-func TestWithoutLock_SkipsLockFileIO(t *testing.T) {
-	// Set up: chdir to a temp dir so any lock file write would land here.
+func TestResolve_NoLockFile_DoesNotCreateLock(t *testing.T) {
 	dir := t.TempDir()
 	origDir, err := os.Getwd()
 	if err != nil {
@@ -80,8 +79,34 @@ func TestWithoutLock_SkipsLockFileIO(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chdir(origDir) })
 
-	// Pre-create a lock file that would match our reference.
-	// Without WithoutLock, ResolveWith would read this and use the locked version.
+	// Apply default config — no opts.
+	var cfg resolveConfig
+	applyResolveDefaults(&cfg)
+
+	if cfg.lockPath != LockFileName {
+		t.Errorf("default lockPath = %q, want %q", cfg.lockPath, LockFileName)
+	}
+
+	// Simulate the lock-write decision: if no file at lockPath, no write should happen.
+	if _, err := os.Stat(cfg.lockPath); !os.IsNotExist(err) {
+		t.Fatalf("expected no lock file in fresh dir, stat err = %v", err)
+	}
+	if shouldUseLock(cfg.lockPath) {
+		t.Errorf("shouldUseLock should return false when lock does not exist")
+	}
+}
+
+func TestResolve_LockExists_UsesIt(t *testing.T) {
+	dir := t.TempDir()
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
 	lock := &LockFile{
 		APIVersion: "v1",
 		Molds: []LockEntry{{
@@ -96,26 +121,17 @@ func TestWithoutLock_SkipsLockFileIO(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Record the lock file's mod time before the resolve call.
-	infoBefore, err := os.Stat(filepath.Join(dir, LockFileName))
-	if err != nil {
-		t.Fatal(err)
+	if !shouldUseLock(LockFileName) {
+		t.Error("shouldUseLock should return true when lock exists")
 	}
+}
 
-	// Verify WithoutLock sets skipLock on the config.
+func TestWithLockPath_OverridesDefault(t *testing.T) {
 	var cfg resolveConfig
-	WithoutLock()(&cfg)
-	if !cfg.skipLock {
-		t.Fatal("WithoutLock should set skipLock to true")
-	}
-
-	// Verify the lock file was not modified (updateLock was not called).
-	infoAfter, err := os.Stat(filepath.Join(dir, LockFileName))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if infoBefore.ModTime() != infoAfter.ModTime() {
-		t.Error("lock file was modified despite WithoutLock being set")
+	applyResolveDefaults(&cfg)
+	WithLockPath("/tmp/custom.lock")(&cfg)
+	if cfg.lockPath != "/tmp/custom.lock" {
+		t.Errorf("lockPath = %q, want /tmp/custom.lock", cfg.lockPath)
 	}
 }
 

--- a/pkg/foundry/lock.go
+++ b/pkg/foundry/lock.go
@@ -13,15 +13,16 @@ import (
 const LockFileName = "ailloy.lock"
 
 // LockEntry records the resolved version of a single mold dependency.
+// File-level provenance (which files were rendered and their hashes) lives
+// on InstalledEntry, not here — that keeps uninstall working when the lock
+// is not opted into.
 type LockEntry struct {
-	Name       string            `yaml:"name"`
-	Source     string            `yaml:"source"`
-	Version    string            `yaml:"version"`
-	Commit     string            `yaml:"commit"`
-	Subpath    string            `yaml:"subpath,omitempty"`
-	Timestamp  time.Time         `yaml:"timestamp"`
-	Files      []string          `yaml:"files,omitempty"`
-	FileHashes map[string]string `yaml:"fileHashes,omitempty"`
+	Name      string    `yaml:"name"`
+	Source    string    `yaml:"source"`
+	Version   string    `yaml:"version"`
+	Commit    string    `yaml:"commit"`
+	Subpath   string    `yaml:"subpath,omitempty"`
+	Timestamp time.Time `yaml:"timestamp"`
 }
 
 // LockFile is the on-disk lock file format.

--- a/pkg/foundry/lock_test.go
+++ b/pkg/foundry/lock_test.go
@@ -149,63 +149,26 @@ func TestLockFile_UpsertEntry_Update(t *testing.T) {
 	}
 }
 
-func TestLockFile_RoundTrip_WithFiles(t *testing.T) {
+func TestLockFile_OldFilesFieldIgnored(t *testing.T) {
+	// Pre-migration locks may have files: / fileHashes: keys. With the schema
+	// move, those fields no longer exist on LockEntry — YAML unmarshal must
+	// silently ignore them rather than failing.
 	dir := t.TempDir()
 	path := filepath.Join(dir, "ailloy.lock")
-
-	original := &LockFile{
-		APIVersion: "v1",
-		Molds: []LockEntry{
-			{
-				Name:    "nimble-mold",
-				Source:  "github.com/nimble-giant/nimble-mold",
-				Version: "v0.4.0",
-				Commit:  "abc123",
-				Files: []string{
-					"agents.md",
-					".claude/skills/brainstorm/SKILL.md",
-				},
-				FileHashes: map[string]string{
-					"agents.md": "deadbeef",
-				},
-			},
-		},
-	}
-
-	if err := WriteLockFile(path, original); err != nil {
-		t.Fatalf("WriteLockFile: %v", err)
-	}
-
-	loaded, err := ReadLockFile(path)
-	if err != nil {
-		t.Fatalf("ReadLockFile: %v", err)
-	}
-	if len(loaded.Molds) != 1 {
-		t.Fatalf("len(Molds) = %d, want 1", len(loaded.Molds))
-	}
-	if got := loaded.Molds[0].Files; len(got) != 2 || got[0] != "agents.md" {
-		t.Errorf("Files = %v, want [agents.md, .claude/...]", got)
-	}
-	if loaded.Molds[0].FileHashes["agents.md"] != "deadbeef" {
-		t.Errorf("FileHashes mismatch: %v", loaded.Molds[0].FileHashes)
-	}
-}
-
-func TestLockFile_LegacyEntry_NoFiles(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "ailloy.lock")
-
-	legacy := `apiVersion: v1
+	old := `apiVersion: v1
 molds:
-  - name: legacy-mold
-    source: github.com/example/legacy
-    version: v1.0.0
-    commit: deadbeef
+  - name: nimble-mold
+    source: github.com/nimble-giant/nimble-mold
+    version: v0.4.0
+    commit: abc123
+    files:
+      - agents.md
+    fileHashes:
+      agents.md: deadbeef
 `
-	if err := os.WriteFile(path, []byte(legacy), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(old), 0644); err != nil {
 		t.Fatal(err)
 	}
-
 	loaded, err := ReadLockFile(path)
 	if err != nil {
 		t.Fatalf("ReadLockFile: %v", err)
@@ -213,7 +176,7 @@ molds:
 	if len(loaded.Molds) != 1 {
 		t.Fatalf("len(Molds) = %d, want 1", len(loaded.Molds))
 	}
-	if loaded.Molds[0].Files != nil {
-		t.Errorf("legacy entry should have nil Files, got %v", loaded.Molds[0].Files)
+	if loaded.Molds[0].Version != "v0.4.0" || loaded.Molds[0].Commit != "abc123" {
+		t.Errorf("entry not parsed correctly: %+v", loaded.Molds[0])
 	}
 }

--- a/pkg/foundry/manifest.go
+++ b/pkg/foundry/manifest.go
@@ -1,0 +1,62 @@
+package foundry
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/goccy/go-yaml"
+)
+
+// InstalledManifestPath is the default project manifest path.
+const InstalledManifestPath = ".ailloy/installed.yaml"
+
+// InstalledEntry records a mold that was cast into the project.
+// Provenance only — does not hash rendered files (those are user-customizable).
+type InstalledEntry struct {
+	Name    string    `yaml:"name"`
+	Source  string    `yaml:"source"`
+	Subpath string    `yaml:"subpath,omitempty"`
+	Version string    `yaml:"version"`
+	Commit  string    `yaml:"commit"`
+	CastAt  time.Time `yaml:"castAt"`
+}
+
+// InstalledManifest is the on-disk manifest of cast molds.
+type InstalledManifest struct {
+	APIVersion string           `yaml:"apiVersion"`
+	Molds      []InstalledEntry `yaml:"molds"`
+}
+
+// ReadInstalledManifest reads and parses the manifest at the given path.
+// Returns (nil, nil) if the file does not exist.
+func ReadInstalledManifest(path string) (*InstalledManifest, error) {
+	data, err := os.ReadFile(path) //#nosec G304 -- path constructed by callers
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading installed manifest: %w", err)
+	}
+	var m InstalledManifest
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parsing installed manifest: %w", err)
+	}
+	return &m, nil
+}
+
+// WriteInstalledManifest marshals and writes the manifest, creating parent dirs.
+func WriteInstalledManifest(path string, m *InstalledManifest) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil { //#nosec G301
+		return fmt.Errorf("creating manifest dir: %w", err)
+	}
+	data, err := yaml.Marshal(m)
+	if err != nil {
+		return fmt.Errorf("marshaling installed manifest: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil { //#nosec G306
+		return fmt.Errorf("writing installed manifest: %w", err)
+	}
+	return nil
+}

--- a/pkg/foundry/manifest.go
+++ b/pkg/foundry/manifest.go
@@ -13,14 +13,19 @@ import (
 const InstalledManifestPath = ".ailloy/installed.yaml"
 
 // InstalledEntry records a mold that was cast into the project.
-// Provenance only — does not hash rendered files (those are user-customizable).
+// Files / FileHashes are populated by RecordInstalledFiles and consumed by
+// UninstallMold so the uninstall flow knows what to remove and can detect
+// post-cast modifications. They are intentionally on the manifest (not the
+// lock) so uninstall keeps working when ailloy.lock has not been opted into.
 type InstalledEntry struct {
-	Name    string    `yaml:"name"`
-	Source  string    `yaml:"source"`
-	Subpath string    `yaml:"subpath,omitempty"`
-	Version string    `yaml:"version"`
-	Commit  string    `yaml:"commit"`
-	CastAt  time.Time `yaml:"castAt"`
+	Name       string            `yaml:"name"`
+	Source     string            `yaml:"source"`
+	Subpath    string            `yaml:"subpath,omitempty"`
+	Version    string            `yaml:"version"`
+	Commit     string            `yaml:"commit"`
+	CastAt     time.Time         `yaml:"castAt"`
+	Files      []string          `yaml:"files,omitempty"`
+	FileHashes map[string]string `yaml:"fileHashes,omitempty"`
 }
 
 // InstalledManifest is the on-disk manifest of cast molds.

--- a/pkg/foundry/manifest.go
+++ b/pkg/foundry/manifest.go
@@ -46,6 +46,43 @@ func ReadInstalledManifest(path string) (*InstalledManifest, error) {
 	return &m, nil
 }
 
+// UpsertEntry adds or updates an entry by source.
+func (m *InstalledManifest) UpsertEntry(entry InstalledEntry) {
+	for i := range m.Molds {
+		if m.Molds[i].Source == entry.Source {
+			m.Molds[i] = entry
+			return
+		}
+	}
+	m.Molds = append(m.Molds, entry)
+}
+
+// FindBySource returns the entry matching the given source, or nil.
+func (m *InstalledManifest) FindBySource(source string) *InstalledEntry {
+	if m == nil {
+		return nil
+	}
+	for i := range m.Molds {
+		if m.Molds[i].Source == source {
+			return &m.Molds[i]
+		}
+	}
+	return nil
+}
+
+// FindByName returns the entry matching the given name, or nil.
+func (m *InstalledManifest) FindByName(name string) *InstalledEntry {
+	if m == nil {
+		return nil
+	}
+	for i := range m.Molds {
+		if m.Molds[i].Name == name {
+			return &m.Molds[i]
+		}
+	}
+	return nil
+}
+
 // WriteInstalledManifest marshals and writes the manifest, creating parent dirs.
 func WriteInstalledManifest(path string, m *InstalledManifest) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil { //#nosec G301

--- a/pkg/foundry/manifest_test.go
+++ b/pkg/foundry/manifest_test.go
@@ -1,0 +1,83 @@
+package foundry
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestInstalledManifest_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".ailloy", "installed.yaml")
+
+	ts := time.Date(2026, 5, 2, 15, 4, 5, 0, time.UTC)
+	original := &InstalledManifest{
+		APIVersion: "v1",
+		Molds: []InstalledEntry{
+			{
+				Name:    "nimble-mold",
+				Source:  "github.com/nimble-giant/nimble-mold",
+				Version: "v0.1.10",
+				Commit:  "2347a626798553252668a15dc98dd020ab9a9c0c",
+				CastAt:  ts,
+			},
+			{
+				Name:    "other-mold",
+				Source:  "github.com/other/mold",
+				Subpath: "sub/path",
+				Version: "v2.0.0",
+				Commit:  "def456",
+				CastAt:  ts,
+			},
+		},
+	}
+
+	if err := WriteInstalledManifest(path, original); err != nil {
+		t.Fatalf("WriteInstalledManifest: %v", err)
+	}
+
+	loaded, err := ReadInstalledManifest(path)
+	if err != nil {
+		t.Fatalf("ReadInstalledManifest: %v", err)
+	}
+	if loaded.APIVersion != "v1" {
+		t.Errorf("APIVersion = %q, want v1", loaded.APIVersion)
+	}
+	if len(loaded.Molds) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(loaded.Molds))
+	}
+	e := loaded.Molds[0]
+	if e.Name != "nimble-mold" || e.Source != "github.com/nimble-giant/nimble-mold" {
+		t.Errorf("entry 0 mismatch: %+v", e)
+	}
+	if e.Commit != "2347a626798553252668a15dc98dd020ab9a9c0c" {
+		t.Errorf("Commit = %q", e.Commit)
+	}
+	if loaded.Molds[1].Subpath != "sub/path" {
+		t.Errorf("Subpath = %q", loaded.Molds[1].Subpath)
+	}
+}
+
+func TestReadInstalledManifest_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	got, err := ReadInstalledManifest(filepath.Join(dir, "missing.yaml"))
+	if err != nil {
+		t.Fatalf("expected nil error for missing file, got %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil manifest for missing file, got %+v", got)
+	}
+}
+
+func TestWriteInstalledManifest_CreatesParentDir(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", ".ailloy", "installed.yaml")
+	m := &InstalledManifest{APIVersion: "v1"}
+	if err := WriteInstalledManifest(path, m); err != nil {
+		t.Fatalf("WriteInstalledManifest: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("file not created: %v", err)
+	}
+}

--- a/pkg/foundry/manifest_test.go
+++ b/pkg/foundry/manifest_test.go
@@ -84,3 +84,60 @@ func TestWriteInstalledManifest_CreatesParentDir(t *testing.T) {
 		t.Fatalf("file not created: %v", err)
 	}
 }
+
+func TestInstalledManifest_UpsertEntry(t *testing.T) {
+	m := &InstalledManifest{APIVersion: "v1"}
+
+	m.UpsertEntry(InstalledEntry{
+		Name:    "a",
+		Source:  "github.com/x/a",
+		Version: "v1.0.0",
+		Commit:  "aaa",
+	})
+	if len(m.Molds) != 1 {
+		t.Fatalf("expected 1 entry after first upsert, got %d", len(m.Molds))
+	}
+
+	m.UpsertEntry(InstalledEntry{
+		Name:    "a",
+		Source:  "github.com/x/a",
+		Version: "v1.1.0",
+		Commit:  "bbb",
+	})
+	if len(m.Molds) != 1 {
+		t.Fatalf("expected 1 entry after re-upsert, got %d", len(m.Molds))
+	}
+	if m.Molds[0].Version != "v1.1.0" || m.Molds[0].Commit != "bbb" {
+		t.Errorf("upsert did not replace existing entry: %+v", m.Molds[0])
+	}
+
+	m.UpsertEntry(InstalledEntry{
+		Name:    "b",
+		Source:  "github.com/x/b",
+		Version: "v0.1.0",
+		Commit:  "ccc",
+	})
+	if len(m.Molds) != 2 {
+		t.Fatalf("expected 2 entries after second source upsert, got %d", len(m.Molds))
+	}
+}
+
+func TestInstalledManifest_FindBySource(t *testing.T) {
+	m := &InstalledManifest{
+		APIVersion: "v1",
+		Molds: []InstalledEntry{
+			{Name: "a", Source: "github.com/x/a"},
+			{Name: "b", Source: "github.com/x/b"},
+		},
+	}
+	if got := m.FindBySource("github.com/x/b"); got == nil || got.Name != "b" {
+		t.Errorf("FindBySource(b) = %+v, want entry b", got)
+	}
+	if got := m.FindBySource("github.com/x/missing"); got != nil {
+		t.Errorf("FindBySource(missing) = %+v, want nil", got)
+	}
+	var nilM *InstalledManifest
+	if got := nilM.FindBySource("any"); got != nil {
+		t.Errorf("nil manifest FindBySource = %+v, want nil", got)
+	}
+}

--- a/pkg/foundry/manifest_test.go
+++ b/pkg/foundry/manifest_test.go
@@ -141,3 +141,38 @@ func TestInstalledManifest_FindBySource(t *testing.T) {
 		t.Errorf("nil manifest FindBySource = %+v, want nil", got)
 	}
 }
+
+func TestManifest_AbsentDoesNotBreakLockReads(t *testing.T) {
+	dir := t.TempDir()
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	// Pre-existing lock, no manifest — typical pre-upgrade state.
+	lock := &LockFile{
+		APIVersion: "v1",
+		Molds: []LockEntry{{
+			Name: "x", Source: "github.com/o/x", Version: "v1.0.0", Commit: "abc",
+			Timestamp: time.Now().UTC(),
+		}},
+	}
+	if err := WriteLockFile(LockFileName, lock); err != nil {
+		t.Fatal(err)
+	}
+
+	manifest, err := ReadInstalledManifest(InstalledManifestPath)
+	if err != nil {
+		t.Fatalf("ReadInstalledManifest should not error on missing file: %v", err)
+	}
+	if manifest != nil {
+		t.Errorf("expected nil manifest, got %+v", manifest)
+	}
+	if !shouldUseLock(LockFileName) {
+		t.Error("shouldUseLock should still be true when only lock exists")
+	}
+}

--- a/pkg/foundry/manifest_test.go
+++ b/pkg/foundry/manifest_test.go
@@ -54,6 +54,9 @@ func TestInstalledManifest_RoundTrip(t *testing.T) {
 	if e.Commit != "2347a626798553252668a15dc98dd020ab9a9c0c" {
 		t.Errorf("Commit = %q", e.Commit)
 	}
+	if !e.CastAt.Equal(ts) {
+		t.Errorf("CastAt = %v, want %v", e.CastAt, ts)
+	}
 	if loaded.Molds[1].Subpath != "sub/path" {
 		t.Errorf("Subpath = %q", loaded.Molds[1].Subpath)
 	}

--- a/pkg/foundry/uninstall.go
+++ b/pkg/foundry/uninstall.go
@@ -14,7 +14,7 @@ import (
 // UninstallOptions controls UninstallMold behavior.
 type UninstallOptions struct {
 	Force  bool // delete even if file content has been modified since cast
-	DryRun bool // report what would happen, don't touch disk or lockfile
+	DryRun bool // report what would happen, don't touch disk or manifest
 }
 
 // UninstallResult summarizes the outcome of an uninstall.
@@ -22,32 +22,38 @@ type UninstallResult struct {
 	Deleted         []string // files removed (or that would be removed in dry-run)
 	SkippedModified []string // files retained because user-modified (no --force)
 	NotFound        []string // files in manifest that didn't exist on disk
-	Retained        []string // files retained because shared with another lock entry
-	LegacyManifest  bool     // entry had no Files manifest (legacy lockfile)
+	Retained        []string // files retained because shared with another manifest entry
+	LegacyManifest  bool     // entry had no Files manifest (legacy install)
 }
 
-// ErrLegacyEntry is returned when the lock entry has no Files manifest.
-// Caller should re-cast the mold to backfill the manifest before retrying.
-var ErrLegacyEntry = errors.New("lock entry has no install manifest (legacy); re-cast the mold to enable safe uninstall")
+// ErrLegacyEntry is returned when the manifest entry has no Files list.
+// Caller should re-cast the mold to backfill the Files list before retrying.
+var ErrLegacyEntry = errors.New("manifest entry has no install file list (legacy); re-cast the mold to enable safe uninstall")
 
-// UninstallMold removes the files listed in a mold's lock entry, prunes any
-// now-empty parent directories, and removes the entry from the lockfile.
-// Files modified since cast (content hash differs) are skipped unless
-// opts.Force is set. Files claimed by another lock entry are retained.
-func UninstallMold(lockPath, source string, opts UninstallOptions) (UninstallResult, error) {
+// UninstallMold removes the files listed in a mold's installed-manifest entry,
+// prunes any now-empty parent directories, and removes the entry from the
+// manifest. If a lock file exists alongside the manifest, the matching lock
+// entry is also removed. Files modified since cast (content hash differs) are
+// skipped unless opts.Force is set. Files claimed by another manifest entry
+// are retained.
+//
+// manifestPath is the path to .ailloy/installed.yaml (project) or
+// ~/.ailloy/installed.yaml (global). The lock that mirrors it is derived by
+// looking for ailloy.lock alongside the manifest's containing directory.
+func UninstallMold(manifestPath, source string, opts UninstallOptions) (UninstallResult, error) {
 	var res UninstallResult
 
-	lock, err := ReadLockFile(lockPath)
+	m, err := ReadInstalledManifest(manifestPath)
 	if err != nil {
-		return res, fmt.Errorf("reading lock file: %w", err)
+		return res, fmt.Errorf("reading installed manifest: %w", err)
 	}
-	if lock == nil {
-		return res, fmt.Errorf("lock file %s does not exist", lockPath)
+	if m == nil {
+		return res, fmt.Errorf("installed manifest %s does not exist", manifestPath)
 	}
 
-	entry := lock.FindEntry(source)
+	entry := m.FindBySource(source)
 	if entry == nil {
-		return res, fmt.Errorf("no lock entry for source %q", source)
+		return res, fmt.Errorf("no installed manifest entry for source %q", source)
 	}
 
 	if entry.Files == nil {
@@ -57,16 +63,19 @@ func UninstallMold(lockPath, source string, opts UninstallOptions) (UninstallRes
 
 	// Build a set of paths claimed by other entries.
 	otherClaims := make(map[string]struct{})
-	for i := range lock.Molds {
-		if lock.Molds[i].Source == source {
+	for i := range m.Molds {
+		if m.Molds[i].Source == source {
 			continue
 		}
-		for _, f := range lock.Molds[i].Files {
+		for _, f := range m.Molds[i].Files {
 			otherClaims[f] = struct{}{}
 		}
 	}
 
-	lockDir := filepath.Dir(lockPath)
+	// Files in the manifest are stored relative to the manifest's *containing*
+	// project root — i.e., the directory above .ailloy/. This matches what
+	// cast.go records (rf.DestPath is project-relative).
+	rootDir := projectRootForManifest(manifestPath)
 	dirsTouched := make(map[string]struct{})
 
 	// Process files in reverse path order so deeper paths come first
@@ -80,7 +89,7 @@ func UninstallMold(lockPath, source string, opts UninstallOptions) (UninstallRes
 			continue
 		}
 
-		abs := filepath.Join(lockDir, filepath.FromSlash(rel))
+		abs := filepath.Join(rootDir, filepath.FromSlash(rel))
 
 		st, err := os.Stat(abs)
 		if err != nil {
@@ -132,27 +141,58 @@ func UninstallMold(lockPath, source string, opts UninstallOptions) (UninstallRes
 	}
 	sort.Sort(sort.Reverse(sort.StringSlice(dirs)))
 	for _, d := range dirs {
-		pruneEmptyDirs(d, lockDir)
+		pruneEmptyDirs(d, rootDir)
 	}
 
-	for i := range lock.Molds {
-		if lock.Molds[i].Source == source {
-			lock.Molds = append(lock.Molds[:i], lock.Molds[i+1:]...)
+	for i := range m.Molds {
+		if m.Molds[i].Source == source {
+			m.Molds = append(m.Molds[:i], m.Molds[i+1:]...)
 			break
 		}
 	}
-	if err := WriteLockFile(lockPath, lock); err != nil {
-		return res, fmt.Errorf("writing lock file: %w", err)
+	if err := WriteInstalledManifest(manifestPath, m); err != nil {
+		return res, fmt.Errorf("writing installed manifest: %w", err)
+	}
+
+	// Best-effort: also drop the matching lock entry if a lock exists alongside.
+	lockPath := filepath.Join(rootDir, LockFileName)
+	if lock, lerr := ReadLockFile(lockPath); lerr == nil && lock != nil {
+		dropped := false
+		for i := range lock.Molds {
+			if lock.Molds[i].Source == source {
+				lock.Molds = append(lock.Molds[:i], lock.Molds[i+1:]...)
+				dropped = true
+				break
+			}
+		}
+		if dropped {
+			_ = WriteLockFile(lockPath, lock)
+		}
 	}
 
 	return res, nil
+}
+
+// projectRootForManifest returns the directory that contains the manifest's
+// .ailloy/ subdirectory. Cast records files relative to this root.
+//
+// For ".ailloy/installed.yaml" we want "."; for "/home/u/.ailloy/installed.yaml"
+// we want "/home/u". The rule is: take the parent of the directory holding the
+// manifest file. If the manifest path doesn't follow the .ailloy/ convention,
+// fall back to the manifest's directory.
+func projectRootForManifest(manifestPath string) string {
+	dir := filepath.Dir(manifestPath)
+	if filepath.Base(dir) == ".ailloy" {
+		return filepath.Dir(dir)
+	}
+	return dir
 }
 
 func fileModifiedSinceCast(path, expectedHash string) (bool, error) {
 	if expectedHash == "" {
 		return true, nil
 	}
-	f, err := os.Open(path) // #nosec G304 -- uninstall reads files from a user-controlled lock manifest by design
+	f, err := os.Open(path) // #nosec G304 -- uninstall reads files from a user-controlled manifest by design
 	if err != nil {
 		return false, err
 	}

--- a/pkg/foundry/uninstall_test.go
+++ b/pkg/foundry/uninstall_test.go
@@ -24,29 +24,29 @@ func sha256Hex(content string) string {
 	return hex.EncodeToString(h[:])
 }
 
-func setupLock(t *testing.T, files []string, hashes map[string]string) string {
+func setupManifest(t *testing.T, files []string, hashes map[string]string) string {
 	t.Helper()
 	dir := t.TempDir()
 	t.Chdir(dir)
-	lockPath := filepath.Join(dir, "ailloy.lock")
-	lock := &LockFile{
+	manifestPath := filepath.Join(dir, ".ailloy", "installed.yaml")
+	m := &InstalledManifest{
 		APIVersion: "v1",
-		Molds: []LockEntry{
+		Molds: []InstalledEntry{
 			{
 				Name:       "test-mold",
 				Source:     "github.com/x/y",
 				Version:    "v1",
 				Commit:     "c1",
-				Timestamp:  time.Now().UTC(),
+				CastAt:     time.Now().UTC(),
 				Files:      files,
 				FileHashes: hashes,
 			},
 		},
 	}
-	if err := WriteLockFile(lockPath, lock); err != nil {
+	if err := WriteInstalledManifest(manifestPath, m); err != nil {
 		t.Fatal(err)
 	}
-	return lockPath
+	return manifestPath
 }
 
 func TestUninstallMold_Clean(t *testing.T) {
@@ -54,11 +54,11 @@ func TestUninstallMold_Clean(t *testing.T) {
 		"agents.md":     sha256Hex("hello"),
 		"skills/x/y.md": sha256Hex("world"),
 	}
-	lockPath := setupLock(t, []string{"agents.md", "skills/x/y.md"}, hashes)
+	manifestPath := setupManifest(t, []string{"agents.md", "skills/x/y.md"}, hashes)
 	writeFileT(t, "agents.md", "hello")
 	writeFileT(t, "skills/x/y.md", "world")
 
-	res, err := UninstallMold(lockPath, "github.com/x/y", UninstallOptions{})
+	res, err := UninstallMold(manifestPath, "github.com/x/y", UninstallOptions{})
 	if err != nil {
 		t.Fatalf("UninstallMold: %v", err)
 	}
@@ -72,18 +72,18 @@ func TestUninstallMold_Clean(t *testing.T) {
 		t.Error("empty skills/ dir not pruned")
 	}
 
-	loaded, _ := ReadLockFile(lockPath)
+	loaded, _ := ReadInstalledManifest(manifestPath)
 	if len(loaded.Molds) != 0 {
-		t.Errorf("entry not removed from lockfile, got %d", len(loaded.Molds))
+		t.Errorf("entry not removed from manifest, got %d", len(loaded.Molds))
 	}
 }
 
 func TestUninstallMold_ModifiedFile_Skipped(t *testing.T) {
 	hashes := map[string]string{"agents.md": sha256Hex("original content")}
-	lockPath := setupLock(t, []string{"agents.md"}, hashes)
+	manifestPath := setupManifest(t, []string{"agents.md"}, hashes)
 	writeFileT(t, "agents.md", "modified content")
 
-	res, err := UninstallMold(lockPath, "github.com/x/y", UninstallOptions{})
+	res, err := UninstallMold(manifestPath, "github.com/x/y", UninstallOptions{})
 	if err != nil {
 		t.Fatalf("UninstallMold: %v", err)
 	}
@@ -97,10 +97,10 @@ func TestUninstallMold_ModifiedFile_Skipped(t *testing.T) {
 
 func TestUninstallMold_ModifiedFile_Force(t *testing.T) {
 	hashes := map[string]string{"agents.md": sha256Hex("original")}
-	lockPath := setupLock(t, []string{"agents.md"}, hashes)
+	manifestPath := setupManifest(t, []string{"agents.md"}, hashes)
 	writeFileT(t, "agents.md", "modified")
 
-	res, err := UninstallMold(lockPath, "github.com/x/y", UninstallOptions{Force: true})
+	res, err := UninstallMold(manifestPath, "github.com/x/y", UninstallOptions{Force: true})
 	if err != nil {
 		t.Fatalf("UninstallMold: %v", err)
 	}
@@ -111,9 +111,9 @@ func TestUninstallMold_ModifiedFile_Force(t *testing.T) {
 
 func TestUninstallMold_Missing(t *testing.T) {
 	hashes := map[string]string{"agents.md": sha256Hex("anything")}
-	lockPath := setupLock(t, []string{"agents.md"}, hashes)
+	manifestPath := setupManifest(t, []string{"agents.md"}, hashes)
 
-	res, err := UninstallMold(lockPath, "github.com/x/y", UninstallOptions{})
+	res, err := UninstallMold(manifestPath, "github.com/x/y", UninstallOptions{})
 	if err != nil {
 		t.Fatalf("UninstallMold: %v", err)
 	}
@@ -124,10 +124,10 @@ func TestUninstallMold_Missing(t *testing.T) {
 
 func TestUninstallMold_DryRun(t *testing.T) {
 	hashes := map[string]string{"agents.md": sha256Hex("x")}
-	lockPath := setupLock(t, []string{"agents.md"}, hashes)
+	manifestPath := setupManifest(t, []string{"agents.md"}, hashes)
 	writeFileT(t, "agents.md", "x")
 
-	res, err := UninstallMold(lockPath, "github.com/x/y", UninstallOptions{DryRun: true})
+	res, err := UninstallMold(manifestPath, "github.com/x/y", UninstallOptions{DryRun: true})
 	if err != nil {
 		t.Fatalf("UninstallMold: %v", err)
 	}
@@ -137,30 +137,30 @@ func TestUninstallMold_DryRun(t *testing.T) {
 	if _, err := os.Stat("agents.md"); err != nil {
 		t.Error("dry-run should NOT remove the file")
 	}
-	loaded, _ := ReadLockFile(lockPath)
+	loaded, _ := ReadInstalledManifest(manifestPath)
 	if len(loaded.Molds) != 1 {
-		t.Error("dry-run should NOT modify the lockfile")
+		t.Error("dry-run should NOT modify the manifest")
 	}
 }
 
 func TestUninstallMold_SharedFile_Retained(t *testing.T) {
 	hash := sha256Hex("shared")
 	hashes := map[string]string{"agents.md": hash}
-	lockPath := setupLock(t, []string{"agents.md"}, hashes)
+	manifestPath := setupManifest(t, []string{"agents.md"}, hashes)
 	writeFileT(t, "agents.md", "shared")
 
-	lock, _ := ReadLockFile(lockPath)
-	lock.Molds = append(lock.Molds, LockEntry{
+	m, _ := ReadInstalledManifest(manifestPath)
+	m.Molds = append(m.Molds, InstalledEntry{
 		Name:       "other",
 		Source:     "github.com/x/other",
 		Files:      []string{"agents.md"},
 		FileHashes: map[string]string{"agents.md": hash},
 	})
-	if err := WriteLockFile(lockPath, lock); err != nil {
+	if err := WriteInstalledManifest(manifestPath, m); err != nil {
 		t.Fatal(err)
 	}
 
-	res, err := UninstallMold(lockPath, "github.com/x/y", UninstallOptions{})
+	res, err := UninstallMold(manifestPath, "github.com/x/y", UninstallOptions{})
 	if err != nil {
 		t.Fatalf("UninstallMold: %v", err)
 	}
@@ -176,22 +176,50 @@ func TestUninstallMold_LegacyEntry_NoFiles(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
 
-	lockPath := filepath.Join(dir, "ailloy.lock")
-	lock := &LockFile{
+	manifestPath := filepath.Join(dir, ".ailloy", "installed.yaml")
+	m := &InstalledManifest{
 		APIVersion: "v1",
-		Molds: []LockEntry{
+		Molds: []InstalledEntry{
 			{Name: "legacy", Source: "github.com/x/y", Version: "v1", Commit: "c1"},
 		},
 	}
-	if err := WriteLockFile(lockPath, lock); err != nil {
+	if err := WriteInstalledManifest(manifestPath, m); err != nil {
 		t.Fatal(err)
 	}
 
-	res, err := UninstallMold(lockPath, "github.com/x/y", UninstallOptions{})
+	res, err := UninstallMold(manifestPath, "github.com/x/y", UninstallOptions{})
 	if err == nil {
 		t.Fatal("expected ErrLegacyEntry")
 	}
 	if !res.LegacyManifest {
 		t.Errorf("expected LegacyManifest=true, got %+v", res)
+	}
+}
+
+// Pre-existing project with both manifest and lock — uninstall should remove
+// the entry from both.
+func TestUninstallMold_DropsLockEntryToo(t *testing.T) {
+	hashes := map[string]string{"agents.md": sha256Hex("x")}
+	manifestPath := setupManifest(t, []string{"agents.md"}, hashes)
+	writeFileT(t, "agents.md", "x")
+
+	// Cwd is the project root; LockFileName resolves there. Seed the lock.
+	lock := &LockFile{
+		APIVersion: "v1",
+		Molds: []LockEntry{
+			{Name: "test-mold", Source: "github.com/x/y", Version: "v1", Commit: "c1", Timestamp: time.Now().UTC()},
+			{Name: "other", Source: "github.com/x/other", Version: "v1", Commit: "c2", Timestamp: time.Now().UTC()},
+		},
+	}
+	if err := WriteLockFile(LockFileName, lock); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := UninstallMold(manifestPath, "github.com/x/y", UninstallOptions{}); err != nil {
+		t.Fatalf("UninstallMold: %v", err)
+	}
+	loaded, _ := ReadLockFile(LockFileName)
+	if loaded == nil || len(loaded.Molds) != 1 || loaded.Molds[0].Source != "github.com/x/other" {
+		t.Errorf("lock entry not cleaned up: %+v", loaded)
 	}
 }


### PR DESCRIPTION
## Summary

Make \`ailloy.lock\` an opt-in feature. Cast on a fresh project no longer creates the file. To opt in, users run \`ailloy quench\` — it reads \`.ailloy/installed.yaml\` (a new always-on provenance manifest written by \`cast\` and \`ingot add\`) and creates \`ailloy.lock\` pinning everything. Once the lock exists, \`cast\` / \`ingot add\` / \`recast\` keep it in sync automatically.

This addresses the long-standing pain of \`ailloy.lock\` appearing unexpectedly in projects after a single \`cast\`, and the resulting timestamp-churn commits (\"refresh ailloy.lock timestamp from test run\") that have been polluting history.

## Design

Two files, two roles:

| File | Behavior |
|---|---|
| \`.ailloy/installed.yaml\` | Always written by \`cast\` and \`ingot add\`. Records provenance (name, source, version, commit, castAt). Source of truth for \`recast\` and \`quench\`. |
| \`ailloy.lock\` | Opt-in. Created only by \`ailloy quench\`. Once it exists, kept up to date automatically. |

Lock reads and writes are gated on file presence (\`shouldUseLock\` checks \`os.Stat\`). \`Resolve\` never creates the lock — only \`quench\` does.

Provenance/integrity comes from git's content-addressable store: the lock pins commit SHAs, and git refuses to fetch any object whose bytes don't hash to the requested SHA. This protects against force-pushed tags and host-level tampering. Local customization of rendered blanks is supported by design — \`quench --verify\` only checks manifest↔lock commit consistency, not on-disk file hashes.

## CLI Changes

| Command | New behavior |
|---|---|
| \`ailloy cast <ref>\` | Always writes manifest. Updates lock only if it already exists. \`--global\` operates on \`~/\` paths. |
| \`ailloy ingot add <ref>\` | Same manifest behavior as cast. |
| \`ailloy quench\` | New: pins everything in the manifest into a fresh \`ailloy.lock\`. |
| \`ailloy quench <ref>\` | New: pins one mold (requires existing lock). |
| \`ailloy quench --verify\` | New: CI-friendly drift check, exits non-zero on manifest↔lock mismatch. |
| \`ailloy quench -g/--global\` | New: operate on \`~/.ailloy/installed.yaml\` and \`~/ailloy.lock\`. |
| \`ailloy recast\` | Now drives off the manifest (not the lock). Updates lock only if present. New \`-g/--global\` flag. |

## Migration

| Pre-upgrade state | Post-upgrade behavior |
|---|---|
| \`ailloy.lock\` present, no manifest | Lock continues to be honored and updated. Next \`cast\` seeds the manifest. (Verified by \`TestManifest_AbsentDoesNotBreakLockReads\`.) |
| No lock, no manifest | Cast writes manifest; no lock created. |
| No lock, rendered blanks from previous cast | First post-upgrade \`cast\` of any mold seeds the manifest for that mold. Other previously-cast molds are invisible until re-cast. |

Also removes the orphaned \`internal/commands/ailloy.lock\` test artifact that has been generating timestamp-refresh commits — with lock-opt-in it's no longer touched by any test.

## Test plan

- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`go vet ./...\` — clean
- [x] \`go test -race ./...\` — all packages pass
- [x] Manual smoke: fresh project → cast creates manifest, no lock
- [x] Manual smoke: \`quench\` creates lock; \`quench --verify\` exits 0
- [x] Manual smoke: \`recast\` no-ops when up to date; verify still passes
- [x] Manual smoke: legacy project (lock present, no manifest) → lock honored at old version, manifest seeded

## Public API additions (\`pkg/foundry\`)

- \`InstalledManifest\`, \`InstalledEntry\`, \`InstalledManifestPath\`
- \`ReadInstalledManifest\`, \`WriteInstalledManifest\`
- \`(*InstalledManifest).UpsertEntry\` / \`FindBySource\` / \`FindByName\`
- \`ResolveResult\`, \`ResolveWithMetadata\`
- \`WithLockPath(path)\` (replaces removed \`WithoutLock()\`)

## Future work (not in this PR)

- Recast preserving local customizations via 3-way diff (rebase-style UX).
- Publisher signing for upstream supply-chain integrity.
- A real \`--rescan\` implementation (the placeholder flag was removed from this PR rather than ship a no-op).