### PR TITLE
feat(tui): flux value picker (press `f` from any foundries tab)

### DIFF
--- a/docs/anneal.md
+++ b/docs/anneal.md
@@ -4,6 +4,14 @@ The `anneal` command provides an interactive, mold-aware wizard for configuring 
 
 Alias: `configure`
 
+> **Quick alternative:** if you're already in `ailloy foundries`, press `f`
+> on the highlighted mold to open the flux value picker — same type-aware
+> editors as `anneal`, scoped to one mold, with fuzzy filter and a save
+> prompt for project / global / session-only. See
+> [Interactive TUI → Flux value picker](foundry.md#flux-value-picker). Use
+> `anneal` when you want a guided walkthrough of every variable, or when
+> you're scripting flux file generation outside the TUI.
+
 ## Quick Start
 
 ```bash

--- a/docs/flux.md
+++ b/docs/flux.md
@@ -91,6 +91,14 @@ ailloy cast ./my-mold --set project.organization=my-org --set scm.provider=GitLa
 ailloy cast ./my-mold -f team-values.yaml --set project.organization=my-org
 ```
 
+### Setting values from the TUI
+
+The `ailloy foundries` TUI also has a flux value picker — press `f` from
+Discover or Installed to set values for the highlighted mold without typing
+`--set` flags by hand. The picker can write to a project flux file, a global
+flux file, or thread the overrides into the next cast as session-only
+`--set` values. See [Interactive TUI → Flux value picker](foundry.md#flux-value-picker).
+
 ## Nested Values and Dotted Paths
 
 Flux values use standard YAML nesting. In blanks, reference them with dotted paths:

--- a/docs/foundry.md
+++ b/docs/foundry.md
@@ -228,7 +228,7 @@ space toggle · enter cast all · / search · c clear · r refresh · j/k move
 
 | Tab | What it does |
 | --- | --- |
-| **Discover** | Browse the merged catalog across every effective foundry. Multi-select with `space`, install all selected with `enter`. Live filter with `/`. The "Recent" section highlights molds whose foundry was indexed in the last 7 days (top 10). Already-installed molds show a blue `● installed <version>` badge. Press `f` on any mold to open the [flux value picker](#flux-value-picker). |
+| **Discover** | Browse the merged catalog across every effective foundry. Nested foundries declared via `foundries:` are resolved transitively, and nested-foundry molds render with a faint `via parent → child` annotation showing their resolution chain. Multi-select with `space`, install all selected with `enter`. Live filter with `/`. The "Recent" section highlights molds whose foundry was indexed in the last 7 days (top 10). Already-installed molds show a blue `● installed <version>` badge. Press `f` on any mold to open the [flux value picker](#flux-value-picker). |
 | **Installed** | List every casted mold across project (`./ailloy.lock`) and global (`~/ailloy.lock`) scope. `u` re-casts to the latest version; `x` uninstalls (uses the install manifest, skips files modified since cast). Pre-manifest legacy entries display a yellow warning. Press `f` to edit flux values for the highlighted mold. |
 | **Foundries** | Add (`a`), remove (`d`), or refresh (`r`) registered foundry indexes. The verified default is rendered as a built-in entry and can't be removed. |
 | **Health** | Drift checks (orphaned molds whose foundry no longer indexes them, legacy install manifests) plus `assay` findings against the rendered blank directories from `.ailloy/state.yaml`. `r` re-runs the checks. |
@@ -265,6 +265,11 @@ installed molds, on demand from the foundry for un-installed ones) and lets
 you set values without leaving the TUI — useful when you want to tweak
 something like `agents.targets=[opencode]` before casting, without crafting a
 `--set` flag or editing `flux.yaml` by hand.
+
+The picker works on nested-foundry molds too: any mold reachable from a
+registered root via `foundries:` references shows up in Discover (with a
+`via parent → child` annotation) and accepts `f` like a directly-indexed
+mold.
 
 | Key | Action |
 | --- | --- |

--- a/docs/foundry.md
+++ b/docs/foundry.md
@@ -284,12 +284,14 @@ select gets a dropdown (with discovery support), int validates as you type.
 
 The save prompt routes the overrides three ways:
 
-- `[p]` project — writes `./.ailloy/flux/<mold>.yaml` (atomic; merges with
+- `[p]` project — writes `./.ailloy/flux/<slug>.yaml` (atomic; merges with
   existing content).
-- `[g]` global — writes `~/.ailloy/flux/<mold>.yaml`.
+- `[g]` global — writes `~/.ailloy/flux/<slug>.yaml`.
 - `[o]` this cast only — keeps the values in TUI memory and threads them as
   `--set` overrides into the next cast of that mold (cleared on success,
   retained on failure for retry).
+
+The `<slug>` is derived from the full mold ref (e.g., `github.com/nimble-giant/agents` → `github.com_nimble-giant_agents`) so molds with the same final segment under different foundries — including nested foundries that re-export shared molds — don't clobber each other on disk.
 
 Required-but-unset fields block save with the missing keys called out in the
 error banner.

--- a/docs/foundry.md
+++ b/docs/foundry.md
@@ -228,8 +228,8 @@ space toggle · enter cast all · / search · c clear · r refresh · j/k move
 
 | Tab | What it does |
 | --- | --- |
-| **Discover** | Browse the merged catalog across every effective foundry. Multi-select with `space`, install all selected with `enter`. Live filter with `/`. The "Recent" section highlights molds whose foundry was indexed in the last 7 days (top 10). Already-installed molds show a blue `● installed <version>` badge. |
-| **Installed** | List every casted mold across project (`./ailloy.lock`) and global (`~/ailloy.lock`) scope. `u` re-casts to the latest version; `x` uninstalls (uses the install manifest, skips files modified since cast). Pre-manifest legacy entries display a yellow warning. |
+| **Discover** | Browse the merged catalog across every effective foundry. Multi-select with `space`, install all selected with `enter`. Live filter with `/`. The "Recent" section highlights molds whose foundry was indexed in the last 7 days (top 10). Already-installed molds show a blue `● installed <version>` badge. Press `f` on any mold to open the [flux value picker](#flux-value-picker). |
+| **Installed** | List every casted mold across project (`./ailloy.lock`) and global (`~/ailloy.lock`) scope. `u` re-casts to the latest version; `x` uninstalls (uses the install manifest, skips files modified since cast). Pre-manifest legacy entries display a yellow warning. Press `f` to edit flux values for the highlighted mold. |
 | **Foundries** | Add (`a`), remove (`d`), or refresh (`r`) registered foundry indexes. The verified default is rendered as a built-in entry and can't be removed. |
 | **Health** | Drift checks (orphaned molds whose foundry no longer indexes them, legacy install manifests) plus `assay` findings against the rendered blank directories from `.ailloy/state.yaml`. `r` re-runs the checks. |
 
@@ -251,10 +251,48 @@ space toggle · enter cast all · / search · c clear · r refresh · j/k move
 | Foundries | `a` | open add-foundry input |
 | Foundries | `d` | remove current foundry |
 | Foundries | `i` | install every mold listed by current foundry (skips already-installed) |
+| Discover, Installed | `f` | open the flux value picker scoped to the highlighted mold |
 
 The TUI requires a TTY; piping `ailloy foundries` to a file errors out with a
 hint to use the scriptable equivalents (`ailloy foundry list/search/...` and
 `ailloy uninstall`).
+
+#### Flux value picker
+
+Press `f` from Discover or Installed to open a fuzzy-filter overlay scoped to
+the highlighted mold. The picker fetches the mold's flux schema (locally for
+installed molds, on demand from the foundry for un-installed ones) and lets
+you set values without leaving the TUI — useful when you want to tweak
+something like `agents.targets=[opencode]` before casting, without crafting a
+`--set` flag or editing `flux.yaml` by hand.
+
+| Key | Action |
+| --- | --- |
+| (typing) | fuzzy-filter the schema |
+| `↑` / `↓` | move cursor through results |
+| `tab` | commit top match into the type-aware editor |
+| `enter` | commit highlighted match (filter) / save value (editor) |
+| `d` | clear the override on the highlighted key |
+| `R` | reset every override in this session |
+| `s` | open the save-target prompt |
+| `esc` | cancel editor, or close picker (prompts to save when there are unsaved overrides) |
+
+Each row shows a badge: `●` set in this session, `○` value comes from
+`flux.yaml` defaults, blank for unset/required. The editor shape is
+type-driven — bool gets a yes/no confirm, list gets a multi-line editor,
+select gets a dropdown (with discovery support), int validates as you type.
+
+The save prompt routes the overrides three ways:
+
+- `[p]` project — writes `./.ailloy/flux/<mold>.yaml` (atomic; merges with
+  existing content).
+- `[g]` global — writes `~/.ailloy/flux/<mold>.yaml`.
+- `[o]` this cast only — keeps the values in TUI memory and threads them as
+  `--set` overrides into the next cast of that mold (cleared on success,
+  retained on failure for retry).
+
+Required-but-unset fields block save with the missing keys called out in the
+error banner.
 
 ### Uninstalling a casted mold
 

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/goccy/go-yaml v1.19.2
 	github.com/knadh/stuffbin v1.3.0
 	github.com/muesli/termenv v0.16.0
+	github.com/sahilm/fuzzy v0.1.1
 	github.com/spf13/cobra v1.9.1
 	golang.org/x/sync v0.15.0
 	golang.org/x/term v0.42.0
@@ -40,7 +41,6 @@ require (
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
-	github.com/sahilm/fuzzy v0.1.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sys v0.43.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/sahilm/fuzzy v0.1.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sys v0.43.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/knadh/stuffbin v1.3.0 h1:HaVSuYV+KnrlCHl7DrLNyOCgpTU2K8x5Hb+J4Ck3gww=
 github.com/knadh/stuffbin v1.3.0/go.mod h1:yVCFaWaKPubSNibBsTAJ939q2ABHudJQxRWZWV5yh+4=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
+github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sahilm/fuzzy v0.1.1 h1:ceu5RHF8DGgoi+/dR5PsECjCDH1BE3Fnmpo7aVXOdRA=
+github.com/sahilm/fuzzy v0.1.1/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=

--- a/internal/commands/schema_fetch_init.go
+++ b/internal/commands/schema_fetch_init.go
@@ -1,0 +1,19 @@
+package commands
+
+import (
+	"context"
+	"io/fs"
+
+	"github.com/nimble-giant/ailloy/pkg/foundry"
+	"github.com/nimble-giant/ailloy/pkg/mold"
+)
+
+func init() {
+	mold.ResolveSchemaFunc = func(ctx context.Context, source string) (fs.FS, func(), error) {
+		fsys, _, err := foundry.ResolveWithMetadata(source)
+		if err != nil {
+			return nil, nil, err
+		}
+		return fsys, nil, nil
+	}
+}

--- a/internal/tui/foundries/app.go
+++ b/internal/tui/foundries/app.go
@@ -144,6 +144,8 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch m := msg.(type) {
 	case tea.WindowSizeMsg:
 		a.width, a.height = m.Width, m.Height
+		// Picker is sized here; tabs receive WindowSizeMsg via the broadcast
+		// loop below.
 		a.picker, _ = a.picker.Update(m)
 	case fluxpicker.FluxOverridesMsg:
 		// Task 11 will route session-target overrides into discover/installed
@@ -151,7 +153,8 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.picker = a.picker.Close()
 		return a, nil
 	case tea.KeyMsg:
-		// If the picker is open, route all key messages to it first.
+		// Picker captures all keys while open — including tab-switch keys —
+		// so the user can't navigate tabs behind the overlay.
 		if a.picker.IsOpen() {
 			var cmd tea.Cmd
 			a.picker, cmd = a.picker.Update(m)

--- a/internal/tui/foundries/app.go
+++ b/internal/tui/foundries/app.go
@@ -8,10 +8,12 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/nimble-giant/ailloy/internal/tui/foundries/data"
 	"github.com/nimble-giant/ailloy/internal/tui/foundries/discover"
+	"github.com/nimble-giant/ailloy/internal/tui/foundries/fluxpicker"
 	"github.com/nimble-giant/ailloy/internal/tui/foundries/health"
 	"github.com/nimble-giant/ailloy/internal/tui/foundries/installed"
 	"github.com/nimble-giant/ailloy/internal/tui/foundries/registered"
 	"github.com/nimble-giant/ailloy/pkg/foundry/index"
+	"github.com/nimble-giant/ailloy/pkg/mold"
 )
 
 // MoldContexter is implemented by tabs that can identify a "currently
@@ -36,6 +38,7 @@ type App struct {
 	installed  installed.Model
 	registered registered.Model
 	health     health.Model
+	picker     fluxpicker.Model
 }
 
 // New constructs an App. deps wires platform operations (cast/add/remove/update)
@@ -124,6 +127,7 @@ func New(deps Deps) App {
 		installed:  installed.New(cfg, installedCast),
 		registered: registered.New(cfg, regAdd, regRemove, regUpdate, regInstall),
 		health:     health.New(cfg),
+		picker:     fluxpicker.New(),
 	}
 }
 
@@ -140,7 +144,19 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch m := msg.(type) {
 	case tea.WindowSizeMsg:
 		a.width, a.height = m.Width, m.Height
+		a.picker, _ = a.picker.Update(m)
+	case fluxpicker.FluxOverridesMsg:
+		// Task 11 will route session-target overrides into discover/installed
+		// before close. For now, just close.
+		a.picker = a.picker.Close()
+		return a, nil
 	case tea.KeyMsg:
+		// If the picker is open, route all key messages to it first.
+		if a.picker.IsOpen() {
+			var cmd tea.Cmd
+			a.picker, cmd = a.picker.Update(m)
+			return a, cmd
+		}
 		switch m.String() {
 		case "ctrl+c", "q":
 			return a, tea.Quit
@@ -149,6 +165,14 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a, nil
 		case "shift+tab", "left", "h":
 			a.active = (a.active + tabCount - 1) % tabCount
+			return a, nil
+		case "f":
+			ref, scope, ok := a.currentMold()
+			if !ok {
+				return a, nil
+			}
+			schema, defaults := a.loadSchemaForMold(ref)
+			a.picker = a.picker.OpenFor(ref, scope, schema, defaults)
 			return a, nil
 		}
 
@@ -201,7 +225,38 @@ func (a App) View() string {
 	}
 	b.WriteString("\n")
 	b.WriteString(statusBar.Render("tab/shift-tab to switch · q quit"))
+	if a.picker.IsOpen() {
+		b.WriteString("\n")
+		b.WriteString(a.picker.View())
+	}
 	return b.String()
+}
+
+// currentMold delegates to the active tab's MoldContexter to identify the
+// currently highlighted mold reference and scope.
+func (a App) currentMold() (string, data.Scope, bool) {
+	switch a.active {
+	case TabDiscover:
+		return a.discover.CurrentMold()
+	case TabInstalled:
+		return a.installed.CurrentMold()
+	case TabFoundries:
+		return a.registered.CurrentMold()
+	case TabHealth:
+		return a.health.CurrentMold()
+	}
+	return "", "", false
+}
+
+// loadSchemaForMold attempts a synchronous fetch via mold.FetchSchemaFromSource.
+// On error returns empty schema/defaults; the picker shows a "no flux variables"
+// state. (Task 13 makes this asynchronous.)
+func (a App) loadSchemaForMold(ref string) ([]mold.FluxVar, map[string]any) {
+	schema, defaults, err := mold.FetchSchemaFromSource(context.Background(), ref)
+	if err != nil {
+		return nil, nil
+	}
+	return schema, defaults
 }
 
 // Interface compliance — these will fail to compile if any tab drifts.

--- a/internal/tui/foundries/app.go
+++ b/internal/tui/foundries/app.go
@@ -147,6 +147,10 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Picker is sized here; tabs receive WindowSizeMsg via the broadcast
 		// loop below.
 		a.picker, _ = a.picker.Update(m)
+	case fluxpicker.SchemaFetchedMsg:
+		var cmd tea.Cmd
+		a.picker, cmd = a.picker.Update(m)
+		return a, cmd
 	case fluxpicker.FluxOverridesMsg:
 		if m.Target == fluxpicker.SaveTargetSession {
 			switch a.active {
@@ -180,9 +184,8 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if !ok {
 				return a, nil
 			}
-			schema, defaults := a.loadSchemaForMold(ref)
-			a.picker = a.picker.OpenFor(ref, scope, schema, defaults)
-			return a, nil
+			a.picker = a.picker.OpenFor(ref, scope, nil, nil).SetFetching(true)
+			return a, fetchSchemaCmd(ref)
 		}
 
 		// Key events go only to the active tab.
@@ -257,15 +260,18 @@ func (a App) currentMold() (string, data.Scope, bool) {
 	return "", "", false
 }
 
-// loadSchemaForMold attempts a synchronous fetch via mold.FetchSchemaFromSource.
-// On error returns empty schema/defaults; the picker shows a "no flux variables"
-// state. (Task 13 makes this asynchronous.)
-func (a App) loadSchemaForMold(ref string) ([]mold.FluxVar, map[string]any) {
-	schema, defaults, err := mold.FetchSchemaFromSource(context.Background(), ref)
-	if err != nil {
-		return nil, nil
+// fetchSchemaCmd returns a Cmd that fetches the schema for the given mold ref
+// asynchronously and dispatches a SchemaFetchedMsg when complete.
+func fetchSchemaCmd(ref string) tea.Cmd {
+	return func() tea.Msg {
+		schema, defaults, err := mold.FetchSchemaFromSource(context.Background(), ref)
+		return fluxpicker.SchemaFetchedMsg{
+			MoldRef:  ref,
+			Schema:   schema,
+			Defaults: defaults,
+			Err:      err,
+		}
 	}
-	return schema, defaults
 }
 
 // Interface compliance — these will fail to compile if any tab drifts.

--- a/internal/tui/foundries/app.go
+++ b/internal/tui/foundries/app.go
@@ -6,12 +6,19 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/nimble-giant/ailloy/internal/tui/foundries/data"
 	"github.com/nimble-giant/ailloy/internal/tui/foundries/discover"
 	"github.com/nimble-giant/ailloy/internal/tui/foundries/health"
 	"github.com/nimble-giant/ailloy/internal/tui/foundries/installed"
 	"github.com/nimble-giant/ailloy/internal/tui/foundries/registered"
 	"github.com/nimble-giant/ailloy/pkg/foundry/index"
 )
+
+// MoldContexter is implemented by tabs that can identify a "currently
+// highlighted" mold. The flux picker uses this to scope its operations.
+type MoldContexter interface {
+	CurrentMold() (ref string, scope data.Scope, ok bool)
+}
 
 type discoverCtx = context.Context
 
@@ -196,3 +203,11 @@ func (a App) View() string {
 	b.WriteString(statusBar.Render("tab/shift-tab to switch · q quit"))
 	return b.String()
 }
+
+// Interface compliance — these will fail to compile if any tab drifts.
+var (
+	_ MoldContexter = discover.Model{}
+	_ MoldContexter = installed.Model{}
+	_ MoldContexter = registered.Model{}
+	_ MoldContexter = health.Model{}
+)

--- a/internal/tui/foundries/app.go
+++ b/internal/tui/foundries/app.go
@@ -148,8 +148,14 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// loop below.
 		a.picker, _ = a.picker.Update(m)
 	case fluxpicker.FluxOverridesMsg:
-		// Task 11 will route session-target overrides into discover/installed
-		// before close. For now, just close.
+		if m.Target == fluxpicker.SaveTargetSession {
+			switch a.active {
+			case TabDiscover:
+				a.discover = a.discover.ApplySessionOverrides(m.MoldRef, m.Overrides)
+			case TabInstalled:
+				a.installed = a.installed.ApplySessionOverrides(m.MoldRef, m.Overrides)
+			}
+		}
 		a.picker = a.picker.Close()
 		return a, nil
 	case tea.KeyMsg:

--- a/internal/tui/foundries/app_test.go
+++ b/internal/tui/foundries/app_test.go
@@ -1,0 +1,61 @@
+package foundries
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/nimble-giant/ailloy/internal/tui/foundries/data"
+	"github.com/nimble-giant/ailloy/internal/tui/foundries/discover"
+	"github.com/nimble-giant/ailloy/internal/tui/foundries/fluxpicker"
+)
+
+func TestApp_FOpensPickerWhenMoldHighlighted(t *testing.T) {
+	a := newAppForTest()
+	a.discover = discover.NewWithFiltered([]data.CatalogEntry{{Name: "x", Source: "official/x"}}, 0)
+	a.active = TabDiscover
+
+	next, _ := a.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	app := next.(App)
+	if !app.picker.IsOpen() {
+		t.Fatal("expected picker to open")
+	}
+	if app.picker.MoldRef() != "official/x" {
+		t.Fatalf("picker moldRef = %q want official/x", app.picker.MoldRef())
+	}
+}
+
+func TestApp_FNoOpWhenNoMoldHighlighted(t *testing.T) {
+	a := newAppForTest()
+	a.active = TabHealth // health has no mold context
+	next, _ := a.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	app := next.(App)
+	if app.picker.IsOpen() {
+		t.Fatal("expected picker to remain closed")
+	}
+}
+
+func TestApp_FluxOverridesMsg_ClosesPicker(t *testing.T) {
+	a := newAppForTest()
+	a.picker = fluxpicker.New().OpenFor("official/x", data.ScopeProject, nil, nil)
+	if !a.picker.IsOpen() {
+		t.Fatal("setup: expected picker open")
+	}
+	next, _ := a.Update(fluxpicker.FluxOverridesMsg{
+		MoldRef: "official/x", Scope: data.ScopeProject,
+		Overrides: map[string]any{"k": "v"}, Target: fluxpicker.SaveTargetSession,
+	})
+	app := next.(App)
+	if app.picker.IsOpen() {
+		t.Fatal("expected picker to close after FluxOverridesMsg")
+	}
+}
+
+// newAppForTest returns a minimal App ready for keystroke-based tests.
+// It bypasses the full New() constructor (which needs a Config and many
+// callbacks) to keep tests focused on the App's routing logic.
+func newAppForTest() App {
+	return App{
+		picker: fluxpicker.New(),
+	}
+}

--- a/internal/tui/foundries/app_test.go
+++ b/internal/tui/foundries/app_test.go
@@ -51,6 +51,28 @@ func TestApp_FluxOverridesMsg_ClosesPicker(t *testing.T) {
 	}
 }
 
+func TestApp_FluxOverridesMsg_SessionRoutesToDiscover(t *testing.T) {
+	a := newAppForTest()
+	a.active = TabDiscover
+	a.picker = fluxpicker.New().OpenFor("official/x", data.ScopeProject, nil, nil)
+
+	next, _ := a.Update(fluxpicker.FluxOverridesMsg{
+		MoldRef: "official/x",
+		Scope:   data.ScopeProject,
+		Overrides: map[string]any{
+			"k": "v",
+		},
+		Target: fluxpicker.SaveTargetSession,
+	})
+	app := next.(App)
+	// We can't read app.discover.pending across packages, but ApplySessionOverrides
+	// is exported — we can call it explicitly to confirm routing didn't choke,
+	// then re-cast and check downstream effects in the integration test (Task 14).
+	if app.picker.IsOpen() {
+		t.Fatal("expected picker to close")
+	}
+}
+
 // newAppForTest returns a minimal App ready for keystroke-based tests.
 // It bypasses the full New() constructor (which needs a Config and many
 // callbacks) to keep tests focused on the App's routing logic.

--- a/internal/tui/foundries/data/catalog.go
+++ b/internal/tui/foundries/data/catalog.go
@@ -13,42 +13,78 @@ type CatalogEntry struct {
 	Source      string
 	Description string
 	Tags        []string
-	FoundryName string
-	FoundryURL  string
+	FoundryName string   // root foundry the user registered (catalog grouping)
+	FoundryURL  string   // root foundry URL
+	OwnerChain  []string // resolution path from root to the foundry that owns the mold; nil/empty for root molds
 	Verified    bool
-	IndexedAt   time.Time // foundry's LastUpdated, used for the "Recent" section
+	IndexedAt   time.Time // root foundry's LastUpdated, used for the "Recent" section
 }
 
+// IsNested reports whether the entry came from a transitively-resolved
+// foundry rather than directly from a registered root foundry.
+func (e CatalogEntry) IsNested() bool { return len(e.OwnerChain) > 0 }
+
 // LoadCatalog walks every effective foundry's cached index and flattens it
-// into a single slice. Foundries without a cached index are skipped silently
-// (they'll appear once the user runs `foundry update` or hits `r` in the TUI).
+// into a single slice, resolving any nested foundries declared by each
+// registered root via their `foundries:` field. Lookups are cache-only —
+// uncached foundries (root or nested) are skipped silently and surface once
+// the user runs `foundry update` or hits `r` in the TUI.
 func LoadCatalog(cfg *index.Config) ([]CatalogEntry, error) {
 	cacheDir, err := index.IndexCacheDir()
 	if err != nil {
 		return nil, err
 	}
+	lookup := cacheOnlyLookup(cacheDir)
+
+	seen := map[string]bool{} // dedupe nested molds shared across roots, keyed by source
 	var out []CatalogEntry
 	for _, entry := range cfg.EffectiveFoundries() {
-		idx, err := index.LoadCachedIndex(cacheDir, &entry)
+		r := index.NewResolver(lookup)
+		root, molds, err := r.Resolve(entry.URL)
 		if err != nil {
+			// Root not cached (or invalid) — skip, mirroring the prior behavior.
 			continue
 		}
 		verified := index.IsOfficialFoundry(entry.URL)
-		for _, m := range idx.Molds {
+		for _, m := range molds {
+			if seen[m.Entry.Source] {
+				continue
+			}
+			seen[m.Entry.Source] = true
+			var chain []string
+			if m.Foundry != root {
+				// Parents is rooted at the registered root, plus the owning
+				// foundry's own name for the final hop.
+				chain = append(append([]string(nil), m.Foundry.Parents...), m.Foundry.Index.Name)
+			}
 			out = append(out, CatalogEntry{
-				Name:        m.Name,
-				Source:      m.Source,
-				Description: m.Description,
-				Tags:        m.Tags,
+				Name:        m.Entry.Name,
+				Source:      m.Entry.Source,
+				Description: m.Entry.Description,
+				Tags:        m.Entry.Tags,
 				FoundryName: entry.Name,
 				FoundryURL:  entry.URL,
-				Verified:    verified,
+				OwnerChain:  chain,
+				Verified:    verified && m.Foundry == root,
 				IndexedAt:   entry.LastUpdated,
 			})
 		}
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out, nil
+}
+
+// cacheOnlyLookup returns an IndexLookup that reads from the index cache and
+// never falls back to the network. The TUI's existing UX is "skip indexes
+// that aren't cached yet" — `r` refreshes the active tab. Honor that for
+// nested foundries too: an uncached child surfaces as a Resolver warning we
+// drop, not a silent network fetch from the render loop.
+func cacheOnlyLookup(cacheDir string) index.IndexLookup {
+	return func(source string) (*index.Index, error) {
+		url := index.NormalizeFoundryURL(source)
+		entry := &index.FoundryEntry{URL: url, Type: index.DetectType(url)}
+		return index.LoadCachedIndex(cacheDir, entry)
+	}
 }
 
 // Recent returns up to n catalog entries indexed within the lookback window,

--- a/internal/tui/foundries/data/catalog_test.go
+++ b/internal/tui/foundries/data/catalog_test.go
@@ -1,0 +1,172 @@
+package data
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nimble-giant/ailloy/pkg/foundry/index"
+)
+
+// writeCachedIndex writes a foundry index YAML to the cache location for entry.
+func writeCachedIndex(t *testing.T, cacheDir string, entry index.FoundryEntry, body string) {
+	t.Helper()
+	path := index.CachedIndexPath(cacheDir, &entry)
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestLoadCatalog_FlattensNestedFoundries verifies that the Discover catalog
+// includes molds from foundries reached via the registered root's
+// `foundries:` field, and tags them with their resolution chain.
+func TestLoadCatalog_FlattensNestedFoundries(t *testing.T) {
+	cacheDir := t.TempDir()
+	t.Setenv("AILLOY_INDEX_CACHE_DIR", cacheDir)
+
+	// Root foundry references one nested foundry by source URL.
+	root := index.FoundryEntry{Name: "root", URL: "https://github.com/example/root", Type: "git"}
+	writeCachedIndex(t, cacheDir, root, `apiVersion: v1
+kind: foundry-index
+name: root
+molds:
+  - name: alpha
+    source: github.com/example/alpha
+foundries:
+  - name: child
+    source: https://github.com/example/child
+`)
+
+	// Nested foundry — must be cached separately under its own URL hash.
+	child := index.FoundryEntry{URL: "https://github.com/example/child", Type: "git"}
+	writeCachedIndex(t, cacheDir, child, `apiVersion: v1
+kind: foundry-index
+name: child
+molds:
+  - name: beta
+    source: github.com/example/beta
+`)
+
+	cfg := &index.Config{Foundries: []index.FoundryEntry{root}}
+	catalog, err := LoadCatalog(cfg)
+	if err != nil {
+		t.Fatalf("LoadCatalog: %v", err)
+	}
+	if len(catalog) != 2 {
+		t.Fatalf("len(catalog) = %d want 2; got %+v", len(catalog), catalog)
+	}
+
+	byName := map[string]CatalogEntry{}
+	for _, e := range catalog {
+		byName[e.Name] = e
+	}
+
+	alpha, ok := byName["alpha"]
+	if !ok {
+		t.Fatal("expected alpha (root mold) in catalog")
+	}
+	if alpha.IsNested() {
+		t.Errorf("root mold reported nested: chain=%v", alpha.OwnerChain)
+	}
+	if alpha.FoundryName != "root" {
+		t.Errorf("alpha.FoundryName = %q want root", alpha.FoundryName)
+	}
+
+	beta, ok := byName["beta"]
+	if !ok {
+		t.Fatal("expected beta (nested mold) in catalog")
+	}
+	if !beta.IsNested() {
+		t.Fatalf("nested mold reported as root; chain=%v", beta.OwnerChain)
+	}
+	if beta.FoundryName != "root" {
+		t.Errorf("beta.FoundryName = %q want root (registered root foundry)", beta.FoundryName)
+	}
+	wantChain := []string{"root", "child"}
+	if len(beta.OwnerChain) != 2 || beta.OwnerChain[0] != wantChain[0] || beta.OwnerChain[1] != wantChain[1] {
+		t.Errorf("beta.OwnerChain = %v want %v", beta.OwnerChain, wantChain)
+	}
+}
+
+// TestLoadCatalog_UncachedNestedFoundryIsSkipped verifies that an uncached
+// child foundry doesn't break the render — the root and its direct molds
+// still surface; the missing child is silently skipped (Resolver records a
+// warning we drop).
+func TestLoadCatalog_UncachedNestedFoundryIsSkipped(t *testing.T) {
+	cacheDir := t.TempDir()
+	t.Setenv("AILLOY_INDEX_CACHE_DIR", cacheDir)
+
+	root := index.FoundryEntry{Name: "root", URL: "https://github.com/example/root", Type: "git"}
+	writeCachedIndex(t, cacheDir, root, `apiVersion: v1
+kind: foundry-index
+name: root
+molds:
+  - name: alpha
+    source: github.com/example/alpha
+foundries:
+  - name: missing
+    source: https://github.com/example/not-cached
+`)
+
+	cfg := &index.Config{Foundries: []index.FoundryEntry{root}}
+	catalog, err := LoadCatalog(cfg)
+	if err != nil {
+		t.Fatalf("LoadCatalog: %v", err)
+	}
+	if len(catalog) != 1 || catalog[0].Name != "alpha" {
+		t.Fatalf("expected only alpha in catalog, got %+v", catalog)
+	}
+}
+
+// TestLoadCatalog_DedupesNestedMoldSharedAcrossRoots verifies that when two
+// registered root foundries both transitively pull in the same nested mold
+// (by source URL), it appears only once in the catalog rather than as a
+// duplicate row.
+func TestLoadCatalog_DedupesNestedMoldSharedAcrossRoots(t *testing.T) {
+	cacheDir := t.TempDir()
+	t.Setenv("AILLOY_INDEX_CACHE_DIR", cacheDir)
+
+	// Two registered roots both nest the same child foundry.
+	rootA := index.FoundryEntry{Name: "rootA", URL: "https://github.com/example/rootA", Type: "git"}
+	rootB := index.FoundryEntry{Name: "rootB", URL: "https://github.com/example/rootB", Type: "git"}
+	writeCachedIndex(t, cacheDir, rootA, `apiVersion: v1
+kind: foundry-index
+name: rootA
+foundries:
+  - name: shared
+    source: https://github.com/example/shared
+`)
+	writeCachedIndex(t, cacheDir, rootB, `apiVersion: v1
+kind: foundry-index
+name: rootB
+foundries:
+  - name: shared
+    source: https://github.com/example/shared
+`)
+	shared := index.FoundryEntry{URL: "https://github.com/example/shared", Type: "git"}
+	writeCachedIndex(t, cacheDir, shared, `apiVersion: v1
+kind: foundry-index
+name: shared
+molds:
+  - name: gamma
+    source: github.com/example/gamma
+`)
+
+	cfg := &index.Config{Foundries: []index.FoundryEntry{rootA, rootB}}
+	catalog, err := LoadCatalog(cfg)
+	if err != nil {
+		t.Fatalf("LoadCatalog: %v", err)
+	}
+	count := 0
+	for _, e := range catalog {
+		if e.Name == "gamma" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected gamma to appear once, got %d times", count)
+	}
+}

--- a/internal/tui/foundries/discover/model.go
+++ b/internal/tui/foundries/discover/model.go
@@ -256,6 +256,15 @@ func (m *Model) applyFilter() {
 	}
 }
 
+// CurrentMold returns the highlighted catalog entry's mold reference and the
+// scope to use when casting. Returns ok=false when no entry is highlighted.
+func (m Model) CurrentMold() (ref string, scope data.Scope, ok bool) {
+	if m.cursor < 0 || m.cursor >= len(m.filtered) {
+		return "", "", false
+	}
+	return m.filtered[m.cursor].Source, data.ScopeProject, true
+}
+
 func (m Model) View() string {
 	if m.loading {
 		return metaStyle.Render("Loading catalog…")

--- a/internal/tui/foundries/discover/model.go
+++ b/internal/tui/foundries/discover/model.go
@@ -265,6 +265,12 @@ func (m Model) CurrentMold() (ref string, scope data.Scope, ok bool) {
 	return m.filtered[m.cursor].Source, data.ScopeProject, true
 }
 
+// NewWithFiltered constructs a Model directly with a known filtered slice
+// and cursor — exported for cross-package tests in the foundries app.
+func NewWithFiltered(entries []data.CatalogEntry, cursor int) Model {
+	return Model{filtered: entries, cursor: cursor}
+}
+
 func (m Model) View() string {
 	if m.loading {
 		return metaStyle.Render("Loading catalog…")

--- a/internal/tui/foundries/discover/model.go
+++ b/internal/tui/foundries/discover/model.go
@@ -380,11 +380,16 @@ func (m Model) View() string {
 				status = "  " + statusErrStyle.Render("("+s+")")
 			}
 		}
-		fmt.Fprintf(&b, "%s%s %s%s%s %s%s\n",
+		nested := ""
+		if e.IsNested() {
+			nested = " " + descStyle.Render("via "+strings.Join(e.OwnerChain, " → "))
+		}
+		fmt.Fprintf(&b, "%s%s %s%s%s%s %s%s\n",
 			caret, mark,
 			moldNameStyle.Render(e.Name),
 			verified,
 			installedTag,
+			nested,
 			descStyle.Render("— "+e.Description),
 			status)
 	}

--- a/internal/tui/foundries/discover/model.go
+++ b/internal/tui/foundries/discover/model.go
@@ -282,6 +282,8 @@ func NewWithFiltered(entries []data.CatalogEntry, cursor int) Model {
 
 // ApplySessionOverrides records session overrides for the given mold ref.
 // They will be applied as --set overrides on the next cast of that mold.
+// Last-write-wins: re-applying replaces any prior pending overrides for the
+// same ref rather than merging.
 func (m Model) ApplySessionOverrides(moldRef string, overrides map[string]any) Model {
 	if m.pending == nil {
 		m.pending = map[string][]string{}
@@ -290,16 +292,33 @@ func (m Model) ApplySessionOverrides(moldRef string, overrides map[string]any) M
 	return m
 }
 
-// encodeSetOverrides converts a typed override map into the --set k=v
-// strings that CastOptions.SetOverrides expects. Result is sorted for
-// deterministic ordering.
+// encodeSetOverrides converts a typed override map into the --set k=v strings
+// that CastOptions.SetOverrides expects. Slices are emitted as YAML flow
+// sequences ([a,b,c]) so the cast core's YAML-aware --set parser produces a
+// real list rather than parsing the Go-default "[a b c]" form as a single
+// string. Result is sorted for deterministic ordering.
 func encodeSetOverrides(overrides map[string]any) []string {
 	out := make([]string, 0, len(overrides))
 	for k, v := range overrides {
-		out = append(out, fmt.Sprintf("%s=%v", k, v))
+		out = append(out, fmt.Sprintf("%s=%s", k, formatSetValue(v)))
 	}
 	sort.Strings(out)
 	return out
+}
+
+func formatSetValue(v any) string {
+	switch x := v.(type) {
+	case []string:
+		return "[" + strings.Join(x, ",") + "]"
+	case []any:
+		parts := make([]string, len(x))
+		for i, item := range x {
+			parts[i] = fmt.Sprintf("%v", item)
+		}
+		return "[" + strings.Join(parts, ",") + "]"
+	default:
+		return fmt.Sprintf("%v", v)
+	}
 }
 
 func (m Model) View() string {

--- a/internal/tui/foundries/discover/model.go
+++ b/internal/tui/foundries/discover/model.go
@@ -64,7 +64,8 @@ type Model struct {
 	loading     bool
 	loadErr     error
 	castStat    map[string]string
-	autoFetched bool // guard so we only auto-fetch once per session
+	autoFetched bool                // guard so we only auto-fetch once per session
+	pending     map[string][]string // moldRef → encoded "--set" overrides
 }
 
 type catalogLoadedMsg struct {
@@ -155,6 +156,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			m.castStat[msg.source] = "err: " + msg.err.Error()
 		} else {
 			m.castStat[msg.source] = "ok"
+			delete(m.pending, msg.source)
 		}
 		// Refresh inventory so the "installed" badge updates immediately.
 		return m, loadInventoryCmd(m.cfg)
@@ -221,11 +223,18 @@ func (m Model) fetchCmd() tea.Cmd {
 
 func (m Model) castCmd(source string) tea.Cmd {
 	cast := m.cast
+	// Capture pending overrides at Cmd build time so concurrent picker edits
+	// don't change what's already in flight.
+	extra := append([]string(nil), m.pending[source]...)
 	return func() tea.Msg {
 		if cast == nil {
 			return castDoneMsg{source: source, err: fmt.Errorf("no cast function configured")}
 		}
-		return castDoneMsg{source: source, err: cast(context.Background(), source, CastOptions{})}
+		opts := CastOptions{}
+		if len(extra) > 0 {
+			opts.SetOverrides = append(opts.SetOverrides, extra...)
+		}
+		return castDoneMsg{source: source, err: cast(context.Background(), source, opts)}
 	}
 }
 
@@ -269,6 +278,28 @@ func (m Model) CurrentMold() (ref string, scope data.Scope, ok bool) {
 // and cursor — exported for cross-package tests in the foundries app.
 func NewWithFiltered(entries []data.CatalogEntry, cursor int) Model {
 	return Model{filtered: entries, cursor: cursor}
+}
+
+// ApplySessionOverrides records session overrides for the given mold ref.
+// They will be applied as --set overrides on the next cast of that mold.
+func (m Model) ApplySessionOverrides(moldRef string, overrides map[string]any) Model {
+	if m.pending == nil {
+		m.pending = map[string][]string{}
+	}
+	m.pending[moldRef] = encodeSetOverrides(overrides)
+	return m
+}
+
+// encodeSetOverrides converts a typed override map into the --set k=v
+// strings that CastOptions.SetOverrides expects. Result is sorted for
+// deterministic ordering.
+func encodeSetOverrides(overrides map[string]any) []string {
+	out := make([]string, 0, len(overrides))
+	for k, v := range overrides {
+		out = append(out, fmt.Sprintf("%s=%v", k, v))
+	}
+	sort.Strings(out)
+	return out
 }
 
 func (m Model) View() string {

--- a/internal/tui/foundries/discover/model_test.go
+++ b/internal/tui/foundries/discover/model_test.go
@@ -31,3 +31,22 @@ func TestCurrentMold_HighlightedEntry(t *testing.T) {
 		t.Fatalf("scope = %v want ScopeProject (default)", scope)
 	}
 }
+
+func TestApplySessionOverrides_StoresEncoded(t *testing.T) {
+	m := Model{}
+	m = m.ApplySessionOverrides("official/x", map[string]any{
+		"agents.targets":  []string{"opencode"},
+		"agents.parallel": true,
+	})
+	got := m.pending["official/x"]
+	if len(got) != 2 {
+		t.Fatalf("len = %d want 2; got %v", len(got), got)
+	}
+	// Sorted; "agents.parallel" < "agents.targets"
+	if got[0] != "agents.parallel=true" {
+		t.Fatalf("got[0] = %q", got[0])
+	}
+	if got[1] != "agents.targets=[opencode]" {
+		t.Fatalf("got[1] = %q (note: %%v formatting on []string)", got[1])
+	}
+}

--- a/internal/tui/foundries/discover/model_test.go
+++ b/internal/tui/foundries/discover/model_test.go
@@ -35,18 +35,20 @@ func TestCurrentMold_HighlightedEntry(t *testing.T) {
 func TestApplySessionOverrides_StoresEncoded(t *testing.T) {
 	m := Model{}
 	m = m.ApplySessionOverrides("official/x", map[string]any{
-		"agents.targets":  []string{"opencode"},
+		"agents.targets":  []string{"opencode", "claude"},
 		"agents.parallel": true,
 	})
 	got := m.pending["official/x"]
 	if len(got) != 2 {
 		t.Fatalf("len = %d want 2; got %v", len(got), got)
 	}
-	// Sorted; "agents.parallel" < "agents.targets"
+	// Sorted: "agents.parallel" < "agents.targets".
 	if got[0] != "agents.parallel=true" {
 		t.Fatalf("got[0] = %q", got[0])
 	}
-	if got[1] != "agents.targets=[opencode]" {
-		t.Fatalf("got[1] = %q (note: %%v formatting on []string)", got[1])
+	// Slices are emitted as YAML flow sequences so the --set parser produces
+	// a real list, not a single space-separated string.
+	if got[1] != "agents.targets=[opencode,claude]" {
+		t.Fatalf("got[1] = %q want agents.targets=[opencode,claude]", got[1])
 	}
 }

--- a/internal/tui/foundries/discover/model_test.go
+++ b/internal/tui/foundries/discover/model_test.go
@@ -1,0 +1,33 @@
+package discover
+
+import (
+	"testing"
+
+	"github.com/nimble-giant/ailloy/internal/tui/foundries/data"
+)
+
+func TestCurrentMold_NoSelection(t *testing.T) {
+	m := Model{}
+	if _, _, ok := m.CurrentMold(); ok {
+		t.Fatalf("expected ok=false on empty model")
+	}
+}
+
+func TestCurrentMold_HighlightedEntry(t *testing.T) {
+	m := Model{
+		filtered: []data.CatalogEntry{
+			{Name: "agents", Source: "official/agents"},
+		},
+		cursor: 0,
+	}
+	ref, scope, ok := m.CurrentMold()
+	if !ok {
+		t.Fatalf("expected ok=true with one filtered entry")
+	}
+	if ref != "official/agents" {
+		t.Fatalf("ref = %q want %q", ref, "official/agents")
+	}
+	if scope != data.ScopeProject {
+		t.Fatalf("scope = %v want ScopeProject (default)", scope)
+	}
+}

--- a/internal/tui/foundries/fluxpicker/editor.go
+++ b/internal/tui/foundries/fluxpicker/editor.go
@@ -104,6 +104,9 @@ func commitEditorValue(m Model, fv mold.FluxVar, raw string) Model {
 		}
 		m.overrides[fv.Name] = n
 	case "bool":
+		// Permissive parse for non-form callers (tests, future programmatic
+		// callers). The TUI path always synthesizes "true"/"false" before
+		// reaching here, so the alternate forms are unreachable from the UI.
 		switch strings.ToLower(strings.TrimSpace(raw)) {
 		case "true", "yes", "y", "1":
 			m.overrides[fv.Name] = true

--- a/internal/tui/foundries/fluxpicker/editor.go
+++ b/internal/tui/foundries/fluxpicker/editor.go
@@ -1,0 +1,161 @@
+package fluxpicker
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/charmbracelet/huh"
+
+	"github.com/nimble-giant/ailloy/pkg/mold"
+)
+
+// buildEditorForm returns a huh.Form for editing one FluxVar. The form's
+// state is driven by `value` (string-typed) for most fields and `boolVal`
+// for booleans. On submit, commitEditorValue parses the appropriate field
+// back into the typed override.
+func buildEditorForm(fv mold.FluxVar, value *string, boolVal *bool) *huh.Form {
+	switch fv.Type {
+	case "bool":
+		return huh.NewForm(
+			huh.NewGroup(
+				huh.NewConfirm().
+					Title(fv.Name).
+					Description(fv.Description).
+					Affirmative("Yes").
+					Negative("No").
+					Value(boolVal),
+			),
+		)
+	case "int":
+		return huh.NewForm(
+			huh.NewGroup(
+				huh.NewInput().
+					Title(fv.Name).
+					Description(fv.Description).
+					Value(value).
+					Validate(func(s string) error {
+						if s == "" {
+							return nil
+						}
+						if _, err := strconv.Atoi(s); err != nil {
+							return fmt.Errorf("must be an integer")
+						}
+						return nil
+					}),
+			),
+		)
+	case "list":
+		return huh.NewForm(
+			huh.NewGroup(
+				huh.NewText().
+					Title(fv.Name).
+					Description(fv.Description).
+					Lines(4).
+					Placeholder("comma- or newline-separated").
+					Value(value),
+			),
+		)
+	case "select":
+		opts := make([]huh.Option[string], 0, len(fv.Options))
+		for _, o := range fv.Options {
+			opts = append(opts, huh.NewOption(o.Label, o.Value))
+		}
+		return huh.NewForm(
+			huh.NewGroup(
+				huh.NewSelect[string]().
+					Title(fv.Name).
+					Description(fv.Description).
+					Options(opts...).
+					Value(value),
+			),
+		)
+	default: // string
+		return huh.NewForm(
+			huh.NewGroup(
+				huh.NewInput().
+					Title(fv.Name).
+					Description(fv.Description).
+					Value(value),
+			),
+		)
+	}
+}
+
+// commitEditorValue parses raw user input into the typed override and stores
+// it on the model. Empty input clears the override. Validation failures are
+// recorded on m.err and the override is left unchanged.
+func commitEditorValue(m Model, fv mold.FluxVar, raw string) Model {
+	if m.overrides == nil {
+		m.overrides = map[string]any{}
+	}
+	if strings.TrimSpace(raw) == "" {
+		delete(m.overrides, fv.Name)
+		m.err = nil
+		return m
+	}
+	switch fv.Type {
+	case "int":
+		n, err := strconv.Atoi(strings.TrimSpace(raw))
+		if err != nil {
+			m.err = fmt.Errorf("%s: must be an integer", fv.Name)
+			return m
+		}
+		m.overrides[fv.Name] = n
+	case "bool":
+		switch strings.ToLower(strings.TrimSpace(raw)) {
+		case "true", "yes", "y", "1":
+			m.overrides[fv.Name] = true
+		case "false", "no", "n", "0":
+			m.overrides[fv.Name] = false
+		default:
+			m.err = fmt.Errorf("%s: must be true/false", fv.Name)
+			return m
+		}
+	case "list":
+		var parts []string
+		for _, p := range strings.FieldsFunc(raw, func(r rune) bool { return r == ',' || r == '\n' }) {
+			t := strings.TrimSpace(p)
+			if t == "" {
+				continue
+			}
+			parts = append(parts, t)
+		}
+		m.overrides[fv.Name] = parts
+	case "select":
+		v := strings.TrimSpace(raw)
+		if len(fv.Options) > 0 {
+			ok := false
+			for _, o := range fv.Options {
+				if o.Value == v {
+					ok = true
+					break
+				}
+			}
+			if !ok {
+				m.err = fmt.Errorf("%s: %q is not a valid option", fv.Name, v)
+				return m
+			}
+		}
+		m.overrides[fv.Name] = v
+	default:
+		m.overrides[fv.Name] = raw
+	}
+	m.err = nil
+	return m
+}
+
+// ErrUnknownVar is returned when the editor is asked to commit a variable
+// not present in the schema.
+var ErrUnknownVar = errors.New("unknown flux variable")
+
+// findVar searches a schema by name.
+func findVar(schema []mold.FluxVar, name string) (mold.FluxVar, bool) {
+	for _, v := range schema {
+		if v.Name == name {
+			return v, true
+		}
+	}
+	return mold.FluxVar{}, false
+}

--- a/internal/tui/foundries/fluxpicker/editor_test.go
+++ b/internal/tui/foundries/fluxpicker/editor_test.go
@@ -1,0 +1,86 @@
+package fluxpicker
+
+import (
+	"testing"
+
+	"github.com/nimble-giant/ailloy/pkg/mold"
+)
+
+func TestCommitEditorValue_String(t *testing.T) {
+	fv := mold.FluxVar{Name: "k", Type: "string"}
+	m := commitEditorValue(Model{overrides: map[string]any{}}, fv, "hello")
+	if got := m.Overrides()["k"]; got != "hello" {
+		t.Fatalf("override = %v want hello", got)
+	}
+}
+
+func TestCommitEditorValue_Int(t *testing.T) {
+	fv := mold.FluxVar{Name: "k", Type: "int"}
+	m := commitEditorValue(Model{overrides: map[string]any{}}, fv, "42")
+	if got := m.Overrides()["k"]; got != 42 {
+		t.Fatalf("override = %v want 42 (int)", got)
+	}
+}
+
+func TestCommitEditorValue_IntInvalid(t *testing.T) {
+	fv := mold.FluxVar{Name: "k", Type: "int"}
+	m := Model{overrides: map[string]any{}}
+	m2 := commitEditorValue(m, fv, "abc")
+	if _, ok := m2.Overrides()["k"]; ok {
+		t.Fatal("expected invalid int to NOT set the override")
+	}
+	if m2.err == nil {
+		t.Fatal("expected validation error on m2.err")
+	}
+}
+
+func TestCommitEditorValue_Bool(t *testing.T) {
+	fv := mold.FluxVar{Name: "k", Type: "bool"}
+	m := commitEditorValue(Model{overrides: map[string]any{}}, fv, "true")
+	if got := m.Overrides()["k"]; got != true {
+		t.Fatalf("override = %v want true", got)
+	}
+}
+
+func TestCommitEditorValue_List(t *testing.T) {
+	fv := mold.FluxVar{Name: "k", Type: "list"}
+	m := commitEditorValue(Model{overrides: map[string]any{}}, fv, "a, b, c")
+	got, ok := m.Overrides()["k"].([]string)
+	if !ok {
+		t.Fatalf("override type = %T want []string", m.Overrides()["k"])
+	}
+	if len(got) != 3 || got[0] != "a" || got[1] != "b" || got[2] != "c" {
+		t.Fatalf("list = %v want [a b c]", got)
+	}
+}
+
+func TestCommitEditorValue_EmptyClears(t *testing.T) {
+	fv := mold.FluxVar{Name: "k", Type: "string"}
+	m := Model{overrides: map[string]any{"k": "old"}}
+	m2 := commitEditorValue(m, fv, "")
+	if _, ok := m2.Overrides()["k"]; ok {
+		t.Fatal("expected empty value to clear the override")
+	}
+}
+
+func TestCommitEditorValue_SelectValidates(t *testing.T) {
+	fv := mold.FluxVar{
+		Name: "k",
+		Type: "select",
+		Options: []mold.SelectOption{
+			{Value: "a", Label: "A"},
+			{Value: "b", Label: "B"},
+		},
+	}
+	m := commitEditorValue(Model{overrides: map[string]any{}}, fv, "a")
+	if got := m.Overrides()["k"]; got != "a" {
+		t.Fatalf("override = %v want a", got)
+	}
+	m2 := commitEditorValue(Model{overrides: map[string]any{}}, fv, "z")
+	if _, ok := m2.Overrides()["k"]; ok {
+		t.Fatal("expected invalid select to NOT set override")
+	}
+	if m2.err == nil {
+		t.Fatal("expected error on invalid select option")
+	}
+}

--- a/internal/tui/foundries/fluxpicker/filter.go
+++ b/internal/tui/foundries/fluxpicker/filter.go
@@ -1,0 +1,30 @@
+package fluxpicker
+
+import (
+	"sort"
+
+	"github.com/sahilm/fuzzy"
+
+	"github.com/nimble-giant/ailloy/pkg/mold"
+)
+
+// filterKeys returns schema vars filtered (and ranked) against query. Empty
+// query returns all vars sorted by name.
+func filterKeys(schema []mold.FluxVar, query string) []mold.FluxVar {
+	if query == "" {
+		out := make([]mold.FluxVar, len(schema))
+		copy(out, schema)
+		sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+		return out
+	}
+	names := make([]string, len(schema))
+	for i, v := range schema {
+		names[i] = v.Name
+	}
+	matches := fuzzy.Find(query, names)
+	out := make([]mold.FluxVar, 0, len(matches))
+	for _, m := range matches {
+		out = append(out, schema[m.Index])
+	}
+	return out
+}

--- a/internal/tui/foundries/fluxpicker/filter.go
+++ b/internal/tui/foundries/fluxpicker/filter.go
@@ -14,7 +14,7 @@ func filterKeys(schema []mold.FluxVar, query string) []mold.FluxVar {
 	if query == "" {
 		out := make([]mold.FluxVar, len(schema))
 		copy(out, schema)
-		sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+		sort.SliceStable(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 		return out
 	}
 	names := make([]string, len(schema))

--- a/internal/tui/foundries/fluxpicker/filter_test.go
+++ b/internal/tui/foundries/fluxpicker/filter_test.go
@@ -45,3 +45,12 @@ func TestFilterKeys_NoMatches(t *testing.T) {
 		t.Fatalf("expected zero matches, got %d", len(out))
 	}
 }
+
+func TestFilterKeys_NilSchema(t *testing.T) {
+	if got := filterKeys(nil, ""); len(got) != 0 {
+		t.Fatalf("nil schema empty query: len = %d want 0", len(got))
+	}
+	if got := filterKeys(nil, "x"); len(got) != 0 {
+		t.Fatalf("nil schema with query: len = %d want 0", len(got))
+	}
+}

--- a/internal/tui/foundries/fluxpicker/filter_test.go
+++ b/internal/tui/foundries/fluxpicker/filter_test.go
@@ -1,0 +1,47 @@
+package fluxpicker
+
+import (
+	"testing"
+
+	"github.com/nimble-giant/ailloy/pkg/mold"
+)
+
+func TestFilterKeys_EmptyQueryReturnsAll(t *testing.T) {
+	schema := []mold.FluxVar{
+		{Name: "agents.targets"},
+		{Name: "agents.parallel"},
+		{Name: "runtime.profile"},
+	}
+	out := filterKeys(schema, "")
+	if len(out) != 3 {
+		t.Fatalf("len = %d want 3", len(out))
+	}
+	if out[0].Name != "agents.parallel" {
+		t.Fatalf("expected sorted by name; got first = %q", out[0].Name)
+	}
+}
+
+func TestFilterKeys_FuzzyRanking(t *testing.T) {
+	schema := []mold.FluxVar{
+		{Name: "agents.targets"},
+		{Name: "agents.parallel"},
+		{Name: "runtime.profile"},
+	}
+	out := filterKeys(schema, "agents.tar")
+	if len(out) == 0 {
+		t.Fatal("expected at least one match")
+	}
+	if out[0].Name != "agents.targets" {
+		t.Fatalf("top match = %q want agents.targets", out[0].Name)
+	}
+}
+
+func TestFilterKeys_NoMatches(t *testing.T) {
+	schema := []mold.FluxVar{
+		{Name: "agents.targets"},
+	}
+	out := filterKeys(schema, "zzz")
+	if len(out) != 0 {
+		t.Fatalf("expected zero matches, got %d", len(out))
+	}
+}

--- a/internal/tui/foundries/fluxpicker/integration_test.go
+++ b/internal/tui/foundries/fluxpicker/integration_test.go
@@ -61,7 +61,9 @@ func TestEndToEnd_SaveToProject(t *testing.T) {
 		t.Fatal("expected emit cmd from save")
 	}
 
-	wantPath := filepath.Join(".ailloy", "flux", "agents.yaml")
+	// Slug is derived from the full mold ref so nested-foundry molds with
+	// the same final segment can't clobber each other.
+	wantPath := filepath.Join(".ailloy", "flux", "official_agents.yaml")
 	b, err := os.ReadFile(wantPath)
 	if err != nil {
 		t.Fatalf("read written file at %s: %v", wantPath, err)

--- a/internal/tui/foundries/fluxpicker/integration_test.go
+++ b/internal/tui/foundries/fluxpicker/integration_test.go
@@ -1,0 +1,121 @@
+package fluxpicker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	yaml "github.com/goccy/go-yaml"
+
+	"github.com/nimble-giant/ailloy/internal/tui/foundries/data"
+	"github.com/nimble-giant/ailloy/pkg/mold"
+)
+
+func TestEndToEnd_SaveToProject(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	schema := []mold.FluxVar{
+		{Name: "agents.targets", Type: "list"},
+		{Name: "agents.parallel", Type: "bool", Default: "true"},
+	}
+	m := New().OpenFor("official/agents", data.ScopeProject, schema, nil)
+
+	// User filters by typing.
+	m.filter.SetValue("agents.tar")
+
+	// Tab commits the top match into the editor.
+	m, _ = m.Update(keyMsg("tab"))
+	if m.editor.key != "agents.targets" {
+		t.Fatalf("editor.key = %q want agents.targets", m.editor.key)
+	}
+
+	// Simulate the user typing into the editor by setting the form-pointer
+	// directly (the huh.Form would otherwise need a real terminal).
+	if m.editor.rawValue == nil {
+		t.Fatal("expected editor.rawValue pointer to be initialized")
+	}
+	*m.editor.rawValue = "opencode, claude"
+
+	// Enter commits the value back to overrides.
+	m, _ = m.Update(keyMsg("enter"))
+	got, ok := m.Overrides()["agents.targets"].([]string)
+	if !ok || len(got) != 2 {
+		t.Fatalf("override not applied: %+v", m.Overrides())
+	}
+
+	// Blur the filter so that the 's' shortcut key is recognized (not typed
+	// into the filter text input).
+	m.filter.Blur()
+
+	// Open save prompt and save to project.
+	m, _ = m.Update(keyMsg("s"))
+	if m.focus != focusSavePrompt {
+		t.Fatalf("expected save prompt, got focus=%v", m.focus)
+	}
+	m, cmd := m.Update(keyMsg("p"))
+	if m.err != nil {
+		t.Fatalf("save error: %v", m.err)
+	}
+	if cmd == nil {
+		t.Fatal("expected emit cmd from save")
+	}
+
+	wantPath := filepath.Join(".ailloy", "flux", "agents.yaml")
+	b, err := os.ReadFile(wantPath)
+	if err != nil {
+		t.Fatalf("read written file at %s: %v", wantPath, err)
+	}
+	var fileBack map[string]any
+	if err := yaml.Unmarshal(b, &fileBack); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	agents, _ := fileBack["agents"].(map[string]any)
+	if agents == nil {
+		t.Fatalf("expected nested agents map, got %+v", fileBack)
+	}
+	targets, _ := agents["targets"].([]any)
+	if len(targets) != 2 || targets[0] != "opencode" || targets[1] != "claude" {
+		t.Fatalf("targets = %v want [opencode claude]", targets)
+	}
+}
+
+func TestEndToEnd_SessionTargetSkipsDisk(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	schema := []mold.FluxVar{{Name: "k", Type: "string"}}
+	m := New().OpenFor("ref", data.ScopeProject, schema, nil)
+	m = m.SetOverride("k", "v")
+
+	// Blur the filter so that the 's' shortcut key is recognized (not typed
+	// into the filter text input).
+	m.filter.Blur()
+
+	m, _ = m.Update(keyMsg("s"))
+	if m.focus != focusSavePrompt {
+		t.Fatalf("expected save prompt focus, got %v", m.focus)
+	}
+	m, cmd := m.Update(keyMsg("o"))
+	if cmd == nil {
+		t.Fatal("expected emit cmd from session save")
+	}
+
+	// Confirm no flux file was written.
+	if _, err := os.Stat(filepath.Join(".ailloy", "flux", "ref.yaml")); !os.IsNotExist(err) {
+		t.Fatalf("expected no flux file on session save; stat err = %v", err)
+	}
+
+	// Confirm the emitted message has Target=Session.
+	msg := cmd()
+	fm, ok := msg.(FluxOverridesMsg)
+	if !ok {
+		t.Fatalf("got %T want FluxOverridesMsg", msg)
+	}
+	if fm.Target != SaveTargetSession {
+		t.Fatalf("target = %v want SaveTargetSession", fm.Target)
+	}
+	if fm.Overrides["k"] != "v" {
+		t.Fatalf("overrides not propagated: %+v", fm.Overrides)
+	}
+}

--- a/internal/tui/foundries/fluxpicker/messages.go
+++ b/internal/tui/foundries/fluxpicker/messages.go
@@ -24,12 +24,6 @@ type FluxOverridesMsg struct {
 	Target    SaveTarget
 }
 
-// OpenPickerMsg requests that the picker open scoped to a particular mold.
-type OpenPickerMsg struct {
-	MoldRef string
-	Scope   data.Scope
-}
-
 // SchemaFetchedMsg is dispatched when async schema fetch completes. The App
 // fires this in response to OpenFor and the picker stitches the result into
 // its Model when MoldRef matches the current target.

--- a/internal/tui/foundries/fluxpicker/messages.go
+++ b/internal/tui/foundries/fluxpicker/messages.go
@@ -30,11 +30,12 @@ type OpenPickerMsg struct {
 	Scope   data.Scope
 }
 
-// schemaFetchedMsg is dispatched when async schema fetch completes.
-// (Promoted to exported SchemaFetchedMsg in Task 13.)
-type schemaFetchedMsg struct {
-	moldRef  string
-	schema   []mold.FluxVar
-	defaults map[string]any
-	err      error
+// SchemaFetchedMsg is dispatched when async schema fetch completes. The App
+// fires this in response to OpenFor and the picker stitches the result into
+// its Model when MoldRef matches the current target.
+type SchemaFetchedMsg struct {
+	MoldRef  string
+	Schema   []mold.FluxVar
+	Defaults map[string]any
+	Err      error
 }

--- a/internal/tui/foundries/fluxpicker/messages.go
+++ b/internal/tui/foundries/fluxpicker/messages.go
@@ -1,0 +1,40 @@
+package fluxpicker
+
+import (
+	"github.com/nimble-giant/ailloy/internal/tui/foundries/data"
+	"github.com/nimble-giant/ailloy/pkg/mold"
+)
+
+// SaveTarget identifies where the picker writes overrides on save.
+type SaveTarget int
+
+const (
+	SaveTargetSession SaveTarget = iota
+	SaveTargetProject
+	SaveTargetGlobal
+)
+
+// FluxOverridesMsg is emitted by the picker on close. The active tab folds
+// these into its next cast call (via CastOptions.SetOverrides) or notes that
+// they have already been written to a file (Target != SaveTargetSession).
+type FluxOverridesMsg struct {
+	MoldRef   string
+	Scope     data.Scope
+	Overrides map[string]any
+	Target    SaveTarget
+}
+
+// OpenPickerMsg requests that the picker open scoped to a particular mold.
+type OpenPickerMsg struct {
+	MoldRef string
+	Scope   data.Scope
+}
+
+// schemaFetchedMsg is dispatched when async schema fetch completes.
+// (Promoted to exported SchemaFetchedMsg in Task 13.)
+type schemaFetchedMsg struct {
+	moldRef  string
+	schema   []mold.FluxVar
+	defaults map[string]any
+	err      error
+}

--- a/internal/tui/foundries/fluxpicker/model.go
+++ b/internal/tui/foundries/fluxpicker/model.go
@@ -106,7 +106,9 @@ type editorState struct {
 
 // saveState holds the save-target prompt's transient state.
 type saveState struct {
-	active bool
+	active    bool
+	committed bool
+	target    SaveTarget
 }
 
 // BadgeState describes the visual badge to draw next to a key in the list.

--- a/internal/tui/foundries/fluxpicker/model.go
+++ b/internal/tui/foundries/fluxpicker/model.go
@@ -96,3 +96,80 @@ type editorState struct {
 type saveState struct {
 	active bool
 }
+
+// BadgeState describes the visual badge to draw next to a key in the list.
+type BadgeState int
+
+const (
+	BadgeUnset BadgeState = iota
+	BadgeDefault
+	BadgeSet
+)
+
+// SetOverride records a session override.
+func (m Model) SetOverride(key string, value any) Model {
+	if m.overrides == nil {
+		m.overrides = map[string]any{}
+	}
+	m.overrides[key] = value
+	return m
+}
+
+// ClearOverride removes a session override.
+func (m Model) ClearOverride(key string) Model {
+	delete(m.overrides, key)
+	return m
+}
+
+// ResetOverrides clears all session overrides.
+func (m Model) ResetOverrides() Model {
+	m.overrides = map[string]any{}
+	return m
+}
+
+// BadgeStateFor returns the badge to render next to a key. The defaults map
+// uses dotted-path lookup (e.g. "agents.targets" → defaults["agents"]["targets"]).
+func (m Model) BadgeStateFor(key string) BadgeState {
+	if _, ok := m.overrides[key]; ok {
+		return BadgeSet
+	}
+	if hasDottedKey(m.defaults, key) {
+		return BadgeDefault
+	}
+	return BadgeUnset
+}
+
+// hasDottedKey reports whether a dotted key exists in a nested map.
+func hasDottedKey(m map[string]any, key string) bool {
+	if m == nil {
+		return false
+	}
+	parts := splitDots(key)
+	cur := any(m)
+	for _, p := range parts {
+		mm, ok := cur.(map[string]any)
+		if !ok {
+			return false
+		}
+		v, present := mm[p]
+		if !present {
+			return false
+		}
+		cur = v
+	}
+	return true
+}
+
+// splitDots splits "a.b.c" into ["a","b","c"].
+func splitDots(s string) []string {
+	out := []string{}
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '.' {
+			out = append(out, s[start:i])
+			start = i + 1
+		}
+	}
+	out = append(out, s[start:])
+	return out
+}

--- a/internal/tui/foundries/fluxpicker/model.go
+++ b/internal/tui/foundries/fluxpicker/model.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/charmbracelet/huh"
 
 	"github.com/nimble-giant/ailloy/internal/tui/foundries/data"
 	"github.com/nimble-giant/ailloy/pkg/mold"
@@ -90,11 +91,13 @@ func (m Model) Close() Model {
 	return m
 }
 
-// editorState holds the active key being edited. Form fields are added in
-// Task 7.
+// editorState holds the active key being edited.
 type editorState struct {
-	active bool
-	key    string
+	active   bool
+	key      string
+	form     *huh.Form
+	rawValue *string
+	boolVal  *bool
 }
 
 // saveState holds the save-target prompt's transient state.

--- a/internal/tui/foundries/fluxpicker/model.go
+++ b/internal/tui/foundries/fluxpicker/model.go
@@ -141,6 +141,13 @@ func (m Model) ResetOverrides() Model {
 	return m
 }
 
+// SetFetching marks the picker as awaiting an asynchronous schema fetch.
+// The View renders a spinner-style placeholder when this is true.
+func (m Model) SetFetching(v bool) Model {
+	m.fetching = v
+	return m
+}
+
 // BadgeStateFor returns the badge to render next to a key. The defaults map
 // uses dotted-path lookup (e.g. "agents.targets" → defaults["agents"]["targets"]).
 func (m Model) BadgeStateFor(key string) BadgeState {

--- a/internal/tui/foundries/fluxpicker/model.go
+++ b/internal/tui/foundries/fluxpicker/model.go
@@ -91,7 +91,11 @@ func (m Model) Close() Model {
 	return m
 }
 
-// editorState holds the active key being edited.
+// editorState holds the active key being edited. rawValue and boolVal MUST
+// be the same pointers passed to buildEditorForm — the huh.Form mutates them
+// in place, and handleEditorKey reads through them on commit. Always replace
+// the whole struct via buildEditorForm rather than overwriting fields
+// individually, or the form will mutate orphaned memory.
 type editorState struct {
 	active   bool
 	key      string

--- a/internal/tui/foundries/fluxpicker/model.go
+++ b/internal/tui/foundries/fluxpicker/model.go
@@ -1,0 +1,98 @@
+package fluxpicker
+
+import (
+	"github.com/charmbracelet/bubbles/textinput"
+
+	"github.com/nimble-giant/ailloy/internal/tui/foundries/data"
+	"github.com/nimble-giant/ailloy/pkg/mold"
+)
+
+// focusArea identifies which sub-component holds keyboard focus.
+type focusArea int
+
+const (
+	focusFilter focusArea = iota
+	focusEditor
+	focusSavePrompt
+)
+
+// Model is the state for the flux picker overlay. It is a value type to fit
+// Bubble Tea's pattern of pure Update functions.
+type Model struct {
+	open      bool
+	moldRef   string
+	scope     data.Scope
+	schema    []mold.FluxVar
+	defaults  map[string]any
+	overrides map[string]any
+	filter    textinput.Model
+	cursor    int
+	focus     focusArea
+	editor    editorState
+	saving    saveState
+	err       error
+	width     int
+	height    int
+	fetching  bool
+}
+
+// New returns a closed picker model.
+func New() Model {
+	ti := textinput.New()
+	ti.Placeholder = "filter flux keys (e.g. agents.tar)"
+	ti.Prompt = "▸ "
+	return Model{
+		filter:    ti,
+		overrides: map[string]any{},
+	}
+}
+
+// IsOpen reports whether the picker is currently visible.
+func (m Model) IsOpen() bool { return m.open }
+
+// MoldRef returns the mold reference the picker is scoped to.
+func (m Model) MoldRef() string { return m.moldRef }
+
+// Scope returns the scope (project/global) inherited from the active tab.
+func (m Model) Scope() data.Scope { return m.scope }
+
+// Overrides returns the current session overrides.
+func (m Model) Overrides() map[string]any { return m.overrides }
+
+// OpenFor opens the picker scoped to the given mold and schema.
+func (m Model) OpenFor(ref string, scope data.Scope, schema []mold.FluxVar, defaults map[string]any) Model {
+	m.open = true
+	m.moldRef = ref
+	m.scope = scope
+	m.schema = schema
+	m.defaults = defaults
+	m.overrides = map[string]any{}
+	m.cursor = 0
+	m.focus = focusFilter
+	m.filter.SetValue("")
+	m.filter.Focus()
+	m.err = nil
+	return m
+}
+
+// Close hides the picker and clears transient state. Overrides are retained
+// so the App can broadcast them to the active tab on close.
+func (m Model) Close() Model {
+	m.open = false
+	m.focus = focusFilter
+	m.editor = editorState{}
+	m.saving = saveState{}
+	return m
+}
+
+// editorState holds the active key being edited. Form fields are added in
+// Task 7.
+type editorState struct {
+	active bool
+	key    string
+}
+
+// saveState holds the save-target prompt's transient state.
+type saveState struct {
+	active bool
+}

--- a/internal/tui/foundries/fluxpicker/model.go
+++ b/internal/tui/foundries/fluxpicker/model.go
@@ -1,6 +1,8 @@
 package fluxpicker
 
 import (
+	"strings"
+
 	"github.com/charmbracelet/bubbles/textinput"
 
 	"github.com/nimble-giant/ailloy/internal/tui/foundries/data"
@@ -19,11 +21,14 @@ const (
 // Model is the state for the flux picker overlay. It is a value type to fit
 // Bubble Tea's pattern of pure Update functions.
 type Model struct {
-	open      bool
-	moldRef   string
-	scope     data.Scope
-	schema    []mold.FluxVar
-	defaults  map[string]any
+	open     bool
+	moldRef  string
+	scope    data.Scope
+	schema   []mold.FluxVar
+	defaults map[string]any
+	// overrides is keyed by the dotted FluxVar.Name (e.g. "agents.targets"),
+	// not by nested maps — kept flat so badge lookup and --set encoding stay
+	// trivial. defaults is YAML-shaped (nested), populated from flux.yaml.
 	overrides map[string]any
 	filter    textinput.Model
 	cursor    int
@@ -144,7 +149,7 @@ func hasDottedKey(m map[string]any, key string) bool {
 	if m == nil {
 		return false
 	}
-	parts := splitDots(key)
+	parts := strings.Split(key, ".")
 	cur := any(m)
 	for _, p := range parts {
 		mm, ok := cur.(map[string]any)
@@ -158,18 +163,4 @@ func hasDottedKey(m map[string]any, key string) bool {
 		cur = v
 	}
 	return true
-}
-
-// splitDots splits "a.b.c" into ["a","b","c"].
-func splitDots(s string) []string {
-	out := []string{}
-	start := 0
-	for i := 0; i < len(s); i++ {
-		if s[i] == '.' {
-			out = append(out, s[start:i])
-			start = i + 1
-		}
-	}
-	out = append(out, s[start:])
-	return out
 }

--- a/internal/tui/foundries/fluxpicker/model_test.go
+++ b/internal/tui/foundries/fluxpicker/model_test.go
@@ -30,3 +30,56 @@ func TestClose_ClearsOpenFlag(t *testing.T) {
 		t.Fatal("expected closed after Close")
 	}
 }
+
+func TestSetOverride_StoresValue(t *testing.T) {
+	m := New().OpenFor("a", data.ScopeProject, nil, nil)
+	m = m.SetOverride("agents.targets", []string{"opencode"})
+	if got := m.Overrides()["agents.targets"]; got == nil {
+		t.Fatalf("expected override to be set, overrides = %+v", m.Overrides())
+	}
+}
+
+func TestClearOverride_RemovesValue(t *testing.T) {
+	m := New().OpenFor("a", data.ScopeProject, nil, nil)
+	m = m.SetOverride("k", "v").ClearOverride("k")
+	if _, ok := m.Overrides()["k"]; ok {
+		t.Fatal("expected override to be cleared")
+	}
+}
+
+func TestResetOverrides_EmptiesMap(t *testing.T) {
+	m := New().OpenFor("a", data.ScopeProject, nil, nil).
+		SetOverride("k1", 1).
+		SetOverride("k2", 2).
+		ResetOverrides()
+	if len(m.Overrides()) != 0 {
+		t.Fatalf("expected empty overrides, got %+v", m.Overrides())
+	}
+}
+
+func TestBadgeStateFor(t *testing.T) {
+	schema := []mold.FluxVar{{Name: "k", Default: "d"}}
+	defaults := map[string]any{"k": "d"}
+	m := New().OpenFor("a", data.ScopeProject, schema, defaults)
+	if got := m.BadgeStateFor("k"); got != BadgeDefault {
+		t.Fatalf("expected BadgeDefault, got %v", got)
+	}
+	m = m.SetOverride("k", "x")
+	if got := m.BadgeStateFor("k"); got != BadgeSet {
+		t.Fatalf("expected BadgeSet, got %v", got)
+	}
+	if got := m.BadgeStateFor("missing"); got != BadgeUnset {
+		t.Fatalf("expected BadgeUnset, got %v", got)
+	}
+}
+
+func TestBadgeStateFor_DottedDefault(t *testing.T) {
+	schema := []mold.FluxVar{{Name: "agents.parallel"}}
+	defaults := map[string]any{
+		"agents": map[string]any{"parallel": true},
+	}
+	m := New().OpenFor("a", data.ScopeProject, schema, defaults)
+	if got := m.BadgeStateFor("agents.parallel"); got != BadgeDefault {
+		t.Fatalf("expected BadgeDefault for nested default, got %v", got)
+	}
+}

--- a/internal/tui/foundries/fluxpicker/model_test.go
+++ b/internal/tui/foundries/fluxpicker/model_test.go
@@ -1,0 +1,32 @@
+package fluxpicker
+
+import (
+	"testing"
+
+	"github.com/nimble-giant/ailloy/internal/tui/foundries/data"
+	"github.com/nimble-giant/ailloy/pkg/mold"
+)
+
+func TestNew_DefaultsAndOpenForMold(t *testing.T) {
+	m := New()
+	if m.IsOpen() {
+		t.Fatal("expected closed picker on construction")
+	}
+
+	schema := []mold.FluxVar{{Name: "k", Type: "string"}}
+	m = m.OpenFor("official/demo", data.ScopeProject, schema, map[string]any{"k": "v"})
+	if !m.IsOpen() {
+		t.Fatal("expected open after OpenFor")
+	}
+	if got := m.MoldRef(); got != "official/demo" {
+		t.Fatalf("MoldRef = %q want official/demo", got)
+	}
+}
+
+func TestClose_ClearsOpenFlag(t *testing.T) {
+	m := New().OpenFor("a", data.ScopeProject, nil, nil)
+	m = m.Close()
+	if m.IsOpen() {
+		t.Fatal("expected closed after Close")
+	}
+}

--- a/internal/tui/foundries/fluxpicker/persist.go
+++ b/internal/tui/foundries/fluxpicker/persist.go
@@ -16,10 +16,12 @@ import (
 // cannot leave the user's flux file truncated.
 func writeFluxFile(path string, overrides map[string]any) error {
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return err
 	}
 	existing := map[string]any{}
+	// #nosec G304 -- path is built from a sanitized mold name plus a fixed
+	// project- or home-rooted prefix; not user-controlled at the moment of read.
 	if b, err := os.ReadFile(path); err == nil {
 		_ = yaml.Unmarshal(b, &existing)
 	}
@@ -46,7 +48,7 @@ func writeFluxFile(path string, overrides map[string]any) error {
 		_ = os.Remove(tmpPath)
 		return err
 	}
-	if err := os.Chmod(tmpPath, 0o644); err != nil {
+	if err := os.Chmod(tmpPath, 0o600); err != nil {
 		_ = os.Remove(tmpPath)
 		return err
 	}

--- a/internal/tui/foundries/fluxpicker/persist.go
+++ b/internal/tui/foundries/fluxpicker/persist.go
@@ -120,3 +120,18 @@ func lastPathSegment(s string) string {
 	}
 	return s
 }
+
+// mergeOverrides returns a new map combining defaults and overrides
+// (overrides win at any nested key).
+func mergeOverrides(defaults map[string]any, overrides map[string]any) map[string]any {
+	out := map[string]any{}
+	for k, v := range defaults {
+		out[k] = v
+	}
+	for k, v := range overrides {
+		if err := setDottedKey(out, k, v); err != nil {
+			continue
+		}
+	}
+	return out
+}

--- a/internal/tui/foundries/fluxpicker/persist.go
+++ b/internal/tui/foundries/fluxpicker/persist.go
@@ -112,15 +112,44 @@ func persistOverrides(moldName string, target SaveTarget, overrides map[string]a
 	return "", fmt.Errorf("unknown save target %v", target)
 }
 
-// lastPathSegment returns the last segment after '/'. For "official/agents"
-// returns "agents". For "trailing/" returns "".
-func lastPathSegment(s string) string {
-	for i := len(s) - 1; i >= 0; i-- {
-		if s[i] == '/' {
-			return s[i+1:]
+// fluxFileSlug derives a deterministic, filesystem-safe filename stem from a
+// mold ref. The full source is preserved (with separators replaced) so molds
+// with the same final segment under different foundries — including nested
+// foundries that can re-export molds — don't collide on disk.
+//
+//	"github.com/nimble-giant/agents@v1"  → "github.com_nimble-giant_agents_v1"
+//	"nimble-giant/agents"                → "nimble-giant_agents"
+//	"agents"                             → "agents"
+//
+// Anything that isn't [A-Za-z0-9._-] is collapsed to '_'.
+func fluxFileSlug(ref string) string {
+	ref = strings.TrimSuffix(strings.TrimSpace(ref), ".git")
+	if ref == "" {
+		return "mold"
+	}
+	out := make([]byte, 0, len(ref))
+	for i := 0; i < len(ref); i++ {
+		c := ref[i]
+		switch {
+		case c >= 'a' && c <= 'z',
+			c >= 'A' && c <= 'Z',
+			c >= '0' && c <= '9',
+			c == '.', c == '-':
+			out = append(out, c)
+		default:
+			if len(out) > 0 && out[len(out)-1] != '_' {
+				out = append(out, '_')
+			}
 		}
 	}
-	return s
+	// Trim trailing underscore from collapsed runs at the tail.
+	for len(out) > 0 && out[len(out)-1] == '_' {
+		out = out[:len(out)-1]
+	}
+	if len(out) == 0 {
+		return "mold"
+	}
+	return string(out)
 }
 
 // mergeOverrides returns a new map combining defaults and overrides

--- a/internal/tui/foundries/fluxpicker/persist.go
+++ b/internal/tui/foundries/fluxpicker/persist.go
@@ -7,15 +7,16 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
-
-	"github.com/nimble-giant/ailloy/internal/tui/foundries/data"
 )
 
 // writeFluxFile writes overrides into a YAML file at path, merging with any
 // existing content (overrides win for keys present in both). Dotted override
-// keys are expanded into nested maps.
+// keys are expanded into nested maps. The write is atomic: the new contents
+// land in a sibling temp file and are renamed into place, so a crash mid-write
+// cannot leave the user's flux file truncated.
 func writeFluxFile(path string, overrides map[string]any) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
 	existing := map[string]any{}
@@ -31,7 +32,29 @@ func writeFluxFile(path string, overrides map[string]any) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, out, 0o644)
+	tmp, err := os.CreateTemp(dir, ".flux-*.yaml")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(out); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Chmod(tmpPath, 0o644); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return nil
 }
 
 // setDottedKey writes value into m at the nested location implied by a dotted
@@ -70,8 +93,7 @@ func resolveGlobalPath(moldName string) (string, error) {
 
 // persistOverrides routes overrides to the chosen save target. Returns the
 // path written (empty string for SaveTargetSession).
-func persistOverrides(scope data.Scope, moldName string, target SaveTarget, overrides map[string]any) (string, error) {
-	_ = scope // reserved for future use
+func persistOverrides(moldName string, target SaveTarget, overrides map[string]any) (string, error) {
 	switch target {
 	case SaveTargetSession:
 		return "", nil
@@ -85,7 +107,7 @@ func persistOverrides(scope data.Scope, moldName string, target SaveTarget, over
 		}
 		return path, writeFluxFile(path, overrides)
 	}
-	return "", fmt.Errorf("unknown save target %d", target)
+	return "", fmt.Errorf("unknown save target %v", target)
 }
 
 // lastPathSegment returns the last segment after '/'. For "official/agents"

--- a/internal/tui/foundries/fluxpicker/persist.go
+++ b/internal/tui/foundries/fluxpicker/persist.go
@@ -38,20 +38,20 @@ func writeFluxFile(path string, overrides map[string]any) error {
 	}
 	tmpPath := tmp.Name()
 	if _, err := tmp.Write(out); err != nil {
-		tmp.Close()
-		os.Remove(tmpPath)
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
 		return err
 	}
 	if err := tmp.Close(); err != nil {
-		os.Remove(tmpPath)
+		_ = os.Remove(tmpPath)
 		return err
 	}
 	if err := os.Chmod(tmpPath, 0o644); err != nil {
-		os.Remove(tmpPath)
+		_ = os.Remove(tmpPath)
 		return err
 	}
 	if err := os.Rename(tmpPath, path); err != nil {
-		os.Remove(tmpPath)
+		_ = os.Remove(tmpPath)
 		return err
 	}
 	return nil

--- a/internal/tui/foundries/fluxpicker/persist.go
+++ b/internal/tui/foundries/fluxpicker/persist.go
@@ -1,0 +1,100 @@
+package fluxpicker
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	yaml "github.com/goccy/go-yaml"
+
+	"github.com/nimble-giant/ailloy/internal/tui/foundries/data"
+)
+
+// writeFluxFile writes overrides into a YAML file at path, merging with any
+// existing content (overrides win for keys present in both). Dotted override
+// keys are expanded into nested maps.
+func writeFluxFile(path string, overrides map[string]any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	existing := map[string]any{}
+	if b, err := os.ReadFile(path); err == nil {
+		_ = yaml.Unmarshal(b, &existing)
+	}
+	for k, v := range overrides {
+		if err := setDottedKey(existing, k, v); err != nil {
+			return err
+		}
+	}
+	out, err := yaml.Marshal(existing)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, out, 0o644)
+}
+
+// setDottedKey writes value into m at the nested location implied by a dotted
+// key (e.g. "agents.targets" → m["agents"]["targets"] = value).
+func setDottedKey(m map[string]any, key string, value any) error {
+	parts := strings.Split(key, ".")
+	cur := m
+	for i, p := range parts {
+		if i == len(parts)-1 {
+			cur[p] = value
+			return nil
+		}
+		next, _ := cur[p].(map[string]any)
+		if next == nil {
+			next = map[string]any{}
+			cur[p] = next
+		}
+		cur = next
+	}
+	return nil
+}
+
+// resolveProjectPath returns the project-scoped flux file path for a mold.
+func resolveProjectPath(moldName string) string {
+	return filepath.Join(".ailloy", "flux", moldName+".yaml")
+}
+
+// resolveGlobalPath returns the global-scoped flux file path for a mold.
+func resolveGlobalPath(moldName string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".ailloy", "flux", moldName+".yaml"), nil
+}
+
+// persistOverrides routes overrides to the chosen save target. Returns the
+// path written (empty string for SaveTargetSession).
+func persistOverrides(scope data.Scope, moldName string, target SaveTarget, overrides map[string]any) (string, error) {
+	_ = scope // reserved for future use
+	switch target {
+	case SaveTargetSession:
+		return "", nil
+	case SaveTargetProject:
+		path := resolveProjectPath(moldName)
+		return path, writeFluxFile(path, overrides)
+	case SaveTargetGlobal:
+		path, err := resolveGlobalPath(moldName)
+		if err != nil {
+			return "", err
+		}
+		return path, writeFluxFile(path, overrides)
+	}
+	return "", fmt.Errorf("unknown save target %d", target)
+}
+
+// lastPathSegment returns the last segment after '/'. For "official/agents"
+// returns "agents". For "trailing/" returns "".
+func lastPathSegment(s string) string {
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == '/' {
+			return s[i+1:]
+		}
+	}
+	return s
+}

--- a/internal/tui/foundries/fluxpicker/persist_test.go
+++ b/internal/tui/foundries/fluxpicker/persist_test.go
@@ -1,0 +1,83 @@
+package fluxpicker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	yaml "github.com/goccy/go-yaml"
+
+	"github.com/nimble-giant/ailloy/internal/tui/foundries/data"
+)
+
+func TestWriteFluxFile_CreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "flux.yaml")
+	overrides := map[string]any{"agents.targets": []string{"opencode"}}
+	if err := writeFluxFile(path, overrides); err != nil {
+		t.Fatalf("writeFluxFile: %v", err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	var got map[string]any
+	if err := yaml.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	agents, _ := got["agents"].(map[string]any)
+	if agents == nil {
+		t.Fatalf("expected nested agents map, got %+v", got)
+	}
+	targets, _ := agents["targets"].([]any)
+	if len(targets) != 1 || targets[0] != "opencode" {
+		t.Fatalf("targets = %v want [opencode]", targets)
+	}
+}
+
+func TestWriteFluxFile_MergesExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "flux.yaml")
+	if err := os.WriteFile(path, []byte("agents:\n  parallel: true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	overrides := map[string]any{"agents.targets": []string{"opencode"}}
+	if err := writeFluxFile(path, overrides); err != nil {
+		t.Fatalf("writeFluxFile: %v", err)
+	}
+	b, _ := os.ReadFile(path)
+	var got map[string]any
+	_ = yaml.Unmarshal(b, &got)
+	agents := got["agents"].(map[string]any)
+	if agents["parallel"] != true {
+		t.Fatalf("expected existing parallel:true preserved, got %+v", agents)
+	}
+	if _, ok := agents["targets"]; !ok {
+		t.Fatalf("expected targets to be merged in, got %+v", agents)
+	}
+}
+
+func TestPersistOverrides_Session(t *testing.T) {
+	path, err := persistOverrides(data.ScopeProject, "agents", SaveTargetSession, map[string]any{"k": "v"})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if path != "" {
+		t.Fatalf("expected empty path for session target, got %q", path)
+	}
+}
+
+func TestLastPathSegment(t *testing.T) {
+	cases := map[string]string{
+		"":                "",
+		"agents":          "agents",
+		"official/agents": "agents",
+		"a/b/c/d":         "d",
+		"trailing/":       "",
+	}
+	for in, want := range cases {
+		if got := lastPathSegment(in); got != want {
+			t.Errorf("lastPathSegment(%q) = %q want %q", in, got, want)
+		}
+	}
+}

--- a/internal/tui/foundries/fluxpicker/persist_test.go
+++ b/internal/tui/foundries/fluxpicker/persist_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	yaml "github.com/goccy/go-yaml"
-
-	"github.com/nimble-giant/ailloy/internal/tui/foundries/data"
 )
 
 func TestWriteFluxFile_CreatesFile(t *testing.T) {
@@ -58,12 +56,42 @@ func TestWriteFluxFile_MergesExisting(t *testing.T) {
 }
 
 func TestPersistOverrides_Session(t *testing.T) {
-	path, err := persistOverrides(data.ScopeProject, "agents", SaveTargetSession, map[string]any{"k": "v"})
+	path, err := persistOverrides("agents", SaveTargetSession, map[string]any{"k": "v"})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	if path != "" {
 		t.Fatalf("expected empty path for session target, got %q", path)
+	}
+}
+
+func TestPersistOverrides_ProjectWritesFile(t *testing.T) {
+	t.Chdir(t.TempDir())
+	path, err := persistOverrides("agents", SaveTargetProject, map[string]any{"agents.targets": []string{"opencode"}})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if path != ".ailloy/flux/agents.yaml" {
+		t.Fatalf("path = %q want .ailloy/flux/agents.yaml", path)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected file at %s, got %v", path, err)
+	}
+}
+
+func TestPersistOverrides_GlobalWritesFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path, err := persistOverrides("agents", SaveTargetGlobal, map[string]any{"k": "v"})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	want := filepath.Join(home, ".ailloy", "flux", "agents.yaml")
+	if path != want {
+		t.Fatalf("path = %q want %q", path, want)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected file at %s, got %v", path, err)
 	}
 }
 

--- a/internal/tui/foundries/fluxpicker/persist_test.go
+++ b/internal/tui/foundries/fluxpicker/persist_test.go
@@ -95,17 +95,31 @@ func TestPersistOverrides_GlobalWritesFile(t *testing.T) {
 	}
 }
 
-func TestLastPathSegment(t *testing.T) {
+func TestFluxFileSlug(t *testing.T) {
 	cases := map[string]string{
-		"":                "",
-		"agents":          "agents",
-		"official/agents": "agents",
-		"a/b/c/d":         "d",
-		"trailing/":       "",
+		"":                                   "mold",
+		"agents":                             "agents",
+		"official/agents":                    "official_agents",
+		"github.com/nimble-giant/agents":     "github.com_nimble-giant_agents",
+		"github.com/nimble-giant/agents@v1":  "github.com_nimble-giant_agents_v1",
+		"github.com/nimble-giant/agents.git": "github.com_nimble-giant_agents",
+		"github.com/foo/bar//sub/path":       "github.com_foo_bar_sub_path",
+		"trailing/":                          "trailing",
+		"  spaces around  ":                  "spaces_around",
 	}
 	for in, want := range cases {
-		if got := lastPathSegment(in); got != want {
-			t.Errorf("lastPathSegment(%q) = %q want %q", in, got, want)
+		if got := fluxFileSlug(in); got != want {
+			t.Errorf("fluxFileSlug(%q) = %q want %q", in, got, want)
 		}
+	}
+}
+
+// Sibling foundries that re-export a same-named mold must produce distinct
+// slugs so neither user's saved overrides clobber the other.
+func TestFluxFileSlug_AvoidsCrossFoundryCollision(t *testing.T) {
+	a := fluxFileSlug("github.com/nimble-giant/agents")
+	b := fluxFileSlug("github.com/replicated/agents")
+	if a == b {
+		t.Fatalf("expected distinct slugs across foundries; both = %q", a)
 	}
 }

--- a/internal/tui/foundries/fluxpicker/update.go
+++ b/internal/tui/foundries/fluxpicker/update.go
@@ -18,11 +18,12 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		return m, nil
 	case tea.KeyMsg:
 		return m.handleKey(msg)
-	case schemaFetchedMsg:
-		if msg.moldRef == m.moldRef {
-			m.schema = msg.schema
-			m.defaults = msg.defaults
-			m.err = msg.err
+	case SchemaFetchedMsg:
+		if msg.MoldRef == m.moldRef {
+			m.schema = msg.Schema
+			m.defaults = msg.Defaults
+			m.err = msg.Err
+			m.fetching = false
 		}
 		return m, nil
 	}

--- a/internal/tui/foundries/fluxpicker/update.go
+++ b/internal/tui/foundries/fluxpicker/update.go
@@ -1,7 +1,10 @@
 package fluxpicker
 
 import (
+	"fmt"
+
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/huh"
 
 	"github.com/nimble-giant/ailloy/pkg/mold"
 )
@@ -60,7 +63,21 @@ func (m Model) handleFilterKey(k tea.KeyMsg) (Model, tea.Cmd) {
 		if idx >= len(filtered) {
 			idx = 0
 		}
-		m.editor = editorState{active: true, key: filtered[idx].Name}
+		fv := filtered[idx]
+		raw := ""
+		if existing, ok := m.overrides[fv.Name]; ok {
+			raw = fmt.Sprint(existing)
+		}
+		bv := false
+		form := buildEditorForm(fv, &raw, &bv)
+		_ = form.Init()
+		m.editor = editorState{
+			active:   true,
+			key:      fv.Name,
+			form:     form,
+			rawValue: &raw,
+			boolVal:  &bv,
+		}
 		m.focus = focusEditor
 		m.filter.Blur()
 		return m, nil
@@ -93,13 +110,45 @@ func (m Model) handleFilterKey(k tea.KeyMsg) (Model, tea.Cmd) {
 	return m, cmd
 }
 
-// handleEditorKey is filled in by Task 7. For now, esc returns to filter.
+// handleEditorKey handles key events when the editor is focused.
 func (m Model) handleEditorKey(k tea.KeyMsg) (Model, tea.Cmd) {
-	if k.Type == tea.KeyEsc {
+	switch k.Type {
+	case tea.KeyEsc:
 		m.editor = editorState{}
 		m.focus = focusFilter
 		m.filter.Focus()
 		return m, nil
+	case tea.KeyEnter:
+		fv, ok := findVar(m.schema, m.editor.key)
+		if !ok {
+			m.err = ErrUnknownVar
+			return m, nil
+		}
+		raw := ""
+		if m.editor.rawValue != nil {
+			raw = *m.editor.rawValue
+		}
+		if fv.Type == "bool" {
+			if m.editor.boolVal != nil && *m.editor.boolVal {
+				raw = "true"
+			} else {
+				raw = "false"
+			}
+		}
+		m = commitEditorValue(m, fv, raw)
+		if m.err == nil {
+			m.editor = editorState{}
+			m.focus = focusFilter
+			m.filter.Focus()
+		}
+		return m, nil
+	}
+	if m.editor.form != nil {
+		next, cmd := m.editor.form.Update(k)
+		if f, ok := next.(*huh.Form); ok {
+			m.editor.form = f
+		}
+		return m, cmd
 	}
 	return m, nil
 }

--- a/internal/tui/foundries/fluxpicker/update.go
+++ b/internal/tui/foundries/fluxpicker/update.go
@@ -65,6 +65,9 @@ func (m Model) handleFilterKey(k tea.KeyMsg) (Model, tea.Cmd) {
 		m.filter.Blur()
 		return m, nil
 	case tea.KeyRunes:
+		// Single-character shortcuts only fire when the filter is blurred —
+		// otherwise typing 'd'/'R'/'s' into the filter would clear overrides
+		// or open the save prompt instead of editing the query.
 		if len(k.Runes) == 1 && !m.filter.Focused() {
 			switch k.Runes[0] {
 			case 'd':
@@ -82,7 +85,8 @@ func (m Model) handleFilterKey(k tea.KeyMsg) (Model, tea.Cmd) {
 			}
 		}
 	}
-	// Otherwise pass through to the textinput.
+	// Otherwise pass through to the textinput; filter changed, so reset the
+	// highlight to the top of the new result list.
 	var cmd tea.Cmd
 	m.filter, cmd = m.filter.Update(k)
 	m.cursor = 0

--- a/internal/tui/foundries/fluxpicker/update.go
+++ b/internal/tui/foundries/fluxpicker/update.go
@@ -174,7 +174,7 @@ func (m Model) handleSaveKey(k tea.KeyMsg) (Model, tea.Cmd) {
 			return m, nil
 		}
 		moldName := lastPathSegment(m.moldRef)
-		if _, err := persistOverrides(m.scope, moldName, target, m.overrides); err != nil {
+		if _, err := persistOverrides(moldName, target, m.overrides); err != nil {
 			m.err = err
 			return m, nil
 		}
@@ -186,9 +186,14 @@ func (m Model) handleSaveKey(k tea.KeyMsg) (Model, tea.Cmd) {
 
 // emitOverridesAndClose returns a Cmd that emits the FluxOverridesMsg
 // upstream. The App handles the message by closing the picker and routing
-// overrides to the active tab.
+// overrides to the active tab. The overrides map is shallow-copied so a
+// later OpenFor (which reassigns m.overrides) cannot leak edits into the
+// already-dispatched message.
 func emitOverridesAndClose(m Model, target SaveTarget) tea.Cmd {
-	overrides := m.overrides
+	overrides := make(map[string]any, len(m.overrides))
+	for k, v := range m.overrides {
+		overrides[k] = v
+	}
 	moldRef := m.moldRef
 	scope := m.scope
 	return func() tea.Msg {

--- a/internal/tui/foundries/fluxpicker/update.go
+++ b/internal/tui/foundries/fluxpicker/update.go
@@ -43,7 +43,11 @@ func (m Model) handleKey(k tea.KeyMsg) (Model, tea.Cmd) {
 func (m Model) handleFilterKey(k tea.KeyMsg) (Model, tea.Cmd) {
 	switch k.Type {
 	case tea.KeyEsc:
-		// Task 12 will add unsaved-changes confirm; for now, close.
+		if len(m.overrides) > 0 && !m.saving.committed {
+			m.saving = saveState{active: true}
+			m.focus = focusSavePrompt
+			return m, nil
+		}
 		return m.Close(), nil
 	case tea.KeyDown:
 		m.cursor = clamp(m.cursor+1, 0, len(m.filteredKeys())-1)
@@ -171,6 +175,11 @@ func (m Model) handleSaveKey(k tea.KeyMsg) (Model, tea.Cmd) {
 		case 'o':
 			target = SaveTargetSession
 		default:
+			return m, nil
+		}
+		merged := mergeOverrides(m.defaults, m.overrides)
+		if err := mold.ValidateFlux(m.schema, merged); err != nil {
+			m.err = err
 			return m, nil
 		}
 		moldName := lastPathSegment(m.moldRef)

--- a/internal/tui/foundries/fluxpicker/update.go
+++ b/internal/tui/foundries/fluxpicker/update.go
@@ -1,0 +1,130 @@
+package fluxpicker
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/nimble-giant/ailloy/pkg/mold"
+)
+
+// Update is the Bubble Tea update function for the picker. The caller (App)
+// only routes messages here when m.IsOpen() is true.
+func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width, m.height = msg.Width, msg.Height
+		return m, nil
+	case tea.KeyMsg:
+		return m.handleKey(msg)
+	case schemaFetchedMsg:
+		if msg.moldRef == m.moldRef {
+			m.schema = msg.schema
+			m.defaults = msg.defaults
+			m.err = msg.err
+		}
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m Model) handleKey(k tea.KeyMsg) (Model, tea.Cmd) {
+	switch m.focus {
+	case focusEditor:
+		return m.handleEditorKey(k)
+	case focusSavePrompt:
+		return m.handleSaveKey(k)
+	default:
+		return m.handleFilterKey(k)
+	}
+}
+
+func (m Model) handleFilterKey(k tea.KeyMsg) (Model, tea.Cmd) {
+	switch k.Type {
+	case tea.KeyEsc:
+		// Task 12 will add unsaved-changes confirm; for now, close.
+		return m.Close(), nil
+	case tea.KeyDown:
+		m.cursor = clamp(m.cursor+1, 0, len(m.filteredKeys())-1)
+		return m, nil
+	case tea.KeyUp:
+		m.cursor = clamp(m.cursor-1, 0, len(m.filteredKeys())-1)
+		return m, nil
+	case tea.KeyTab, tea.KeyEnter:
+		filtered := m.filteredKeys()
+		if len(filtered) == 0 {
+			return m, nil
+		}
+		idx := m.cursor
+		if k.Type == tea.KeyTab {
+			idx = 0 // tab commits top match
+		}
+		if idx >= len(filtered) {
+			idx = 0
+		}
+		m.editor = editorState{active: true, key: filtered[idx].Name}
+		m.focus = focusEditor
+		m.filter.Blur()
+		return m, nil
+	case tea.KeyRunes:
+		if len(k.Runes) == 1 && !m.filter.Focused() {
+			switch k.Runes[0] {
+			case 'd':
+				filtered := m.filteredKeys()
+				if m.cursor < len(filtered) {
+					m = m.ClearOverride(filtered[m.cursor].Name)
+				}
+				return m, nil
+			case 'R':
+				return m.ResetOverrides(), nil
+			case 's':
+				m.saving = saveState{active: true}
+				m.focus = focusSavePrompt
+				return m, nil
+			}
+		}
+	}
+	// Otherwise pass through to the textinput.
+	var cmd tea.Cmd
+	m.filter, cmd = m.filter.Update(k)
+	m.cursor = 0
+	return m, cmd
+}
+
+// handleEditorKey is filled in by Task 7. For now, esc returns to filter.
+func (m Model) handleEditorKey(k tea.KeyMsg) (Model, tea.Cmd) {
+	if k.Type == tea.KeyEsc {
+		m.editor = editorState{}
+		m.focus = focusFilter
+		m.filter.Focus()
+		return m, nil
+	}
+	return m, nil
+}
+
+// handleSaveKey is filled in by Task 8. For now, esc returns to filter.
+func (m Model) handleSaveKey(k tea.KeyMsg) (Model, tea.Cmd) {
+	if k.Type == tea.KeyEsc {
+		m.saving = saveState{}
+		m.focus = focusFilter
+		m.filter.Focus()
+		return m, nil
+	}
+	return m, nil
+}
+
+// filteredKeys returns the schema vars currently visible in the result list.
+func (m Model) filteredKeys() []mold.FluxVar {
+	return filterKeys(m.schema, m.filter.Value())
+}
+
+func clamp(v, lo, hi int) int {
+	if hi < lo {
+		return lo
+	}
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}

--- a/internal/tui/foundries/fluxpicker/update.go
+++ b/internal/tui/foundries/fluxpicker/update.go
@@ -153,7 +153,7 @@ func (m Model) handleEditorKey(k tea.KeyMsg) (Model, tea.Cmd) {
 	return m, nil
 }
 
-// handleSaveKey is filled in by Task 8. For now, esc returns to filter.
+// handleSaveKey handles key events when the save-target prompt is focused.
 func (m Model) handleSaveKey(k tea.KeyMsg) (Model, tea.Cmd) {
 	if k.Type == tea.KeyEsc {
 		m.saving = saveState{}
@@ -161,7 +161,44 @@ func (m Model) handleSaveKey(k tea.KeyMsg) (Model, tea.Cmd) {
 		m.filter.Focus()
 		return m, nil
 	}
+	if k.Type == tea.KeyRunes && len(k.Runes) == 1 {
+		var target SaveTarget
+		switch k.Runes[0] {
+		case 'p':
+			target = SaveTargetProject
+		case 'g':
+			target = SaveTargetGlobal
+		case 'o':
+			target = SaveTargetSession
+		default:
+			return m, nil
+		}
+		moldName := lastPathSegment(m.moldRef)
+		if _, err := persistOverrides(m.scope, moldName, target, m.overrides); err != nil {
+			m.err = err
+			return m, nil
+		}
+		m.saving = saveState{committed: true, target: target}
+		return m, emitOverridesAndClose(m, target)
+	}
 	return m, nil
+}
+
+// emitOverridesAndClose returns a Cmd that emits the FluxOverridesMsg
+// upstream. The App handles the message by closing the picker and routing
+// overrides to the active tab.
+func emitOverridesAndClose(m Model, target SaveTarget) tea.Cmd {
+	overrides := m.overrides
+	moldRef := m.moldRef
+	scope := m.scope
+	return func() tea.Msg {
+		return FluxOverridesMsg{
+			MoldRef:   moldRef,
+			Scope:     scope,
+			Overrides: overrides,
+			Target:    target,
+		}
+	}
 }
 
 // filteredKeys returns the schema vars currently visible in the result list.

--- a/internal/tui/foundries/fluxpicker/update.go
+++ b/internal/tui/foundries/fluxpicker/update.go
@@ -183,7 +183,7 @@ func (m Model) handleSaveKey(k tea.KeyMsg) (Model, tea.Cmd) {
 			m.err = err
 			return m, nil
 		}
-		moldName := lastPathSegment(m.moldRef)
+		moldName := fluxFileSlug(m.moldRef)
 		if _, err := persistOverrides(moldName, target, m.overrides); err != nil {
 			m.err = err
 			return m, nil

--- a/internal/tui/foundries/fluxpicker/update_test.go
+++ b/internal/tui/foundries/fluxpicker/update_test.go
@@ -135,3 +135,42 @@ func TestUpdate_ShortcutKeysGoToFilterWhenFocused(t *testing.T) {
 		t.Fatalf("filter value = %q want ds", m.filter.Value())
 	}
 }
+
+func TestHandleSaveKey_SessionEmitsMsg(t *testing.T) {
+	m := New().OpenFor("official/demo", data.ScopeProject, nil, nil).
+		SetOverride("k", "v")
+	m.saving = saveState{active: true}
+	m.focus = focusSavePrompt
+
+	m, cmd := m.Update(keyMsg("o"))
+	if cmd == nil {
+		t.Fatal("expected cmd that emits FluxOverridesMsg")
+	}
+	msg := cmd()
+	fm, ok := msg.(FluxOverridesMsg)
+	if !ok {
+		t.Fatalf("got %T want FluxOverridesMsg", msg)
+	}
+	if fm.Target != SaveTargetSession {
+		t.Fatalf("target = %v want SaveTargetSession", fm.Target)
+	}
+	if fm.Overrides["k"] != "v" {
+		t.Fatalf("overrides not propagated: %+v", fm.Overrides)
+	}
+	if !m.saving.committed {
+		t.Fatal("expected saving.committed=true after dispatch")
+	}
+}
+
+func TestHandleSaveKey_EscReturnsToFilter(t *testing.T) {
+	m := New().OpenFor("ref", data.ScopeProject, nil, nil)
+	m.saving = saveState{active: true}
+	m.focus = focusSavePrompt
+	m, _ = m.Update(keyMsg("esc"))
+	if m.focus != focusFilter {
+		t.Fatalf("expected focus to return to filter, got %v", m.focus)
+	}
+	if m.saving.active {
+		t.Fatal("expected saving cleared")
+	}
+}

--- a/internal/tui/foundries/fluxpicker/update_test.go
+++ b/internal/tui/foundries/fluxpicker/update_test.go
@@ -112,3 +112,26 @@ func TestUpdate_TypingIntoFilterUpdatesQuery(t *testing.T) {
 		t.Fatalf("cursor reset expected; got %d", m.cursor)
 	}
 }
+
+func TestUpdate_ShortcutKeysGoToFilterWhenFocused(t *testing.T) {
+	m := New().OpenFor("a", data.ScopeProject,
+		[]mold.FluxVar{{Name: "k"}}, nil).
+		SetOverride("k", "v")
+	// filter is focused by OpenFor; 'd' must NOT clear the override.
+	m, _ = m.Update(keyMsg("d"))
+	if _, ok := m.Overrides()["k"]; !ok {
+		t.Fatal("'d' on focused filter should not clear override")
+	}
+	if m.filter.Value() != "d" {
+		t.Fatalf("filter value = %q want d", m.filter.Value())
+	}
+
+	// 's' must NOT open save prompt while filter is focused.
+	m, _ = m.Update(keyMsg("s"))
+	if m.focus == focusSavePrompt {
+		t.Fatal("'s' on focused filter should not open save prompt")
+	}
+	if m.filter.Value() != "ds" {
+		t.Fatalf("filter value = %q want ds", m.filter.Value())
+	}
+}

--- a/internal/tui/foundries/fluxpicker/update_test.go
+++ b/internal/tui/foundries/fluxpicker/update_test.go
@@ -174,3 +174,40 @@ func TestHandleSaveKey_EscReturnsToFilter(t *testing.T) {
 		t.Fatal("expected saving cleared")
 	}
 }
+
+func TestSave_BlockedWhenRequiredFieldMissing(t *testing.T) {
+	schema := []mold.FluxVar{
+		{Name: "must_have", Type: "string", Required: true},
+	}
+	m := New().OpenFor("ref", data.ScopeProject, schema, nil)
+	m.saving = saveState{active: true}
+	m.focus = focusSavePrompt
+	m, _ = m.Update(keyMsg("o"))
+	if m.err == nil {
+		t.Fatal("expected validation error blocking save")
+	}
+}
+
+func TestEsc_WithUnsavedChanges_OpensSavePrompt(t *testing.T) {
+	m := New().OpenFor("ref", data.ScopeProject,
+		[]mold.FluxVar{{Name: "k", Type: "string"}}, nil).
+		SetOverride("k", "v")
+	m.filter.Blur()
+	m, _ = m.Update(keyMsg("esc"))
+	if !m.IsOpen() {
+		t.Fatal("expected picker to STAY open with unsaved changes")
+	}
+	if m.focus != focusSavePrompt {
+		t.Fatalf("expected save prompt focus, got %v", m.focus)
+	}
+}
+
+func TestEsc_NoChanges_ClosesPicker(t *testing.T) {
+	m := New().OpenFor("ref", data.ScopeProject,
+		[]mold.FluxVar{{Name: "k"}}, nil)
+	m.filter.Blur()
+	m, _ = m.Update(keyMsg("esc"))
+	if m.IsOpen() {
+		t.Fatal("expected picker to close with no overrides")
+	}
+}

--- a/internal/tui/foundries/fluxpicker/update_test.go
+++ b/internal/tui/foundries/fluxpicker/update_test.go
@@ -1,0 +1,114 @@
+package fluxpicker
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/nimble-giant/ailloy/internal/tui/foundries/data"
+	"github.com/nimble-giant/ailloy/pkg/mold"
+)
+
+func keyMsg(s string) tea.KeyMsg {
+	switch s {
+	case "esc":
+		return tea.KeyMsg{Type: tea.KeyEsc}
+	case "tab":
+		return tea.KeyMsg{Type: tea.KeyTab}
+	case "enter":
+		return tea.KeyMsg{Type: tea.KeyEnter}
+	case "down":
+		return tea.KeyMsg{Type: tea.KeyDown}
+	case "up":
+		return tea.KeyMsg{Type: tea.KeyUp}
+	default:
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+	}
+}
+
+func TestUpdate_EscClosesPicker(t *testing.T) {
+	m := New().OpenFor("a", data.ScopeProject,
+		[]mold.FluxVar{{Name: "k", Type: "string"}}, nil)
+	m.filter.Blur()
+	m, _ = m.Update(keyMsg("esc"))
+	if m.IsOpen() {
+		t.Fatal("expected esc to close picker")
+	}
+}
+
+func TestUpdate_DownArrowMovesCursor(t *testing.T) {
+	m := New().OpenFor("a", data.ScopeProject,
+		[]mold.FluxVar{
+			{Name: "a"}, {Name: "b"}, {Name: "c"},
+		}, nil)
+	m.filter.Blur()
+	m, _ = m.Update(keyMsg("down"))
+	if m.cursor != 1 {
+		t.Fatalf("cursor = %d want 1", m.cursor)
+	}
+}
+
+func TestUpdate_TabCommitsTopMatchToEditor(t *testing.T) {
+	schema := []mold.FluxVar{
+		{Name: "agents.targets", Type: "string"},
+		{Name: "runtime.profile", Type: "string"},
+	}
+	m := New().OpenFor("a", data.ScopeProject, schema, nil)
+	m.filter.SetValue("agents")
+	m, _ = m.Update(keyMsg("tab"))
+	if m.focus != focusEditor {
+		t.Fatalf("expected focus to move to editor; got %v", m.focus)
+	}
+	if m.editor.key != "agents.targets" {
+		t.Fatalf("editor.key = %q want agents.targets", m.editor.key)
+	}
+}
+
+func TestUpdate_DClearsHighlightedOverride(t *testing.T) {
+	m := New().OpenFor("a", data.ScopeProject,
+		[]mold.FluxVar{{Name: "k", Type: "string"}}, nil).
+		SetOverride("k", "v")
+	m.filter.Blur()
+	m, _ = m.Update(keyMsg("d"))
+	if _, ok := m.Overrides()["k"]; ok {
+		t.Fatal("expected 'd' to clear override on highlighted key")
+	}
+}
+
+func TestUpdate_RResetsAllOverrides(t *testing.T) {
+	m := New().OpenFor("a", data.ScopeProject,
+		[]mold.FluxVar{{Name: "k1"}, {Name: "k2"}}, nil).
+		SetOverride("k1", 1).
+		SetOverride("k2", 2)
+	m.filter.Blur()
+	m, _ = m.Update(keyMsg("R"))
+	if len(m.Overrides()) != 0 {
+		t.Fatalf("expected R to reset all; got %+v", m.Overrides())
+	}
+}
+
+func TestUpdate_SOpensSavePrompt(t *testing.T) {
+	m := New().OpenFor("a", data.ScopeProject,
+		[]mold.FluxVar{{Name: "k"}}, nil)
+	m.filter.Blur()
+	m, _ = m.Update(keyMsg("s"))
+	if m.focus != focusSavePrompt {
+		t.Fatalf("expected save prompt focus, got %v", m.focus)
+	}
+	if !m.saving.active {
+		t.Fatal("expected saving.active=true")
+	}
+}
+
+func TestUpdate_TypingIntoFilterUpdatesQuery(t *testing.T) {
+	m := New().OpenFor("a", data.ScopeProject,
+		[]mold.FluxVar{{Name: "agents.targets"}}, nil)
+	// filter is focused by OpenFor; type "a"
+	m, _ = m.Update(keyMsg("a"))
+	if v := m.filter.Value(); v != "a" {
+		t.Fatalf("filter value = %q want a", v)
+	}
+	if m.cursor != 0 {
+		t.Fatalf("cursor reset expected; got %d", m.cursor)
+	}
+}

--- a/internal/tui/foundries/fluxpicker/update_test.go
+++ b/internal/tui/foundries/fluxpicker/update_test.go
@@ -211,3 +211,28 @@ func TestEsc_NoChanges_ClosesPicker(t *testing.T) {
 		t.Fatal("expected picker to close with no overrides")
 	}
 }
+
+func TestUpdate_SchemaFetchedMsgPopulatesState(t *testing.T) {
+	m := New().OpenFor("ref", data.ScopeProject, nil, nil)
+	m = m.SetFetching(true)
+	schema := []mold.FluxVar{{Name: "k", Type: "string"}}
+	m, _ = m.Update(SchemaFetchedMsg{MoldRef: "ref", Schema: schema})
+	if len(m.schema) != 1 || m.schema[0].Name != "k" {
+		t.Fatalf("schema not applied: %+v", m.schema)
+	}
+	if m.fetching {
+		t.Fatal("expected fetching=false after message")
+	}
+}
+
+func TestUpdate_SchemaFetchedMsg_IgnoresMismatchedRef(t *testing.T) {
+	m := New().OpenFor("a", data.ScopeProject, nil, nil)
+	m = m.SetFetching(true)
+	m, _ = m.Update(SchemaFetchedMsg{MoldRef: "b", Schema: []mold.FluxVar{{Name: "k"}}})
+	if len(m.schema) != 0 {
+		t.Fatalf("expected schema unchanged, got %+v", m.schema)
+	}
+	if !m.fetching {
+		t.Fatal("expected fetching to remain true on ref mismatch")
+	}
+}

--- a/internal/tui/foundries/fluxpicker/view.go
+++ b/internal/tui/foundries/fluxpicker/view.go
@@ -35,6 +35,12 @@ func (m Model) View() string {
 	b.WriteString(m.filter.View())
 	b.WriteString("\n\n")
 
+	if m.fetching {
+		b.WriteString("fetching schema…\n\n")
+	} else if len(m.schema) == 0 && m.err == nil {
+		b.WriteString(footer.Render("(no flux variables defined for this mold)") + "\n\n")
+	}
+
 	rows := m.filteredKeys()
 	for i, fv := range rows {
 		badge := " "

--- a/internal/tui/foundries/fluxpicker/view.go
+++ b/internal/tui/foundries/fluxpicker/view.go
@@ -7,6 +7,8 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
+const footerHint = "tab: commit filter   enter: save key   d: clear   R: reset all   s: save & close   esc: cancel"
+
 var (
 	pickerBox = lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
@@ -47,6 +49,8 @@ func (m Model) View() string {
 		}
 		display := m.displayValueFor(fv.Name)
 		line := fmt.Sprintf("%s %-22s %-8s %s", badge, fv.Name, fv.Type, display)
+		// cursor starts at 0, so the top row is highlighted by default until
+		// the user moves it.
 		if i == m.cursor && m.focus == focusFilter {
 			line = highlight.Render("▸ " + line)
 		} else {
@@ -70,11 +74,12 @@ func (m Model) View() string {
 	}
 
 	if m.err != nil {
+		// Developer-facing tool — raw error text is intentional.
 		b.WriteString("\n" + errStyle.Render("error: "+m.err.Error()) + "\n")
 	}
 
 	b.WriteString("\n")
-	b.WriteString(footer.Render("tab: commit filter   enter: save key   d: clear   R: reset all   s: save & close   esc: cancel"))
+	b.WriteString(footer.Render(footerHint))
 
 	return pickerBox.Render(b.String())
 }

--- a/internal/tui/foundries/fluxpicker/view.go
+++ b/internal/tui/foundries/fluxpicker/view.go
@@ -1,0 +1,103 @@
+package fluxpicker
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+var (
+	pickerBox = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			Padding(1, 2)
+	headerStyle = lipgloss.NewStyle().Bold(true)
+	rowSet      = lipgloss.NewStyle().Foreground(lipgloss.Color("13"))
+	rowDefault  = lipgloss.NewStyle().Faint(true)
+	rowUnset    = lipgloss.NewStyle()
+	highlight   = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("11"))
+	footer      = lipgloss.NewStyle().Faint(true)
+	errStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
+)
+
+// View renders the picker overlay. Returns empty string when closed.
+func (m Model) View() string {
+	if !m.open {
+		return ""
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s — %s\n\n",
+		headerStyle.Render("Flux: "+m.moldRef),
+		strings.ToLower(string(m.scope)))
+
+	b.WriteString(m.filter.View())
+	b.WriteString("\n\n")
+
+	rows := m.filteredKeys()
+	for i, fv := range rows {
+		badge := " "
+		row := rowUnset
+		switch m.BadgeStateFor(fv.Name) {
+		case BadgeSet:
+			badge = "●"
+			row = rowSet
+		case BadgeDefault:
+			badge = "○"
+			row = rowDefault
+		}
+		display := m.displayValueFor(fv.Name)
+		line := fmt.Sprintf("%s %-22s %-8s %s", badge, fv.Name, fv.Type, display)
+		if i == m.cursor && m.focus == focusFilter {
+			line = highlight.Render("▸ " + line)
+		} else {
+			line = "  " + row.Render(line)
+		}
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+
+	if m.editor.active {
+		b.WriteString("\n" + strings.Repeat("─", 40) + " value editor " + strings.Repeat("─", 24) + "\n")
+		if m.editor.form != nil {
+			b.WriteString(m.editor.form.View())
+		} else {
+			b.WriteString("editing " + m.editor.key)
+		}
+	}
+
+	if m.saving.active {
+		b.WriteString("\nsave: [p] project  [g] global  [o] this cast only  [esc] cancel\n")
+	}
+
+	if m.err != nil {
+		b.WriteString("\n" + errStyle.Render("error: "+m.err.Error()) + "\n")
+	}
+
+	b.WriteString("\n")
+	b.WriteString(footer.Render("tab: commit filter   enter: save key   d: clear   R: reset all   s: save & close   esc: cancel"))
+
+	return pickerBox.Render(b.String())
+}
+
+func (m Model) displayValueFor(name string) string {
+	if v, ok := m.overrides[name]; ok {
+		return fmt.Sprintf("%v", v)
+	}
+	if hasDottedKey(m.defaults, name) {
+		return fmt.Sprintf("%v (default)", lookupDottedKey(m.defaults, name))
+	}
+	return "—"
+}
+
+func lookupDottedKey(m map[string]any, key string) any {
+	parts := strings.Split(key, ".")
+	var cur any = m
+	for _, p := range parts {
+		mm, ok := cur.(map[string]any)
+		if !ok {
+			return nil
+		}
+		cur = mm[p]
+	}
+	return cur
+}

--- a/internal/tui/foundries/fluxpicker/view_test.go
+++ b/internal/tui/foundries/fluxpicker/view_test.go
@@ -1,0 +1,73 @@
+package fluxpicker
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nimble-giant/ailloy/internal/tui/foundries/data"
+	"github.com/nimble-giant/ailloy/pkg/mold"
+)
+
+func TestView_RendersHeaderAndKeys(t *testing.T) {
+	schema := []mold.FluxVar{
+		{Name: "agents.targets", Type: "list"},
+		{Name: "agents.parallel", Type: "bool", Default: "true"},
+	}
+	defaults := map[string]any{"agents": map[string]any{"parallel": true}}
+	m := New().OpenFor("official/agents", data.ScopeProject, schema, defaults)
+	m.width, m.height = 80, 24
+
+	out := m.View()
+	if !strings.Contains(out, "official/agents") {
+		t.Fatalf("expected mold ref in header, got:\n%s", out)
+	}
+	if !strings.Contains(out, "agents.targets") {
+		t.Fatalf("expected agents.targets in list, got:\n%s", out)
+	}
+	if !strings.Contains(out, "agents.parallel") {
+		t.Fatalf("expected agents.parallel in list, got:\n%s", out)
+	}
+}
+
+func TestView_BadgesReflectState(t *testing.T) {
+	schema := []mold.FluxVar{{Name: "k", Type: "string"}}
+	m := New().OpenFor("ref", data.ScopeProject, schema, nil).SetOverride("k", "v")
+	m.width, m.height = 80, 24
+	out := m.View()
+	if !strings.Contains(out, "●") {
+		t.Fatalf("expected '●' badge for set key, got:\n%s", out)
+	}
+}
+
+func TestView_HiddenWhenClosed(t *testing.T) {
+	m := New()
+	if m.View() != "" {
+		t.Fatalf("expected empty view when closed, got %q", m.View())
+	}
+}
+
+func TestView_RendersSavePromptWhenActive(t *testing.T) {
+	schema := []mold.FluxVar{{Name: "k"}}
+	m := New().OpenFor("ref", data.ScopeProject, schema, nil)
+	m.saving = saveState{active: true}
+	m.focus = focusSavePrompt
+	out := m.View()
+	if !strings.Contains(out, "[p]") || !strings.Contains(out, "[g]") || !strings.Contains(out, "[o]") {
+		t.Fatalf("expected save prompt options, got:\n%s", out)
+	}
+}
+
+func TestView_ShowsErrorBanner(t *testing.T) {
+	m := New().OpenFor("ref", data.ScopeProject, nil, nil)
+	m.err = errSentinel
+	out := m.View()
+	if !strings.Contains(out, "boom") {
+		t.Fatalf("expected error message in view, got:\n%s", out)
+	}
+}
+
+type _e struct{}
+
+func (_e) Error() string { return "boom" }
+
+var errSentinel = _e{}

--- a/internal/tui/foundries/health/model.go
+++ b/internal/tui/foundries/health/model.go
@@ -61,6 +61,11 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	return m, nil
 }
 
+// CurrentMold returns ok=false; the health tab has no per-mold context.
+func (m Model) CurrentMold() (ref string, scope data.Scope, ok bool) {
+	return "", "", false
+}
+
 func (m Model) View() string {
 	if m.loading {
 		return metaStyle.Render("Running health checks…")

--- a/internal/tui/foundries/installed/model.go
+++ b/internal/tui/foundries/installed/model.go
@@ -165,6 +165,8 @@ func (m Model) CurrentMold() (ref string, scope data.Scope, ok bool) {
 
 // ApplySessionOverrides records session overrides for the given mold ref.
 // They will be applied as --set overrides on the next cast of that mold.
+// Last-write-wins: re-applying replaces any prior pending overrides for the
+// same ref rather than merging.
 func (m Model) ApplySessionOverrides(moldRef string, overrides map[string]any) Model {
 	if m.pending == nil {
 		m.pending = map[string][]string{}
@@ -173,16 +175,33 @@ func (m Model) ApplySessionOverrides(moldRef string, overrides map[string]any) M
 	return m
 }
 
-// encodeSetOverrides converts a typed override map into the --set k=v
-// strings that CastOptions.SetOverrides expects. Result is sorted for
-// deterministic ordering.
+// encodeSetOverrides converts a typed override map into the --set k=v strings
+// that CastOptions.SetOverrides expects. Slices are emitted as YAML flow
+// sequences ([a,b,c]) so the cast core's YAML-aware --set parser produces a
+// real list rather than parsing the Go-default "[a b c]" form as a single
+// string. Result is sorted for deterministic ordering.
 func encodeSetOverrides(overrides map[string]any) []string {
 	out := make([]string, 0, len(overrides))
 	for k, v := range overrides {
-		out = append(out, fmt.Sprintf("%s=%v", k, v))
+		out = append(out, fmt.Sprintf("%s=%s", k, formatSetValue(v)))
 	}
 	sort.Strings(out)
 	return out
+}
+
+func formatSetValue(v any) string {
+	switch x := v.(type) {
+	case []string:
+		return "[" + strings.Join(x, ",") + "]"
+	case []any:
+		parts := make([]string, len(x))
+		for i, item := range x {
+			parts[i] = fmt.Sprintf("%v", item)
+		}
+		return "[" + strings.Join(parts, ",") + "]"
+	default:
+		return fmt.Sprintf("%v", v)
+	}
 }
 
 func (m Model) View() string {

--- a/internal/tui/foundries/installed/model.go
+++ b/internal/tui/foundries/installed/model.go
@@ -143,6 +143,16 @@ func (m Model) updateCmd(it data.InventoryItem) tea.Cmd {
 	}
 }
 
+// CurrentMold returns the highlighted installed mold's source and its scope
+// (project or global). Returns ok=false when no item is highlighted.
+func (m Model) CurrentMold() (ref string, scope data.Scope, ok bool) {
+	if m.cursor < 0 || m.cursor >= len(m.items) {
+		return "", "", false
+	}
+	it := m.items[m.cursor]
+	return it.Entry.Source, it.Scope, true
+}
+
 func (m Model) View() string {
 	if m.loading {
 		return metaStyle.Render("Loading inventory…")

--- a/internal/tui/foundries/installed/model.go
+++ b/internal/tui/foundries/installed/model.go
@@ -3,6 +3,7 @@ package installed
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -46,6 +47,7 @@ type Model struct {
 	loading bool
 	loadErr error
 	flash   string
+	pending map[string][]string // moldRef → encoded "--set" overrides
 }
 
 type loadedMsg struct {
@@ -97,6 +99,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			m.flash = "update error: " + msg.err.Error()
 		} else {
 			m.flash = "updated " + msg.source
+			delete(m.pending, msg.source)
 		}
 		return m, loadCmd(m.cfg)
 	case tea.KeyMsg:
@@ -134,11 +137,18 @@ func uninstallCmd(it data.InventoryItem) tea.Cmd {
 
 func (m Model) updateCmd(it data.InventoryItem) tea.Cmd {
 	cast := m.cast
+	// Capture pending overrides at Cmd build time so concurrent picker edits
+	// don't change what's already in flight.
+	extra := append([]string(nil), m.pending[it.Entry.Source]...)
 	return func() tea.Msg {
 		if cast == nil {
 			return updateDoneMsg{source: it.Entry.Source, err: fmt.Errorf("no cast function configured")}
 		}
-		err := cast(context.Background(), it.Entry.Source, CastOptions{Global: it.Scope == data.ScopeGlobal})
+		opts := CastOptions{Global: it.Scope == data.ScopeGlobal}
+		if len(extra) > 0 {
+			opts.SetOverrides = append(opts.SetOverrides, extra...)
+		}
+		err := cast(context.Background(), it.Entry.Source, opts)
 		return updateDoneMsg{source: it.Entry.Source, err: err}
 	}
 }
@@ -151,6 +161,28 @@ func (m Model) CurrentMold() (ref string, scope data.Scope, ok bool) {
 	}
 	it := m.items[m.cursor]
 	return it.Entry.Source, it.Scope, true
+}
+
+// ApplySessionOverrides records session overrides for the given mold ref.
+// They will be applied as --set overrides on the next cast of that mold.
+func (m Model) ApplySessionOverrides(moldRef string, overrides map[string]any) Model {
+	if m.pending == nil {
+		m.pending = map[string][]string{}
+	}
+	m.pending[moldRef] = encodeSetOverrides(overrides)
+	return m
+}
+
+// encodeSetOverrides converts a typed override map into the --set k=v
+// strings that CastOptions.SetOverrides expects. Result is sorted for
+// deterministic ordering.
+func encodeSetOverrides(overrides map[string]any) []string {
+	out := make([]string, 0, len(overrides))
+	for k, v := range overrides {
+		out = append(out, fmt.Sprintf("%s=%v", k, v))
+	}
+	sort.Strings(out)
+	return out
 }
 
 func (m Model) View() string {

--- a/internal/tui/foundries/installed/model_test.go
+++ b/internal/tui/foundries/installed/model_test.go
@@ -1,0 +1,34 @@
+package installed
+
+import (
+	"testing"
+
+	"github.com/nimble-giant/ailloy/internal/tui/foundries/data"
+	"github.com/nimble-giant/ailloy/pkg/foundry"
+)
+
+func TestCurrentMold_NoSelection(t *testing.T) {
+	m := Model{}
+	if _, _, ok := m.CurrentMold(); ok {
+		t.Fatalf("expected ok=false on empty model")
+	}
+}
+
+func TestCurrentMold_HighlightedItem_PreservesScope(t *testing.T) {
+	m := Model{
+		items: []data.InventoryItem{
+			{Scope: data.ScopeGlobal, Entry: foundry.InstalledEntry{Source: "official/agents"}},
+		},
+		cursor: 0,
+	}
+	ref, scope, ok := m.CurrentMold()
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
+	if ref != "official/agents" {
+		t.Fatalf("ref = %q want %q", ref, "official/agents")
+	}
+	if scope != data.ScopeGlobal {
+		t.Fatalf("scope = %v want ScopeGlobal", scope)
+	}
+}

--- a/internal/tui/foundries/registered/model.go
+++ b/internal/tui/foundries/registered/model.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/nimble-giant/ailloy/internal/tui/foundries/data"
 	"github.com/nimble-giant/ailloy/pkg/foundry/index"
 	"github.com/nimble-giant/ailloy/pkg/styles"
 )
@@ -258,6 +259,11 @@ func (m Model) removeCmd(urlOrName string) tea.Cmd {
 		_, err := remove(cfg, urlOrName)
 		return removeDoneMsg{name: urlOrName, err: err}
 	}
+}
+
+// CurrentMold returns ok=false; the foundries tab has no per-mold context.
+func (m Model) CurrentMold() (ref string, scope data.Scope, ok bool) {
+	return "", "", false
 }
 
 func (m Model) View() string {

--- a/pkg/mold/schema_fetch.go
+++ b/pkg/mold/schema_fetch.go
@@ -1,0 +1,58 @@
+package mold
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+)
+
+// FetchSchemaFromSource resolves a mold by source string (local path or remote
+// ref) and returns its flux schema and default values, without doing a full
+// cast. For local paths it reads from the filesystem directly; for remote refs
+// it delegates to ResolveSchemaFunc (set by callers that have access to the
+// foundry resolver to avoid an import cycle).
+//
+// When neither flux.schema.yaml nor flux.yaml exist, returns an empty schema
+// and empty defaults with no error.
+func FetchSchemaFromSource(ctx context.Context, source string) ([]FluxVar, map[string]any, error) {
+	if source == "" {
+		return nil, nil, errors.New("FetchSchemaFromSource: empty source")
+	}
+	// Local path?
+	if info, err := os.Stat(source); err == nil && info.IsDir() {
+		return loadSchemaFromFS(os.DirFS(source))
+	}
+	if ResolveSchemaFunc == nil {
+		return nil, nil, fmt.Errorf("FetchSchemaFromSource: no remote resolver registered for source %q", source)
+	}
+	fsys, cleanup, err := ResolveSchemaFunc(ctx, source)
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+	return loadSchemaFromFS(fsys)
+}
+
+// ResolveSchemaFunc is set by callers that can resolve a remote mold to an
+// fs.FS without creating an import cycle into pkg/mold. The returned cleanup
+// function (if non-nil) is called after schema files are read.
+var ResolveSchemaFunc func(ctx context.Context, source string) (fs.FS, func(), error)
+
+func loadSchemaFromFS(fsys fs.FS) ([]FluxVar, map[string]any, error) {
+	schema, err := LoadFluxSchema(fsys, "flux.schema.yaml")
+	if err != nil {
+		return nil, nil, fmt.Errorf("load schema: %w", err)
+	}
+	defaults, err := LoadFluxFile(fsys, "flux.yaml")
+	if err != nil {
+		return nil, nil, fmt.Errorf("load defaults: %w", err)
+	}
+	if defaults == nil {
+		defaults = map[string]any{}
+	}
+	return schema, defaults, nil
+}

--- a/pkg/mold/schema_fetch.go
+++ b/pkg/mold/schema_fetch.go
@@ -21,8 +21,13 @@ func FetchSchemaFromSource(ctx context.Context, source string) ([]FluxVar, map[s
 		return nil, nil, errors.New("FetchSchemaFromSource: empty source")
 	}
 	// Local path?
-	if info, err := os.Stat(source); err == nil && info.IsDir() {
+	if info, err := os.Stat(source); err == nil {
+		if !info.IsDir() {
+			return nil, nil, fmt.Errorf("FetchSchemaFromSource: %q is not a directory", source)
+		}
 		return loadSchemaFromFS(os.DirFS(source))
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return nil, nil, fmt.Errorf("FetchSchemaFromSource: stat %q: %w", source, err)
 	}
 	if ResolveSchemaFunc == nil {
 		return nil, nil, fmt.Errorf("FetchSchemaFromSource: no remote resolver registered for source %q", source)

--- a/pkg/mold/schema_fetch_test.go
+++ b/pkg/mold/schema_fetch_test.go
@@ -1,0 +1,67 @@
+package mold_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nimble-giant/ailloy/pkg/mold"
+)
+
+func TestFetchSchemaFromLocalDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "mold.yaml"), []byte("name: demo\nversion: 0.0.1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "flux.schema.yaml"), []byte(`- name: agents.targets
+  type: list
+  description: which agents to install
+- name: agents.parallel
+  type: bool
+  default: "true"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "flux.yaml"), []byte("agents:\n  targets: []\n  parallel: true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	schema, defaults, err := mold.FetchSchemaFromSource(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("FetchSchemaFromSource: %v", err)
+	}
+	if len(schema) != 2 {
+		t.Fatalf("schema len = %d want 2", len(schema))
+	}
+	if schema[0].Name != "agents.targets" || schema[0].Type != "list" {
+		t.Fatalf("schema[0] = %+v", schema[0])
+	}
+	if defaults["agents"] == nil {
+		t.Fatalf("expected defaults[agents] to be present, got %+v", defaults)
+	}
+}
+
+func TestFetchSchemaFromSource_MissingFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "mold.yaml"), []byte("name: demo\nversion: 0.0.1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	schema, defaults, err := mold.FetchSchemaFromSource(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("expected nil error when schema/defaults absent, got %v", err)
+	}
+	if len(schema) != 0 {
+		t.Fatalf("expected empty schema, got %d entries", len(schema))
+	}
+	if len(defaults) != 0 {
+		t.Fatalf("expected empty defaults, got %+v", defaults)
+	}
+}
+
+func TestFetchSchemaFromSource_EmptySource(t *testing.T) {
+	_, _, err := mold.FetchSchemaFromSource(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected error for empty source")
+	}
+}

--- a/pkg/mold/schema_fetch_test.go
+++ b/pkg/mold/schema_fetch_test.go
@@ -74,7 +74,7 @@ func TestFetchSchemaFromSource_FileNotDir(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	f.Close()
+	_ = f.Close()
 
 	_, _, err = mold.FetchSchemaFromSource(context.Background(), f.Name())
 	if err == nil {

--- a/pkg/mold/schema_fetch_test.go
+++ b/pkg/mold/schema_fetch_test.go
@@ -2,9 +2,12 @@ package mold_test
 
 import (
 	"context"
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
+	"testing/fstest"
 
 	"github.com/nimble-giant/ailloy/pkg/mold"
 )
@@ -63,5 +66,63 @@ func TestFetchSchemaFromSource_EmptySource(t *testing.T) {
 	_, _, err := mold.FetchSchemaFromSource(context.Background(), "")
 	if err == nil {
 		t.Fatal("expected error for empty source")
+	}
+}
+
+func TestFetchSchemaFromSource_FileNotDir(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "not-a-dir-*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	_, _, err = mold.FetchSchemaFromSource(context.Background(), f.Name())
+	if err == nil {
+		t.Fatal("expected error when source is a file, not a dir")
+	}
+}
+
+func TestFetchSchemaFromSource_RemoteResolverDispatchAndCleanup(t *testing.T) {
+	prev := mold.ResolveSchemaFunc
+	t.Cleanup(func() { mold.ResolveSchemaFunc = prev })
+
+	cleanupCalls := 0
+	mold.ResolveSchemaFunc = func(ctx context.Context, source string) (fs.FS, func(), error) {
+		if source != "official/agents" {
+			t.Fatalf("unexpected source: %q", source)
+		}
+		return fstest.MapFS{
+			"flux.schema.yaml": &fstest.MapFile{Data: []byte("- name: k\n  type: string\n")},
+			"flux.yaml":        &fstest.MapFile{Data: []byte("k: v\n")},
+		}, func() { cleanupCalls++ }, nil
+	}
+
+	schema, defaults, err := mold.FetchSchemaFromSource(context.Background(), "official/agents")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(schema) != 1 || schema[0].Name != "k" {
+		t.Fatalf("schema = %+v", schema)
+	}
+	if defaults["k"] != "v" {
+		t.Fatalf("defaults = %+v", defaults)
+	}
+	if cleanupCalls != 1 {
+		t.Fatalf("cleanup calls = %d want 1", cleanupCalls)
+	}
+}
+
+func TestFetchSchemaFromSource_RemoteResolverError(t *testing.T) {
+	prev := mold.ResolveSchemaFunc
+	t.Cleanup(func() { mold.ResolveSchemaFunc = prev })
+
+	sentinel := errors.New("resolver boom")
+	mold.ResolveSchemaFunc = func(ctx context.Context, source string) (fs.FS, func(), error) {
+		return nil, nil, sentinel
+	}
+
+	_, _, err := mold.FetchSchemaFromSource(context.Background(), "remote/ref")
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v want wrap of sentinel", err)
 	}
 }


### PR DESCRIPTION
## Summary

Adds a TUI flux value picker to the foundries app. Press `f` from any tab to open an overlay scoped to the highlighted mold, fuzzy-filter the schema, set values via type-aware widgets, and save to a project flux file, a global flux file, or session-only (next cast).

Motivation: today, users casting from foundries set flux values via `--set` flags or by editing yaml files by hand. The picker turns that into one keystroke + filter + tab-complete, with the schema as a guide.

## What's in it

**Picker UX**
- `f` opens the picker scoped to the active tab's highlighted mold (Discover catalog entry or Installed mold). Health/Foundries tabs are no-ops (no mold context).
- Fuzzy filter (`sahilm/fuzzy`) with `tab` to commit the top match, `enter` to commit the highlighted entry.
- Type-aware editor backed by `huh` widgets — string / int / bool / list / select (with discovery support).
- `●`/`○` badges show set / default state. `d` clears the highlighted override; `R` resets all.
- `s` opens the save prompt: `[p]` project, `[g]` global, `[o]` next cast only.
- `esc` with unsaved overrides routes to the save prompt; otherwise closes immediately.

**Persistence**
- Project: `.ailloy/flux/<mold>.yaml`. Global: `~/.ailloy/flux/<mold>.yaml`. Both writes are atomic (temp + rename).
- Existing files merge — overrides win on conflict.
- Session-only overrides flow back to the active tab's `pending` map and inject into `CastOptions.SetOverrides` on the next cast (cleared on success, retained on failure for retry).
- Slice values encode as YAML flow sequences (`[a,b,c]`) so the existing YAML-aware `--set` parser produces real lists.

**Schema fetching**
- New `pkg/mold.FetchSchemaFromSource` reads `flux.schema.yaml` + `flux.yaml` directly for local paths, and via a registered foundry resolver hook for remote refs (registered from `internal/commands` to avoid an import cycle).
- Async on `f` press — picker shows "fetching schema…" until `SchemaFetchedMsg` arrives. Empty schema renders "(no flux variables defined for this mold)". Mismatched-ref messages are ignored.

**Validation**
- `mold.ValidateFlux` runs against the merged (defaults + overrides) map on save; failures set the error banner and block persistence.

## Files

New package: `internal/tui/foundries/fluxpicker/` (model, update, editor, persist, view, messages, filter, integration_test).
New helper: `pkg/mold/schema_fetch.go` + resolver registration in `internal/commands/schema_fetch_init.go`.
Touched: `internal/tui/foundries/app.go` (embed picker, intercept `f`, route `FluxOverridesMsg`, dispatch async fetch); `discover/model.go` and `installed/model.go` (`MoldContexter`, `pending` map, `ApplySessionOverrides`, cast-time injection).

## Test plan

- [x] Unit tests pass for fluxpicker, discover, installed, mold (`go test ./...`)
- [x] Two end-to-end integration tests: project-save round-trips through YAML on disk; session-save emits `FluxOverridesMsg` without writing
- [x] `go vet`, `go build`, and `golangci-lint` clean (run via `lefthook` pre-push)
- [ ] Manual smoke: open the TUI, navigate to Discover, highlight a mold, press `f`, filter and commit a value, save with `p`, confirm `.ailloy/flux/<mold>.yaml` contents
- [ ] Manual smoke: same flow with `g` writes to `~/.ailloy/flux/<mold>.yaml`
- [ ] Manual smoke: same flow with `o` (session) leaves no file, then casting the mold picks up the overrides

## Known follow-ups (intentionally out of scope)

- No "saved to <path>" toast surfaces on the active tab after a project/global save (picker closes immediately).
- Validation runs only at save-time, not per-key on commit.
- `FluxOverridesMsg.Scope` is captured but the App routes purely off `a.active`; either wire it or drop in a follow-up.