### PR TITLE
feat: nested foundries — transitive mold aggregation across foundry indexes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ Thumbs.db
 .flox/cache/
 .flox/log/
 .flox/run/
+
+# Local agent working artifacts (specs/plans from superpowers brainstorming/writing-plans)
+docs/superpowers/

--- a/docs/cast-claude-plugin.md
+++ b/docs/cast-claude-plugin.md
@@ -77,7 +77,7 @@ Re-running cast against an existing plugin replaces the contents of that single 
 
 ## Bulk install: every mold in a foundry as a plugin
 
-`ailloy foundry install <name|url> --claude-plugin` installs every mold listed by a foundry as its own Claude Code plugin. Each plugin lands at `.claude/plugins/<slug>/` (or `~/.claude/plugins/<slug>/` with `--global`), named after the mold.
+`ailloy foundry install <name|url> --claude-plugin` installs every mold listed by a foundry as its own Claude Code plugin, including molds pulled in transitively through nested foundries. Each plugin lands at `.claude/plugins/<slug>/` (or `~/.claude/plugins/<slug>/` with `--global`), named after the mold. Pass `--shallow` to skip nested foundries and install only the named foundry's direct molds.
 
 ```bash
 # Install every mold from the verified default foundry as plugins

--- a/docs/foundry.md
+++ b/docs/foundry.md
@@ -143,6 +143,8 @@ ailloy foundry search blueprint --github-only
 
 Results from registered indexes appear first, followed by GitHub Topics results. Duplicates (same source) are collapsed, preferring the index entry.
 
+Mold names from registered indexes are namespaced as `<foundry-name>/<mold-name>`, and nested-foundry molds show their resolution chain in the origin column (e.g., `index:nimble-giant via nimble-giant → replicated`). See [Nested Foundries](#nested-foundries) below.
+
 ### Making Your Mold Discoverable
 
 To make your mold appear in GitHub Topics search results, add the `ailloy-mold` topic to your GitHub repository:
@@ -173,8 +175,11 @@ ailloy foundry list
 ailloy foundry update
 
 # Cast every mold listed by a foundry (alias: cast-all)
+# Walks nested foundries transitively — pulls in molds from any
+# foundries that the named foundry references in its `foundries:` field.
 # Skips molds already in the target lockfile unless --force.
-# Supports -g/--global, --with-workflows, --dry-run, --force, --claude-plugin.
+# Pass --shallow to install only the named foundry's direct molds.
+# Supports -g/--global, --with-workflows, --dry-run, --force, --claude-plugin, --shallow.
 ailloy foundry install foundry
 
 # Install every mold from a foundry as Claude Code plugins
@@ -304,6 +309,10 @@ molds:
     source: github.com/my-org/mold
     description: "AI workflow blanks"
     tags: ["workflows", "claude"]
+foundries:
+  - name: child-foundry
+    source: github.com/my-org/another-foundry
+    description: "Nested foundry pulled in transitively"
 ```
 
 ### Fields
@@ -320,6 +329,9 @@ molds:
 | `molds[].source` | Yes | Mold source reference (`host/owner/repo`) |
 | `molds[].description` | No | Short description for search results |
 | `molds[].tags` | No | Searchable tags/categories |
+| `foundries[].name` | No | Display label for the nested foundry (informational) |
+| `foundries[].source` | Yes | Source URL of the nested foundry index |
+| `foundries[].description` | No | Short description |
 
 ### Hosting a Foundry Index
 
@@ -342,6 +354,59 @@ To add your mold to the official Ailloy foundry index:
 1. Fork the official index repository
 2. Add your mold entry to `foundry.yaml`
 3. Submit a pull request with a description of your mold
+
+If you maintain your own foundry with multiple molds, contributing it as a single nested-foundry entry is usually preferable to per-mold entries — see the next section.
+
+## Nested Foundries
+
+A foundry can list other foundries under a top-level `foundries:` field. When a parent foundry is fetched, every child foundry it lists is resolved transitively, and all the children's molds become discoverable, searchable, and installable through the parent.
+
+This means a foundry author who wants their molds surfaced through the official `nimble-giant/foundry` only needs to add a single entry — once — pointing at their own foundry. Every mold they add to their own foundry afterwards flows into the official one automatically the next time someone runs `ailloy foundry update`. No more per-mold PRs into the parent.
+
+### Schema
+
+Add a `foundries:` block to a `foundry.yaml`:
+
+```yaml
+apiVersion: v1
+kind: foundry-index
+name: nimble-giant
+molds:
+  - name: my-direct-mold
+    source: github.com/nimble-giant/my-direct-mold
+foundries:
+  - name: replicated
+    source: github.com/kriscoleman/replicated-foundry
+    description: "Kris's molds"
+```
+
+### Behavior
+
+- **Transitive by default.** `ailloy foundry search`, `ailloy foundry list`, `ailloy foundry update`, and `ailloy foundry install` all walk children automatically.
+- **Mold names are namespaced.** Every mold from a registered foundry appears in search and install output as `<foundry-name>/<mold-name>`. The foundry name comes from the `name:` field of the foundry that *owns* the mold (the immediate parent, not the root).
+- **Resolution chain is shown.** Search results for nested molds include a `via parent → child` annotation so it's clear which root surfaced them. `ailloy foundry list` prints a tree view of nested foundries beneath each registered root.
+- **Cycles are silently broken.** If foundry A lists B, and B lists A back, the visited-set short-circuits — no infinite loop, no warning.
+- **Diamond resolution is deduplicated.** A child reachable from two parents is fetched once and its molds appear once.
+- **Child fetch failures degrade gracefully.** If a nested foundry is unreachable, the parent's resolution still succeeds; `ailloy foundry update` prints a warning per failed child.
+- **Foundry-name collisions are fatal.** If two distinct source URLs in the resolved tree declare the same `name:` field, resolution errors out with both source URLs in the message — the upstream conflict must be fixed.
+
+### Opting out (`--shallow`)
+
+`ailloy foundry install --shallow <name>` casts only the named foundry's direct molds, skipping nested ones. Useful when you want only what a parent maintainer has authored themselves and not the transitively-aggregated set.
+
+```bash
+# Install everything the official foundry transitively aggregates (default)
+ailloy foundry install foundry
+
+# Install only the official foundry's own direct molds
+ailloy foundry install foundry --shallow
+```
+
+If you `--shallow` install a foundry that has only a `foundries:` block and no direct `molds:`, the CLI prints a hint that the foundry is acting purely as an aggregator and tells you to drop `--shallow`.
+
+### Cache implications
+
+`ailloy foundry update` walks every nested foundry and writes each one's `foundry.yaml` into the on-disk cache. `ailloy foundry search` reads from that cache, so running `update` periodically keeps offline search fast and complete. If a search hits a child that hasn't been cached yet, it falls back to a one-off network fetch transparently.
 
 ## Downloading Without Installing
 
@@ -593,3 +658,4 @@ Remote mold references work with all mold-consuming commands:
 | `foundry list` | `ailloy foundry list`                                                     |
 | `foundry remove` | `ailloy foundry remove nimble-foundry`                              |
 | `foundry update` | `ailloy foundry update`                                             |
+| `foundry install` | `ailloy foundry install foundry` or `ailloy foundry install foundry --shallow` |

--- a/internal/commands/foundry.go
+++ b/internal/commands/foundry.go
@@ -329,6 +329,10 @@ func runFoundryUpdate(_ *cobra.Command, _ []string) error {
 		}
 		fmt.Println(" " + styles.SuccessStyle.Render("ok") +
 			styles.SubtleStyle.Render(fmt.Sprintf(" (%d molds)", r.MoldCount)))
+		for _, w := range r.Warnings {
+			fmt.Println(styles.SubtleStyle.Render(
+				fmt.Sprintf("    warning: nested foundry %q failed: %v", w.Source, w.Err)))
+		}
 	}
 
 	if err := index.SaveConfig(cfg); err != nil {

--- a/internal/commands/foundry.go
+++ b/internal/commands/foundry.go
@@ -408,8 +408,21 @@ func runFoundryInstall(_ *cobra.Command, args []string) error {
 		skipped   int
 		failed    int
 	)
+	lastFnd := "\x00" // sentinel so the first iteration always prints a header
 	for _, r := range reports {
-		fmt.Printf("  %s", styles.AccentStyle.Render(r.Name))
+		if r.Foundry != lastFnd {
+			if lastFnd != "\x00" {
+				fmt.Println()
+			}
+			header := "Installing from " + styles.AccentStyle.Render(r.Foundry)
+			if len(r.Chain) > 0 {
+				header += styles.SubtleStyle.Render(" (via " + strings.Join(r.Chain, " → ") + ")")
+			}
+			fmt.Println(header)
+			lastFnd = r.Foundry
+		}
+		display := r.Foundry + "/" + r.Name
+		fmt.Printf("  %s", styles.AccentStyle.Render(display))
 		switch {
 		case r.Err != nil:
 			failed++
@@ -428,6 +441,12 @@ func runFoundryInstall(_ *cobra.Command, args []string) error {
 			installed++
 			fmt.Println(" " + styles.SuccessStyle.Render("ok"))
 		}
+	}
+
+	if len(reports) == 0 && foundryInstallShallow {
+		fmt.Println(styles.InfoStyle.Render("Nothing to install — this foundry only aggregates nested foundries."))
+		fmt.Println(styles.SubtleStyle.Render("Drop --shallow to install transitively."))
+		return nil
 	}
 
 	fmt.Println()

--- a/internal/commands/foundry.go
+++ b/internal/commands/foundry.go
@@ -84,6 +84,7 @@ var (
 	foundryInstallDryRun        bool
 	foundryInstallForce         bool
 	foundryInstallClaudePlugin  bool
+	foundryInstallShallow       bool
 )
 
 var foundryInstallCmd = &cobra.Command{
@@ -117,6 +118,7 @@ func init() {
 	foundryInstallCmd.Flags().BoolVar(&foundryInstallDryRun, "dry-run", false, "list what would be installed without casting")
 	foundryInstallCmd.Flags().BoolVar(&foundryInstallForce, "force", false, "re-cast molds that are already installed")
 	foundryInstallCmd.Flags().BoolVar(&foundryInstallClaudePlugin, "claude-plugin", false, "package each mold as a Claude Code plugin under .claude/plugins/<slug>/")
+	foundryInstallCmd.Flags().BoolVar(&foundryInstallShallow, "shallow", false, "install only the named foundry's direct molds (skip nested foundries)")
 }
 
 func runFoundrySearch(_ *cobra.Command, args []string) error {
@@ -395,6 +397,7 @@ func runFoundryInstall(_ *cobra.Command, args []string) error {
 		DryRun:        foundryInstallDryRun,
 		Force:         foundryInstallForce,
 		ClaudePlugin:  foundryInstallClaudePlugin,
+		Shallow:       foundryInstallShallow,
 	})
 	if err != nil {
 		return err

--- a/internal/commands/foundry.go
+++ b/internal/commands/foundry.go
@@ -225,6 +225,13 @@ func runFoundryList(_ *cobra.Command, _ []string) error {
 	fmt.Println(styles.HeaderStyle.Render(fmt.Sprintf("Registered foundries (%d):", len(foundries))))
 	fmt.Println()
 
+	cacheDir, _ := index.IndexCacheDir()
+	fetcher, _ := index.NewFetcher(defaultGitRunner())
+	var lookup index.IndexLookup
+	if cacheDir != "" && fetcher != nil {
+		lookup = index.CacheFirstLookup(cacheDir, fetcher)
+	}
+
 	for _, entry := range foundries {
 		name := styles.AccentStyle.Render(entry.Name)
 		if index.IsOfficialFoundry(entry.URL) {
@@ -240,10 +247,33 @@ func runFoundryList(_ *cobra.Command, _ []string) error {
 		fmt.Println(styles.SubtleStyle.Render(fmt.Sprintf("    URL:     %s", entry.URL)))
 		fmt.Println(styles.SubtleStyle.Render(fmt.Sprintf("    Type:    %s", entry.Type)))
 		fmt.Println(styles.SubtleStyle.Render(fmt.Sprintf("    Updated: %s", lastUpdated)))
+
+		// Render nested-foundry tree if any. Skip silently when the index
+		// can't be resolved (offline / not cached / no children).
+		if lookup != nil {
+			r := index.NewResolver(lookup)
+			root, _, err := r.Resolve(entry.URL)
+			if err == nil && len(root.Children) > 0 {
+				fmt.Println(styles.SubtleStyle.Render("    Nested foundries:"))
+				for _, child := range root.Children {
+					printFoundryTree(child, "      ")
+				}
+			}
+		}
+
 		fmt.Println()
 	}
 
 	return nil
+}
+
+// printFoundryTree recursively prints a child foundry node and its descendants.
+func printFoundryTree(node *index.ResolvedFoundry, indent string) {
+	line := fmt.Sprintf("%s└─ %s (%s)", indent, node.Index.Name, node.Source)
+	fmt.Println(styles.SubtleStyle.Render(line))
+	for _, c := range node.Children {
+		printFoundryTree(c, indent+"   ")
+	}
 }
 
 func runFoundryRemove(_ *cobra.Command, args []string) error {

--- a/internal/commands/foundry_core.go
+++ b/internal/commands/foundry_core.go
@@ -128,15 +128,18 @@ type InstallFoundryOptions struct {
 	DryRun        bool // report what would be installed; don't touch disk
 	Force         bool // re-cast even if already installed in the target lockfile
 	ClaudePlugin  bool // package each mold as a Claude Code plugin
+	Shallow       bool // install only the root foundry's molds; skip nested foundries
 }
 
 // InstallFoundryReport is the per-mold result of an InstallFoundryCore run.
 type InstallFoundryReport struct {
 	Name    string
 	Source  string
-	Skipped bool   // true when already installed and !Force
-	Err     error  // non-nil if cast failed for this mold
-	Version string // populated on success or skip (from CastResult / lockfile)
+	Foundry string   // owning foundry name (e.g., "replicated")
+	Chain   []string // resolution chain from root to owning foundry, excluding owner ([] when root-owned)
+	Skipped bool     // true when already installed and !Force
+	Err     error    // non-nil if cast failed for this mold
+	Version string   // populated on success or skip (from CastResult / lockfile)
 }
 
 // ErrFoundryNotFound is returned when nameOrURL doesn't match any effective
@@ -168,21 +171,28 @@ func InstallFoundryCore(ctx context.Context, cfg *index.Config, nameOrURL string
 		return nil, fmt.Errorf("%w: %q", ErrFoundryNotFound, nameOrURL)
 	}
 
-	idx, err := index.LoadCachedIndex(cacheDir, match)
+	fetcher, ferr := index.NewFetcher(defaultGitRunner())
+	if ferr != nil {
+		return nil, ferr
+	}
+	lookup := index.CacheFirstLookup(cacheDir, fetcher)
+
+	r := index.NewResolver(lookup)
+	root, allMolds, err := r.Resolve(match.URL)
 	if err != nil {
-		// Try to populate the cache once before giving up.
-		git := defaultGitRunner()
-		fetcher, ferr := index.NewFetcher(git)
-		if ferr != nil {
-			return nil, fmt.Errorf("loading cached index for %s: %w", match.Name, err)
+		return nil, fmt.Errorf("resolving foundry %s: %w", match.Name, err)
+	}
+
+	// Build the working set of molds to install.
+	var molds []index.ResolvedMold
+	if opts.Shallow {
+		for _, m := range allMolds {
+			if m.Foundry == root {
+				molds = append(molds, m)
+			}
 		}
-		if _, fetchErr := fetcher.FetchIndex(match); fetchErr != nil {
-			return nil, fmt.Errorf("fetching foundry index %s: %w", match.Name, fetchErr)
-		}
-		idx, err = index.LoadCachedIndex(cacheDir, match)
-		if err != nil {
-			return nil, fmt.Errorf("loading cached index for %s: %w", match.Name, err)
-		}
+	} else {
+		molds = allMolds
 	}
 
 	// Read target lockfile to spot already-installed sources.
@@ -199,11 +209,17 @@ func InstallFoundryCore(ctx context.Context, cfg *index.Config, nameOrURL string
 		}
 	}
 
-	out := make([]InstallFoundryReport, 0, len(idx.Molds))
-	for _, m := range idx.Molds {
-		report := InstallFoundryReport{Name: m.Name, Source: m.Source}
+	out := make([]InstallFoundryReport, 0, len(molds))
+	for _, m := range molds {
+		chain := append([]string(nil), m.Foundry.Parents...)
+		report := InstallFoundryReport{
+			Name:    m.Entry.Name,
+			Source:  m.Entry.Source,
+			Foundry: m.Foundry.Index.Name,
+			Chain:   chain,
+		}
 
-		if v, already := installed[strings.ToLower(m.Source)]; already && !opts.Force {
+		if v, already := installed[strings.ToLower(m.Entry.Source)]; already && !opts.Force {
 			report.Skipped = true
 			report.Version = v
 			out = append(out, report)
@@ -214,7 +230,7 @@ func InstallFoundryCore(ctx context.Context, cfg *index.Config, nameOrURL string
 			continue
 		}
 
-		castRes, cerr := CastMold(ctx, m.Source, CastOptions{
+		castRes, cerr := CastMold(ctx, m.Entry.Source, CastOptions{
 			Global:        opts.Global,
 			WithWorkflows: opts.WithWorkflows,
 			ClaudePlugin:  opts.ClaudePlugin,
@@ -222,7 +238,7 @@ func InstallFoundryCore(ctx context.Context, cfg *index.Config, nameOrURL string
 		if cerr != nil {
 			report.Err = cerr
 		} else {
-			report.Version = castRes.MoldName // best-effort; real version sits in lockfile
+			report.Version = castRes.MoldName
 		}
 		out = append(out, report)
 	}

--- a/internal/commands/foundry_core.go
+++ b/internal/commands/foundry_core.go
@@ -84,6 +84,7 @@ type UpdateFoundryReport struct {
 	MoldCount int
 	Persisted bool // false for the virtual default
 	Err       error
+	Warnings  []index.ResolutionWarning
 }
 
 // UpdateFoundriesCore fetches every effective foundry, persists status/timestamp
@@ -129,6 +130,7 @@ func UpdateFoundriesCore(cfg *index.Config) ([]UpdateFoundryReport, error) {
 			continue
 		}
 		report.MoldCount = len(root.Index.Molds)
+		report.Warnings = r.Warnings()
 
 		// Mirror the metadata Fetcher would have set on a direct call.
 		t.entry.LastUpdated = time.Now().UTC()

--- a/internal/commands/foundry_core.go
+++ b/internal/commands/foundry_core.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/nimble-giant/ailloy/pkg/foundry"
 	"github.com/nimble-giant/ailloy/pkg/foundry/index"
@@ -107,15 +108,32 @@ func UpdateFoundriesCore(cfg *index.Config) ([]UpdateFoundryReport, error) {
 		targets = append([]target{{entry: &official, persisted: false}}, targets...)
 	}
 
+	// Network-only lookup. Fetcher writes each fetched index to disk on
+	// success, so resolving the tree also populates the on-disk cache that
+	// `foundry search` reads from.
+	networkLookup := func(source string) (*index.Index, error) {
+		url := index.NormalizeFoundryURL(source)
+		entry := &index.FoundryEntry{URL: url, Type: index.DetectType(url)}
+		return fetcher.FetchIndex(entry)
+	}
+
 	out := make([]UpdateFoundryReport, 0, len(targets))
 	for _, t := range targets {
 		report := UpdateFoundryReport{Name: t.entry.Name, URL: t.entry.URL, Persisted: t.persisted}
-		idx, err := fetcher.FetchIndex(t.entry)
-		if err != nil {
-			report.Err = err
-		} else {
-			report.MoldCount = len(idx.Molds)
+
+		r := index.NewResolver(networkLookup)
+		root, _, rerr := r.Resolve(t.entry.URL)
+		if rerr != nil {
+			report.Err = rerr
+			out = append(out, report)
+			continue
 		}
+		report.MoldCount = len(root.Index.Molds)
+
+		// Mirror the metadata Fetcher would have set on a direct call.
+		t.entry.LastUpdated = time.Now().UTC()
+		t.entry.Status = "ok"
+
 		out = append(out, report)
 	}
 	return out, nil

--- a/internal/commands/foundry_core_test.go
+++ b/internal/commands/foundry_core_test.go
@@ -1,0 +1,64 @@
+package commands
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nimble-giant/ailloy/pkg/foundry/index"
+)
+
+// TestInstallFoundryCoreShallow verifies --shallow restricts to root molds.
+// It uses --dry-run to avoid invoking CastMold, and seeds a temp cache with
+// a parent foundry that references a (non-existent) child URL — the child
+// fetch fails and the resolver downgrades it to a warning, so the parent
+// still resolves successfully and we only see the parent's own molds.
+func TestInstallFoundryCoreShallow(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("AILLOY_INDEX_CACHE_DIR", tmp)
+
+	parentURL := "https://github.com/example/parent"
+	parentEntry := &index.FoundryEntry{URL: parentURL, Type: "git"}
+	parentDir := index.CachedIndexDir(tmp, parentEntry)
+	if err := os.MkdirAll(parentDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	parentYAML := []byte(`apiVersion: v1
+kind: foundry-index
+name: parent
+molds:
+  - name: alpha
+    source: github.com/x/alpha
+foundries:
+  - name: missing
+    source: github.com/example/missing
+`)
+	if err := os.WriteFile(filepath.Join(parentDir, "foundry.yaml"), parentYAML, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &index.Config{
+		Foundries: []index.FoundryEntry{{Name: "parent", URL: parentURL, Type: "git", Status: "ok"}},
+	}
+
+	reports, err := InstallFoundryCore(context.Background(), cfg, "parent", InstallFoundryOptions{
+		DryRun:  true,
+		Shallow: true,
+	})
+	if err != nil {
+		t.Fatalf("InstallFoundryCore: %v", err)
+	}
+	if len(reports) != 1 {
+		t.Fatalf("got %d reports, want 1", len(reports))
+	}
+	if reports[0].Name != "alpha" {
+		t.Errorf("reports[0].Name = %q, want alpha", reports[0].Name)
+	}
+	if reports[0].Foundry != "parent" {
+		t.Errorf("reports[0].Foundry = %q, want parent", reports[0].Foundry)
+	}
+	if len(reports[0].Chain) != 0 {
+		t.Errorf("reports[0].Chain = %v, want empty (root-owned)", reports[0].Chain)
+	}
+}

--- a/pkg/foundry/index/index.go
+++ b/pkg/foundry/index/index.go
@@ -9,12 +9,13 @@ import (
 
 // Index represents a parsed foundry.yaml index manifest.
 type Index struct {
-	APIVersion  string      `yaml:"apiVersion"`
-	Kind        string      `yaml:"kind"`
-	Name        string      `yaml:"name"`
-	Description string      `yaml:"description,omitempty"`
-	Author      Author      `yaml:"author,omitempty"`
-	Molds       []MoldEntry `yaml:"molds"`
+	APIVersion  string       `yaml:"apiVersion"`
+	Kind        string       `yaml:"kind"`
+	Name        string       `yaml:"name"`
+	Description string       `yaml:"description,omitempty"`
+	Author      Author       `yaml:"author,omitempty"`
+	Molds       []MoldEntry  `yaml:"molds"`
+	Foundries   []FoundryRef `yaml:"foundries,omitempty"`
 }
 
 // Author represents the author of a foundry index.
@@ -29,6 +30,15 @@ type MoldEntry struct {
 	Source      string   `yaml:"source"`
 	Description string   `yaml:"description,omitempty"`
 	Tags        []string `yaml:"tags,omitempty"`
+}
+
+// FoundryRef is a reference from one foundry to another nested foundry.
+// The Name is informational; the authoritative namespace key is the Name
+// of the fetched child index.
+type FoundryRef struct {
+	Name        string `yaml:"name"`
+	Source      string `yaml:"source"`
+	Description string `yaml:"description,omitempty"`
 }
 
 // ParseIndex parses raw YAML bytes into an Index.
@@ -60,6 +70,12 @@ func (idx *Index) Validate() error {
 		}
 		if m.Source == "" {
 			errs = append(errs, fmt.Sprintf("molds[%d].source is required", i))
+		}
+	}
+
+	for i, f := range idx.Foundries {
+		if f.Source == "" {
+			errs = append(errs, fmt.Sprintf("foundries[%d].source is required", i))
 		}
 	}
 

--- a/pkg/foundry/index/index_test.go
+++ b/pkg/foundry/index/index_test.go
@@ -60,6 +60,32 @@ molds: []
 			},
 		},
 		{
+			name: "index with nested foundries",
+			input: `
+apiVersion: v1
+kind: foundry-index
+name: aggregator
+molds: []
+foundries:
+  - name: replicated
+    source: github.com/kriscoleman/replicated-foundry
+    description: "Kris's molds"
+`,
+			want: Index{
+				APIVersion: "v1",
+				Kind:       "foundry-index",
+				Name:       "aggregator",
+				Molds:      []MoldEntry{},
+				Foundries: []FoundryRef{
+					{
+						Name:        "replicated",
+						Source:      "github.com/kriscoleman/replicated-foundry",
+						Description: "Kris's molds",
+					},
+				},
+			},
+		},
+		{
 			name:    "invalid yaml",
 			input:   `{{{not yaml`,
 			wantErr: true,
@@ -102,6 +128,17 @@ molds: []
 				}
 				if m.Source != tt.want.Molds[i].Source {
 					t.Errorf("Molds[%d].Source = %q, want %q", i, m.Source, tt.want.Molds[i].Source)
+				}
+			}
+			if len(idx.Foundries) != len(tt.want.Foundries) {
+				t.Fatalf("len(Foundries) = %d, want %d", len(idx.Foundries), len(tt.want.Foundries))
+			}
+			for i, f := range idx.Foundries {
+				if f.Name != tt.want.Foundries[i].Name {
+					t.Errorf("Foundries[%d].Name = %q, want %q", i, f.Name, tt.want.Foundries[i].Name)
+				}
+				if f.Source != tt.want.Foundries[i].Source {
+					t.Errorf("Foundries[%d].Source = %q, want %q", i, f.Source, tt.want.Foundries[i].Source)
 				}
 			}
 		})
@@ -173,6 +210,18 @@ func TestValidate(t *testing.T) {
 				},
 			},
 			wantErr: "molds[0].source is required",
+		},
+		{
+			name: "foundry ref missing source",
+			idx: Index{
+				APIVersion: "v1",
+				Kind:       "foundry-index",
+				Name:       "test",
+				Foundries: []FoundryRef{
+					{Name: "child"},
+				},
+			},
+			wantErr: "foundries[0].source is required",
 		},
 	}
 

--- a/pkg/foundry/index/resolver.go
+++ b/pkg/foundry/index/resolver.go
@@ -1,6 +1,9 @@
 package index
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 // canonicalizeSource normalizes a foundry source URL so equivalent inputs map
 // to the same key. Used as the visited-set key during transitive resolution.
@@ -69,8 +72,28 @@ func (r *Resolver) Resolve(rootSource string) (*ResolvedFoundry, []ResolvedMold,
 	if err != nil {
 		return nil, nil, err
 	}
+	if err := r.checkNameCollisions(); err != nil {
+		return nil, nil, err
+	}
 	molds := flattenMolds(root, make(map[string]bool))
 	return root, molds, nil
+}
+
+// checkNameCollisions returns an error if any two distinct source URLs in the
+// visited tree declare the same foundry Name (the namespace key).
+func (r *Resolver) checkNameCollisions() error {
+	nameToSources := make(map[string][]string)
+	for src, node := range r.visited {
+		nameToSources[node.Index.Name] = append(nameToSources[node.Index.Name], src)
+	}
+	for name, sources := range nameToSources {
+		if len(sources) <= 1 {
+			continue
+		}
+		return fmt.Errorf("foundry name %q is declared by multiple sources: %s",
+			name, strings.Join(sources, ", "))
+	}
+	return nil
 }
 
 func (r *Resolver) resolveNode(source string, parents []string) (*ResolvedFoundry, error) {

--- a/pkg/foundry/index/resolver.go
+++ b/pkg/foundry/index/resolver.go
@@ -116,8 +116,8 @@ func (r *Resolver) resolveNode(source string, parents []string) (*ResolvedFoundr
 	for _, ref := range idx.Foundries {
 		child, err := r.resolveNode(ref.Source, childParents)
 		if err != nil {
-			// Child fetch errors are handled in a later task — for now propagate.
-			return nil, err
+			r.warnings = append(r.warnings, ResolutionWarning{Source: ref.Source, Err: err})
+			continue
 		}
 		node.Children = append(node.Children, child)
 	}

--- a/pkg/foundry/index/resolver.go
+++ b/pkg/foundry/index/resolver.go
@@ -1,0 +1,15 @@
+package index
+
+import "strings"
+
+// canonicalizeSource normalizes a foundry source URL so equivalent inputs map
+// to the same key. Used as the visited-set key during transitive resolution.
+func canonicalizeSource(source string) string {
+	s := strings.TrimSpace(source)
+	s = strings.TrimPrefix(s, "https://")
+	s = strings.TrimPrefix(s, "http://")
+	s = strings.TrimSuffix(s, "/")
+	s = strings.TrimSuffix(s, ".git")
+	s = strings.ToLower(s)
+	return s
+}

--- a/pkg/foundry/index/resolver.go
+++ b/pkg/foundry/index/resolver.go
@@ -13,3 +13,95 @@ func canonicalizeSource(source string) string {
 	s = strings.ToLower(s)
 	return s
 }
+
+// IndexLookup fetches a parsed Index for a given source URL. Implementations
+// may be network-backed (Fetcher) or cache-backed (LoadCachedIndex).
+type IndexLookup func(source string) (*Index, error)
+
+// ResolvedFoundry is one node in the resolved foundry tree.
+type ResolvedFoundry struct {
+	Index    *Index
+	Source   string   // canonical source URL
+	Parents  []string // chain of foundry Names from root to this node's parent (empty for root)
+	Children []*ResolvedFoundry
+}
+
+// ResolvedMold is a mold paired with the foundry that owns it.
+type ResolvedMold struct {
+	Entry   MoldEntry
+	Foundry *ResolvedFoundry
+}
+
+// ResolutionWarning captures a non-fatal problem encountered during Resolve
+// (e.g., a child foundry that failed to fetch).
+type ResolutionWarning struct {
+	Source string
+	Err    error
+}
+
+// Resolver walks a foundry tree depth-first via an IndexLookup, deduplicating
+// shared subtrees and silently breaking cycles via a visited-set keyed by
+// canonical source URL.
+type Resolver struct {
+	lookup   IndexLookup
+	visited  map[string]*ResolvedFoundry
+	warnings []ResolutionWarning
+}
+
+// NewResolver constructs a Resolver around the given lookup.
+func NewResolver(lookup IndexLookup) *Resolver {
+	return &Resolver{
+		lookup:  lookup,
+		visited: make(map[string]*ResolvedFoundry),
+	}
+}
+
+// Warnings returns any non-fatal issues collected during the most recent Resolve.
+func (r *Resolver) Warnings() []ResolutionWarning {
+	return r.warnings
+}
+
+// Resolve fetches the root foundry at rootSource and recursively resolves all
+// child foundries. Returns the root node and a flat depth-first list of every
+// reachable mold (each with a back-pointer to its owning foundry).
+func (r *Resolver) Resolve(rootSource string) (*ResolvedFoundry, []ResolvedMold, error) {
+	root, err := r.resolveNode(rootSource, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	molds := flattenMolds(root, make(map[string]bool))
+	return root, molds, nil
+}
+
+func (r *Resolver) resolveNode(source string, parents []string) (*ResolvedFoundry, error) {
+	key := canonicalizeSource(source)
+	if existing, ok := r.visited[key]; ok {
+		return existing, nil
+	}
+	idx, err := r.lookup(source)
+	if err != nil {
+		return nil, err
+	}
+	node := &ResolvedFoundry{
+		Index:   idx,
+		Source:  key,
+		Parents: append([]string(nil), parents...),
+	}
+	r.visited[key] = node
+	return node, nil
+}
+
+func flattenMolds(node *ResolvedFoundry, seen map[string]bool) []ResolvedMold {
+	if seen[node.Source] {
+		return nil
+	}
+	seen[node.Source] = true
+	out := make([]ResolvedMold, 0, len(node.Index.Molds))
+	for _, m := range node.Index.Molds {
+		out = append(out, ResolvedMold{Entry: m, Foundry: node})
+	}
+	for _, child := range node.Children {
+		out = append(out, flattenMolds(child, seen)...)
+	}
+	return out
+}

--- a/pkg/foundry/index/resolver.go
+++ b/pkg/foundry/index/resolver.go
@@ -88,6 +88,16 @@ func (r *Resolver) resolveNode(source string, parents []string) (*ResolvedFoundr
 		Parents: append([]string(nil), parents...),
 	}
 	r.visited[key] = node
+
+	childParents := append(append([]string(nil), parents...), idx.Name)
+	for _, ref := range idx.Foundries {
+		child, err := r.resolveNode(ref.Source, childParents)
+		if err != nil {
+			// Child fetch errors are handled in a later task — for now propagate.
+			return nil, err
+		}
+		node.Children = append(node.Children, child)
+	}
 	return node, nil
 }
 

--- a/pkg/foundry/index/resolver_test.go
+++ b/pkg/foundry/index/resolver_test.go
@@ -65,3 +65,65 @@ func TestResolverFlatFoundry(t *testing.T) {
 		}
 	}
 }
+
+// fakeLookup builds an IndexLookup from a static map of canonical source → index.
+func fakeLookup(t *testing.T, m map[string]*Index) (IndexLookup, *int) {
+	t.Helper()
+	calls := 0
+	return func(source string) (*Index, error) {
+		calls++
+		key := canonicalizeSource(source)
+		idx, ok := m[key]
+		if !ok {
+			t.Fatalf("unexpected lookup for %q", source)
+		}
+		return idx, nil
+	}, &calls
+}
+
+func TestResolverChildRecursion(t *testing.T) {
+	root := &Index{
+		APIVersion: "v1", Kind: "foundry-index", Name: "root",
+		Molds: []MoldEntry{{Name: "alpha", Source: "github.com/x/alpha"}},
+		Foundries: []FoundryRef{
+			{Name: "child", Source: "github.com/x/child"},
+		},
+	}
+	child := &Index{
+		APIVersion: "v1", Kind: "foundry-index", Name: "child",
+		Molds: []MoldEntry{{Name: "gamma", Source: "github.com/x/gamma"}},
+	}
+	lookup, calls := fakeLookup(t, map[string]*Index{
+		"github.com/x/root":  root,
+		"github.com/x/child": child,
+	})
+
+	rf, molds, err := NewResolver(lookup).Resolve("github.com/x/root")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if *calls != 2 {
+		t.Errorf("lookup calls = %d, want 2", *calls)
+	}
+	if len(rf.Children) != 1 {
+		t.Fatalf("len(Children) = %d, want 1", len(rf.Children))
+	}
+	if rf.Children[0].Index.Name != "child" {
+		t.Errorf("Children[0].Index.Name = %q, want child", rf.Children[0].Index.Name)
+	}
+	if got := rf.Children[0].Parents; len(got) != 1 || got[0] != "root" {
+		t.Errorf("Children[0].Parents = %v, want [root]", got)
+	}
+	if len(molds) != 2 {
+		t.Fatalf("len(molds) = %d, want 2 (parent first, child second)", len(molds))
+	}
+	if molds[0].Entry.Name != "alpha" {
+		t.Errorf("molds[0] = %q, want alpha (parent first)", molds[0].Entry.Name)
+	}
+	if molds[1].Entry.Name != "gamma" {
+		t.Errorf("molds[1] = %q, want gamma (child second)", molds[1].Entry.Name)
+	}
+	if molds[1].Foundry.Index.Name != "child" {
+		t.Errorf("molds[1].Foundry = %q, want child", molds[1].Foundry.Index.Name)
+	}
+}

--- a/pkg/foundry/index/resolver_test.go
+++ b/pkg/foundry/index/resolver_test.go
@@ -1,6 +1,9 @@
 package index
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestCanonicalizeSource(t *testing.T) {
 	tests := []struct {
@@ -173,6 +176,35 @@ func TestResolverSelfCycle(t *testing.T) {
 	}
 	if len(rf.Children) != 1 || rf.Children[0] != rf {
 		t.Errorf("self-cycle not short-circuited: %+v", rf.Children)
+	}
+}
+
+func TestResolverNameCollision(t *testing.T) {
+	root := &Index{
+		APIVersion: "v1", Kind: "foundry-index", Name: "root",
+		Foundries: []FoundryRef{
+			{Name: "x", Source: "github.com/a/x"},
+			{Name: "x", Source: "github.com/b/x"},
+		},
+	}
+	a := &Index{APIVersion: "v1", Kind: "foundry-index", Name: "dup"}
+	b := &Index{APIVersion: "v1", Kind: "foundry-index", Name: "dup"}
+	lookup, _ := fakeLookup(t, map[string]*Index{
+		"github.com/x/root": root,
+		"github.com/a/x":    a,
+		"github.com/b/x":    b,
+	})
+
+	_, _, err := NewResolver(lookup).Resolve("github.com/x/root")
+	if err == nil {
+		t.Fatal("expected name-collision error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, `"dup"`) {
+		t.Errorf("error %q should name the conflicting foundry name", msg)
+	}
+	if !strings.Contains(msg, "github.com/a/x") || !strings.Contains(msg, "github.com/b/x") {
+		t.Errorf("error %q should name both source URLs", msg)
 	}
 }
 

--- a/pkg/foundry/index/resolver_test.go
+++ b/pkg/foundry/index/resolver_test.go
@@ -22,3 +22,46 @@ func TestCanonicalizeSource(t *testing.T) {
 		})
 	}
 }
+
+func TestResolverFlatFoundry(t *testing.T) {
+	root := &Index{
+		APIVersion: "v1", Kind: "foundry-index", Name: "root",
+		Molds: []MoldEntry{
+			{Name: "alpha", Source: "github.com/x/alpha"},
+			{Name: "beta", Source: "github.com/x/beta"},
+		},
+	}
+	lookup := func(source string) (*Index, error) {
+		if canonicalizeSource(source) == "github.com/x/root" {
+			return root, nil
+		}
+		t.Fatalf("unexpected lookup: %q", source)
+		return nil, nil
+	}
+
+	r := NewResolver(lookup)
+	rf, molds, err := r.Resolve("github.com/x/root")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if rf.Index != root {
+		t.Errorf("rf.Index = %v, want root", rf.Index)
+	}
+	if rf.Source != "github.com/x/root" {
+		t.Errorf("rf.Source = %q, want github.com/x/root", rf.Source)
+	}
+	if len(rf.Parents) != 0 {
+		t.Errorf("rf.Parents = %v, want empty", rf.Parents)
+	}
+	if len(rf.Children) != 0 {
+		t.Errorf("rf.Children = %v, want empty", rf.Children)
+	}
+	if len(molds) != 2 {
+		t.Fatalf("len(molds) = %d, want 2", len(molds))
+	}
+	for i, m := range molds {
+		if m.Foundry != rf {
+			t.Errorf("molds[%d].Foundry = %v, want root", i, m.Foundry)
+		}
+	}
+}

--- a/pkg/foundry/index/resolver_test.go
+++ b/pkg/foundry/index/resolver_test.go
@@ -1,0 +1,24 @@
+package index
+
+import "testing"
+
+func TestCanonicalizeSource(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"github.com/owner/repo", "github.com/owner/repo"},
+		{"https://github.com/owner/repo", "github.com/owner/repo"},
+		{"https://github.com/owner/repo.git", "github.com/owner/repo"},
+		{"https://GitHub.com/Owner/Repo", "github.com/owner/repo"},
+		{"http://example.com/foundry.yaml", "example.com/foundry.yaml"},
+		{"github.com/owner/repo/", "github.com/owner/repo"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got := canonicalizeSource(tt.in)
+			if got != tt.want {
+				t.Errorf("canonicalizeSource(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/foundry/index/resolver_test.go
+++ b/pkg/foundry/index/resolver_test.go
@@ -127,3 +127,98 @@ func TestResolverChildRecursion(t *testing.T) {
 		t.Errorf("molds[1].Foundry = %q, want child", molds[1].Foundry.Index.Name)
 	}
 }
+
+func TestResolverCycle(t *testing.T) {
+	a := &Index{
+		APIVersion: "v1", Kind: "foundry-index", Name: "a",
+		Foundries: []FoundryRef{{Name: "b", Source: "github.com/x/b"}},
+	}
+	b := &Index{
+		APIVersion: "v1", Kind: "foundry-index", Name: "b",
+		Foundries: []FoundryRef{{Name: "a", Source: "github.com/x/a"}},
+	}
+	lookup, calls := fakeLookup(t, map[string]*Index{
+		"github.com/x/a": a,
+		"github.com/x/b": b,
+	})
+
+	rf, _, err := NewResolver(lookup).Resolve("github.com/x/a")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if *calls != 2 {
+		t.Errorf("lookup calls = %d, want 2 (each fetched once)", *calls)
+	}
+	if len(rf.Children) != 1 || rf.Children[0].Index.Name != "b" {
+		t.Fatalf("rf.Children layout unexpected: %+v", rf.Children)
+	}
+	// b's child "a" should resolve back to the root, not a fresh node.
+	if len(rf.Children[0].Children) != 1 || rf.Children[0].Children[0] != rf {
+		t.Errorf("expected b.Children[0] to be the root a (cycle short-circuit)")
+	}
+}
+
+func TestResolverSelfCycle(t *testing.T) {
+	a := &Index{
+		APIVersion: "v1", Kind: "foundry-index", Name: "a",
+		Foundries: []FoundryRef{{Name: "a", Source: "github.com/x/a"}},
+	}
+	lookup, calls := fakeLookup(t, map[string]*Index{"github.com/x/a": a})
+	rf, _, err := NewResolver(lookup).Resolve("github.com/x/a")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if *calls != 1 {
+		t.Errorf("lookup calls = %d, want 1", *calls)
+	}
+	if len(rf.Children) != 1 || rf.Children[0] != rf {
+		t.Errorf("self-cycle not short-circuited: %+v", rf.Children)
+	}
+}
+
+func TestResolverDiamond(t *testing.T) {
+	p := &Index{
+		APIVersion: "v1", Kind: "foundry-index", Name: "p",
+		Foundries: []FoundryRef{
+			{Name: "b", Source: "github.com/x/b"},
+			{Name: "c", Source: "github.com/x/c"},
+		},
+	}
+	b := &Index{
+		APIVersion: "v1", Kind: "foundry-index", Name: "b",
+		Foundries: []FoundryRef{{Name: "d", Source: "github.com/x/d"}},
+	}
+	c := &Index{
+		APIVersion: "v1", Kind: "foundry-index", Name: "c",
+		Foundries: []FoundryRef{{Name: "d", Source: "github.com/x/d"}},
+	}
+	d := &Index{
+		APIVersion: "v1", Kind: "foundry-index", Name: "d",
+		Molds: []MoldEntry{{Name: "delta", Source: "github.com/x/delta"}},
+	}
+	lookup, calls := fakeLookup(t, map[string]*Index{
+		"github.com/x/p": p, "github.com/x/b": b, "github.com/x/c": c, "github.com/x/d": d,
+	})
+
+	rf, molds, err := NewResolver(lookup).Resolve("github.com/x/p")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if *calls != 4 {
+		t.Errorf("lookup calls = %d, want 4 (d fetched once)", *calls)
+	}
+	// d appears as a child of both b and c, but is the same node.
+	if rf.Children[0].Children[0] != rf.Children[1].Children[0] {
+		t.Errorf("expected b's d and c's d to be the same ResolvedFoundry instance")
+	}
+	// Mold "delta" should appear exactly once in the flat list.
+	deltas := 0
+	for _, m := range molds {
+		if m.Entry.Name == "delta" {
+			deltas++
+		}
+	}
+	if deltas != 1 {
+		t.Errorf("delta appeared %d times in flat molds, want 1", deltas)
+	}
+}

--- a/pkg/foundry/index/resolver_test.go
+++ b/pkg/foundry/index/resolver_test.go
@@ -1,6 +1,7 @@
 package index
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -205,6 +206,59 @@ func TestResolverNameCollision(t *testing.T) {
 	}
 	if !strings.Contains(msg, "github.com/a/x") || !strings.Contains(msg, "github.com/b/x") {
 		t.Errorf("error %q should name both source URLs", msg)
+	}
+}
+
+func TestResolverChildFetchFailure(t *testing.T) {
+	root := &Index{
+		APIVersion: "v1", Kind: "foundry-index", Name: "root",
+		Molds: []MoldEntry{{Name: "ok-mold", Source: "github.com/x/ok"}},
+		Foundries: []FoundryRef{
+			{Name: "broken", Source: "github.com/x/broken"},
+			{Name: "good", Source: "github.com/x/good"},
+		},
+	}
+	good := &Index{
+		APIVersion: "v1", Kind: "foundry-index", Name: "good",
+		Molds: []MoldEntry{{Name: "good-mold", Source: "github.com/x/good-mold"}},
+	}
+	lookup := func(source string) (*Index, error) {
+		switch canonicalizeSource(source) {
+		case "github.com/x/root":
+			return root, nil
+		case "github.com/x/broken":
+			return nil, fmt.Errorf("network down")
+		case "github.com/x/good":
+			return good, nil
+		}
+		t.Fatalf("unexpected lookup: %q", source)
+		return nil, nil
+	}
+
+	r := NewResolver(lookup)
+	rf, molds, err := r.Resolve("github.com/x/root")
+	if err != nil {
+		t.Fatalf("Resolve: %v (broken child should be a warning, not an error)", err)
+	}
+	// Only the good child should appear in rf.Children.
+	if len(rf.Children) != 1 || rf.Children[0].Index.Name != "good" {
+		t.Errorf("rf.Children = %+v, want exactly [good]", rf.Children)
+	}
+	// ok-mold + good-mold should both be present.
+	var names []string
+	for _, m := range molds {
+		names = append(names, m.Entry.Name)
+	}
+	if len(names) != 2 {
+		t.Errorf("got molds %v, want 2 (ok-mold + good-mold)", names)
+	}
+	// Warning should record the broken source.
+	warnings := r.Warnings()
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %+v, want 1", warnings)
+	}
+	if !strings.Contains(canonicalizeSource(warnings[0].Source), "github.com/x/broken") {
+		t.Errorf("warning source = %q, want broken", warnings[0].Source)
 	}
 }
 

--- a/pkg/foundry/index/search.go
+++ b/pkg/foundry/index/search.go
@@ -79,7 +79,7 @@ func searchIndexes(cfg *Config, query string) ([]SearchResult, error) {
 	}
 	git := defaultGitRunnerForSearch()
 	fetcher := NewFetcherWithCacheDir(git, cacheDir)
-	lookup := cacheFirstLookup(cacheDir, fetcher)
+	lookup := CacheFirstLookup(cacheDir, fetcher)
 	return searchWithLookup(cfg, query, lookup)
 }
 
@@ -128,10 +128,11 @@ func formatOrigin(root, owner *ResolvedFoundry) string {
 	return base + " via " + strings.Join(chain, " → ")
 }
 
-// cacheFirstLookup returns an IndexLookup that reads the cache when present
+// CacheFirstLookup returns an IndexLookup that reads the cache when present
 // and falls back to the network (via Fetcher) otherwise. The synthesized
 // FoundryEntry mirrors what `foundry add` would build for the same URL.
-func cacheFirstLookup(cacheDir string, fetcher *Fetcher) IndexLookup {
+// Used by both search and the foundry list command.
+func CacheFirstLookup(cacheDir string, fetcher *Fetcher) IndexLookup {
 	return func(source string) (*Index, error) {
 		url := NormalizeFoundryURL(source)
 		entry := &FoundryEntry{

--- a/pkg/foundry/index/search.go
+++ b/pkg/foundry/index/search.go
@@ -68,39 +68,91 @@ func Search(cfg *Config, query string, opts SearchOptions) ([]SearchResult, erro
 	return results, nil
 }
 
-// searchIndexes searches all cached foundry indexes for matching molds.
+// searchIndexes searches all cached foundry indexes for matching molds,
+// transitively resolving any nested foundries declared in their `foundries:`
+// fields. Lookups are cache-first; child foundries not yet cached fall back
+// to the network so a freshly-added parent works without an explicit update.
 func searchIndexes(cfg *Config, query string) ([]SearchResult, error) {
 	cacheDir, err := IndexCacheDir()
 	if err != nil {
 		return nil, err
 	}
+	git := defaultGitRunnerForSearch()
+	fetcher := NewFetcherWithCacheDir(git, cacheDir)
+	lookup := cacheFirstLookup(cacheDir, fetcher)
+	return searchWithLookup(cfg, query, lookup)
+}
 
+// searchWithLookup is the testable core: given an explicit IndexLookup, walk
+// every registered root via a fresh Resolver and return matching molds with
+// their resolution chain.
+func searchWithLookup(cfg *Config, query string, lookup IndexLookup) ([]SearchResult, error) {
 	var results []SearchResult
 	q := strings.ToLower(query)
 
 	for _, entry := range cfg.EffectiveFoundries() {
-		idx, err := LoadCachedIndex(cacheDir, &entry)
-		if err != nil {
-			continue // Skip indexes that aren't cached yet.
-		}
-
 		verified := IsOfficialFoundry(entry.URL)
-		for _, m := range idx.Molds {
-			if matchesMold(m, q) {
-				results = append(results, SearchResult{
-					Name:        m.Name,
-					Source:      m.Source,
-					Description: m.Description,
-					Tags:        m.Tags,
-					Origin:      "index:" + entry.Name,
-					URL:         sourceToURL(m.Source),
-					Verified:    verified,
-				})
+		r := NewResolver(lookup)
+		root, molds, err := r.Resolve(entry.URL)
+		if err != nil {
+			// Root failed (e.g., not cached and offline). Skip — preserves
+			// the existing "skip indexes that aren't cached yet" behavior.
+			continue
+		}
+		for _, m := range molds {
+			if !matchesMold(m.Entry, q) {
+				continue
 			}
+			results = append(results, SearchResult{
+				Name:        m.Foundry.Index.Name + "/" + m.Entry.Name,
+				Source:      m.Entry.Source,
+				Description: m.Entry.Description,
+				Tags:        m.Entry.Tags,
+				Origin:      formatOrigin(root, m.Foundry),
+				URL:         sourceToURL(m.Entry.Source),
+				Verified:    verified && m.Foundry == root,
+			})
 		}
 	}
-
 	return results, nil
+}
+
+// formatOrigin renders the resolution chain. Root molds get "index:<root>";
+// nested molds get "index:<root> via <parent> → <child>".
+func formatOrigin(root, owner *ResolvedFoundry) string {
+	base := "index:" + root.Index.Name
+	if owner == root {
+		return base
+	}
+	chain := append(append([]string(nil), owner.Parents...), owner.Index.Name)
+	return base + " via " + strings.Join(chain, " → ")
+}
+
+// cacheFirstLookup returns an IndexLookup that reads the cache when present
+// and falls back to the network (via Fetcher) otherwise. The synthesized
+// FoundryEntry mirrors what `foundry add` would build for the same URL.
+func cacheFirstLookup(cacheDir string, fetcher *Fetcher) IndexLookup {
+	return func(source string) (*Index, error) {
+		url := NormalizeFoundryURL(source)
+		entry := &FoundryEntry{
+			URL:  url,
+			Type: DetectType(url),
+		}
+		if idx, err := LoadCachedIndex(cacheDir, entry); err == nil {
+			return idx, nil
+		}
+		return fetcher.FetchIndex(entry)
+	}
+}
+
+// defaultGitRunnerForSearch returns a GitRunner used by the cache-fallback
+// fetcher inside searchIndexes. Defined locally to avoid importing
+// internal/commands from the index package.
+func defaultGitRunnerForSearch() GitRunner {
+	return func(args ...string) ([]byte, error) {
+		cmd := exec.Command("git", args...) // #nosec G204 -- args are constructed internally
+		return cmd.CombinedOutput()
+	}
 }
 
 // matchesMold checks if a mold entry matches the search query.

--- a/pkg/foundry/index/search_test.go
+++ b/pkg/foundry/index/search_test.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
 	"testing"
 )
 
@@ -249,5 +252,52 @@ molds:
 	}
 	if results[0].Name != "workflow-mold" {
 		t.Errorf("Name = %q, want workflow-mold", results[0].Name)
+	}
+}
+
+func TestSearchTraversesNestedFoundries(t *testing.T) {
+	parent := &Index{
+		APIVersion: "v1", Kind: "foundry-index", Name: "parent",
+		Molds:     []MoldEntry{{Name: "parent-mold", Source: "github.com/x/parent-mold", Description: "alpha"}},
+		Foundries: []FoundryRef{{Name: "child", Source: "github.com/x/child"}},
+	}
+	child := &Index{
+		APIVersion: "v1", Kind: "foundry-index", Name: "child",
+		Molds: []MoldEntry{{Name: "child-mold", Source: "github.com/x/child-mold", Description: "alpha"}},
+	}
+	lookup := func(source string) (*Index, error) {
+		switch canonicalizeSource(source) {
+		case "github.com/x/parent":
+			return parent, nil
+		case "github.com/x/child":
+			return child, nil
+		}
+		return nil, fmt.Errorf("not found: %s", source)
+	}
+
+	cfg := &Config{Foundries: []FoundryEntry{{Name: "parent", URL: "github.com/x/parent", Type: "git"}}}
+	results, err := searchWithLookup(cfg, "alpha", lookup)
+	if err != nil {
+		t.Fatalf("searchWithLookup: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("got %d results, want 2", len(results))
+	}
+	// Both molds should be namespaced as <foundry>/<mold>.
+	names := []string{results[0].Name, results[1].Name}
+	sort.Strings(names)
+	want := []string{"child/child-mold", "parent/parent-mold"}
+	if !reflect.DeepEqual(names, want) {
+		t.Errorf("names = %v, want %v", names, want)
+	}
+	// The child mold's Origin should reflect the resolution chain.
+	var childResult SearchResult
+	for _, r := range results {
+		if r.Name == "child/child-mold" {
+			childResult = r
+		}
+	}
+	if !strings.Contains(childResult.Origin, "via parent") {
+		t.Errorf("child Origin = %q, want it to contain 'via parent'", childResult.Origin)
 	}
 }


### PR DESCRIPTION
## Summary

A `foundry.yaml` can now list other foundries under a top-level `foundries:` field. The CLI walks the tree transitively so all of a child foundry's molds become discoverable, searchable, and installable through the parent — no per-mold PRs into the parent foundry required.

This unlocks the workflow we want: a foundry author contributes a single 3-line entry to `nimble-giant/foundry` pointing at their own foundry, and every mold they add afterwards flows into the official one automatically the next time someone runs `ailloy foundry update`.

## What's new

**Schema (`pkg/foundry/index/index.go`)**
- New optional `Foundries []FoundryRef` field on `Index`. Backwards compatible — existing flat foundries continue to work unchanged.

**Resolver (`pkg/foundry/index/resolver.go`, new file)**
- Depth-first walk via a pluggable `IndexLookup` (network or cache).
- Visited-source map silently breaks cycles and dedupes diamond subtrees.
- Errors loudly when two distinct source URLs declare the same foundry `name:`.
- Downgrades child fetch failures to warnings — one broken nested foundry doesn't break the whole tree.
- 7 unit tests cover flat, recursion, cycle, self-cycle, diamond, name collision, and child-failure paths.

**CLI behavior**
- `foundry search` — molds named uniformly as `<foundry>/<mold>`; nested results show their resolution chain (`via parent → child`).
- `foundry list` — renders nested-foundry tree under each registered root.
- `foundry install` — transitive by default; `--shallow` opts back into root-only. Output groups installs by owning foundry with a `via` annotation.
- `foundry update` — walks children too, populating the on-disk cache so `foundry search` stays fast and offline-friendly. Surfaces resolver warnings inline.

**Docs (`docs/foundry.md`)**
- New "Nested Foundries" section covering schema, behavior, `--shallow`, and cache implications.
- `foundries[].*` rows added to the schema table.
- `foundry install` notes mention transitive aggregation and `--shallow`.

## Verification

- `go test ./... -race -count=1` — all packages green
- `golangci-lint run ./...` — 0 issues
- CLI smoke-tested: build clean, `--shallow` flag wired, `foundry list` renders normally for a flat foundry

## Test plan

- [ ] Add a `foundries:` entry pointing at a real second foundry; run `ailloy foundry update` and confirm both indexes are cached
- [ ] Run `ailloy foundry search <term>` and confirm child-foundry molds appear with `<foundry>/<mold>` names and `via parent` annotations
- [ ] Run `ailloy foundry list` and confirm the nested foundry appears as a tree under its parent
- [ ] Run `ailloy foundry install <parent> --dry-run` and confirm grouped per-foundry sections
- [ ] Run `ailloy foundry install <parent> --dry-run --shallow` and confirm only direct molds are listed
- [ ] Author a self-referential cycle in a test fixture and confirm it terminates without warning
- [ ] Author two children declaring the same `name:` and confirm `foundry search` errors out with both source URLs

## Migration / rollout

Purely additive. Foundries with no `foundries:` field behave exactly as they did before. The mold-name display format change (`<foundry>/<mold>`) is visible in `foundry search` output but uses the same identifier semantics underneath — there's no flag flip required for existing foundries.

## Follow-up to consider

A scheduled agent could open a cleanup PR in 4 weeks to migrate the per-mold entries currently in `nimble-giant/foundry` for `kriscoleman/replicated-foundry` into a single nested-foundry entry, once the new behavior has soaked.