### PR TITLE
fix: identify installed molds by (source, subpath), not source alone

### DIFF
--- a/internal/commands/cast.go
+++ b/internal/commands/cast.go
@@ -291,7 +291,7 @@ func castProject(reader *blanks.MoldReader, source string) error {
 	// Backfill the manifest entry's Files list so uninstall knows what to remove.
 	// The manifest is always written (regardless of --global), so this works
 	// for both project and global installs.
-	if source != "" {
+	if source != "" && resolvedRemote != nil {
 		manifestPath := manifestPathFor(castGlobal)
 		if manifestPath != "" {
 			installed := make([]foundry.InstalledFile, 0, len(filesToCast))
@@ -305,7 +305,7 @@ func castProject(reader *blanks.MoldReader, source string) error {
 				}
 				installed = append(installed, foundry.InstalledFile{RelPath: rel, SHA256: sum})
 			}
-			if err := foundry.RecordInstalledFiles(manifestPath, source, installed); err != nil {
+			if err := foundry.RecordInstalledFiles(manifestPath, source, resolvedRemote.Ref.Subpath, installed); err != nil {
 				log.Printf("warning: recording installed files: %v", err)
 			}
 		}
@@ -451,16 +451,38 @@ type installState struct {
 	WorkflowDirs []string `yaml:"workflowDirs,omitempty"`
 }
 
+const installStatePath = ".ailloy/state.yaml"
+
 // writeInstallState records where blanks were installed so `mold list` can find them.
+//
+// Reads the existing state.yaml first and unions the new dirs into it, so
+// repeated casts (e.g. installing several molds from a foundry) accumulate
+// rather than overwriting each other.
 func writeInstallState(dirs []string) error {
 	state := installState{}
+	if existing, err := readInstallState(installStatePath); err == nil && existing != nil {
+		state = *existing
+	}
+
+	blankSet := make(map[string]struct{}, len(state.BlankDirs)+len(dirs))
+	workflowSet := make(map[string]struct{}, len(state.WorkflowDirs)+len(dirs))
+	for _, d := range state.BlankDirs {
+		blankSet[d] = struct{}{}
+	}
+	for _, d := range state.WorkflowDirs {
+		workflowSet[d] = struct{}{}
+	}
 	for _, d := range dirs {
 		if strings.HasPrefix(d, ".github/") {
-			state.WorkflowDirs = append(state.WorkflowDirs, d)
+			workflowSet[d] = struct{}{}
 		} else {
-			state.BlankDirs = append(state.BlankDirs, d)
+			blankSet[d] = struct{}{}
 		}
 	}
+
+	state.BlankDirs = sortedKeys(blankSet)
+	state.WorkflowDirs = sortedKeys(workflowSet)
+
 	data, err := yaml.Marshal(state)
 	if err != nil {
 		return err
@@ -468,7 +490,34 @@ func writeInstallState(dirs []string) error {
 	if err := os.MkdirAll(".ailloy", 0750); err != nil { // #nosec G301
 		return err
 	}
-	return os.WriteFile(".ailloy/state.yaml", data, 0644) // #nosec G306
+	return os.WriteFile(installStatePath, data, 0644) // #nosec G306
+}
+
+func readInstallState(path string) (*installState, error) {
+	data, err := os.ReadFile(path) // #nosec G304 -- path is a known constant
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var s installState
+	if err := yaml.Unmarshal(data, &s); err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+func sortedKeys(m map[string]struct{}) []string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // hasDestFile checks if any resolved file targets the given destination path.

--- a/internal/commands/cast_core.go
+++ b/internal/commands/cast_core.go
@@ -154,6 +154,14 @@ func CastMold(_ context.Context, ref string, opts CastOptions) (CastResult, erro
 		return res, fmt.Errorf("copying files: %w", err)
 	}
 
+	// Mirror what cast.go does: record install dirs in .ailloy/state.yaml so
+	// `mold list` can find blanks installed via the foundries TUI.
+	if destPrefix == "" {
+		if err := writeInstallState(dirs); err != nil {
+			log.Printf("warning: failed to write install state: %v", err)
+		}
+	}
+
 	if remoteResult != nil {
 		manifestPath := manifestPathFor(opts.Global)
 		if manifestPath != "" {
@@ -175,7 +183,7 @@ func CastMold(_ context.Context, ref string, opts CastOptions) (CastResult, erro
 					installed = append(installed, foundry.InstalledFile{RelPath: rel, SHA256: sum})
 				}
 				res.FilesCast = installed
-				_ = foundry.RecordInstalledFiles(manifestPath, source, installed)
+				_ = foundry.RecordInstalledFiles(manifestPath, source, remoteResult.Ref.Subpath, installed)
 			}
 		}
 	}

--- a/internal/commands/cast_state_test.go
+++ b/internal/commands/cast_state_test.go
@@ -1,0 +1,79 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/goccy/go-yaml"
+)
+
+// Regression: writeInstallState must merge with the existing state.yaml
+// instead of overwriting. The previous behavior wiped earlier mold install
+// dirs every time a new mold was cast.
+func TestWriteInstallState_MergesWithExisting(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	if err := writeInstallState([]string{".claude/skills/shortcut-cli", ".github/workflows"}); err != nil {
+		t.Fatalf("first writeInstallState: %v", err)
+	}
+	if err := writeInstallState([]string{".claude/skills/linear-cli"}); err != nil {
+		t.Fatalf("second writeInstallState: %v", err)
+	}
+
+	state, err := loadInstallStateForTest(installStatePath)
+	if err != nil {
+		t.Fatalf("read state.yaml: %v", err)
+	}
+	wantBlank := []string{".claude/skills/linear-cli", ".claude/skills/shortcut-cli"}
+	if !reflect.DeepEqual(state.BlankDirs, wantBlank) {
+		t.Errorf("BlankDirs = %v, want %v", state.BlankDirs, wantBlank)
+	}
+	wantWorkflows := []string{".github/workflows"}
+	if !reflect.DeepEqual(state.WorkflowDirs, wantWorkflows) {
+		t.Errorf("WorkflowDirs = %v, want %v", state.WorkflowDirs, wantWorkflows)
+	}
+}
+
+func TestWriteInstallState_DedupesRepeatedDirs(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	if err := writeInstallState([]string{".claude/skills/foo"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeInstallState([]string{".claude/skills/foo"}); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := loadInstallStateForTest(installStatePath)
+	if err != nil {
+		t.Fatalf("read state.yaml: %v", err)
+	}
+	if len(state.BlankDirs) != 1 || state.BlankDirs[0] != ".claude/skills/foo" {
+		t.Errorf("expected 1 deduped dir, got %v", state.BlankDirs)
+	}
+}
+
+func TestWriteInstallState_FreshDirCreatesFile(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	if err := writeInstallState([]string{".claude/skills/x"}); err != nil {
+		t.Fatalf("writeInstallState: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(".ailloy", "state.yaml")); err != nil {
+		t.Errorf("state.yaml not created: %v", err)
+	}
+}
+
+func loadInstallStateForTest(path string) (*installState, error) {
+	data, err := os.ReadFile(path) // #nosec G304 -- test path
+	if err != nil {
+		return nil, err
+	}
+	var s installState
+	if err := yaml.Unmarshal(data, &s); err != nil {
+		return nil, err
+	}
+	return &s, nil
+}

--- a/internal/commands/ingot.go
+++ b/internal/commands/ingot.go
@@ -83,7 +83,7 @@ func runIngotGet(_ *cobra.Command, args []string) error {
 
 	lock, _ := foundry.ReadLockFile(foundry.LockFileName)
 	version := "latest"
-	if entry := lock.FindEntry(parsed.CacheKey()); entry != nil {
+	if entry := lock.FindEntry(parsed.CacheKey(), parsed.Subpath); entry != nil {
 		version = entry.Version
 	}
 

--- a/internal/commands/mold.go
+++ b/internal/commands/mold.go
@@ -341,7 +341,7 @@ func runGetMold(_ *cobra.Command, args []string) error {
 	// Read lock to get resolved version for path display.
 	lock, _ := foundry.ReadLockFile(foundry.LockFileName)
 	version := "latest"
-	if entry := lock.FindEntry(parsed.CacheKey()); entry != nil {
+	if entry := lock.FindEntry(parsed.CacheKey(), parsed.Subpath); entry != nil {
 		version = entry.Version
 	}
 

--- a/internal/commands/quench.go
+++ b/internal/commands/quench.go
@@ -64,7 +64,7 @@ func runQuench(_ *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("parsing reference: %w", err)
 		}
-		match := manifest.FindBySource(ref.CacheKey())
+		match := manifest.FindBySource(ref.CacheKey(), ref.Subpath)
 		if match == nil {
 			return fmt.Errorf("mold %q not found in installed manifest — run %s first",
 				args[0],
@@ -159,7 +159,7 @@ func verifyManifestAgainstLock(entries []foundry.InstalledEntry, lock *foundry.L
 		return nil // no lock to verify against — first quench scenario
 	}
 	for _, entry := range entries {
-		locked := lock.FindEntry(entry.Source)
+		locked := lock.FindEntry(entry.Source, entry.Subpath)
 		if locked == nil {
 			failures = append(failures, fmt.Sprintf("%s is in installed manifest but missing from lock", entry.Name))
 			continue

--- a/internal/commands/uninstall.go
+++ b/internal/commands/uninstall.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/nimble-giant/ailloy/pkg/foundry"
 	"github.com/nimble-giant/ailloy/pkg/styles"
@@ -16,7 +17,7 @@ var (
 )
 
 var uninstallCmd = &cobra.Command{
-	Use:   "uninstall <source>",
+	Use:   "uninstall <source[//subpath]>",
 	Short: "Remove a casted mold from this project (or ~/ with -g)",
 	Long: `Uninstall a previously casted mold by source identifier (e.g. github.com/owner/repo).
 
@@ -24,6 +25,10 @@ Removes the files listed in the mold's installed manifest entry, prunes any
 empty directories, and drops the entry from .ailloy/installed.yaml. If
 ailloy.lock exists alongside the manifest, the matching lock entry is also
 removed.
+
+A foundry repo may host multiple molds at different subpaths. Pass the full
+ref (e.g. github.com/owner/repo//molds/shortcut) to disambiguate. Bare
+sources are accepted when only one matching entry exists.
 
 Files modified since they were cast are retained unless --force is given.
 Files claimed by another casted mold are retained automatically.`,
@@ -39,21 +44,28 @@ func init() {
 }
 
 func runUninstall(_ *cobra.Command, args []string) error {
-	source := args[0]
-
 	manifestPath := manifestPathFor(uninstallGlobal)
 	if manifestPath == "" {
 		return fmt.Errorf("cannot determine installed manifest path")
 	}
 
-	res, err := foundry.UninstallMold(manifestPath, source, foundry.UninstallOptions{
+	source, subpath, err := resolveUninstallTarget(manifestPath, args[0])
+	if err != nil {
+		return err
+	}
+
+	res, err := foundry.UninstallMold(manifestPath, source, subpath, foundry.UninstallOptions{
 		Force:  uninstallForce,
 		DryRun: uninstallDryRun,
 	})
+	display := source
+	if subpath != "" {
+		display = source + "//" + subpath
+	}
 	if err != nil {
 		if errors.Is(err, foundry.ErrLegacyEntry) {
 			fmt.Println(styles.WarningStyle.Render("⚠️  ") + err.Error())
-			fmt.Println(styles.SubtleStyle.Render("    Run `ailloy cast " + source + "` to backfill the manifest, then retry."))
+			fmt.Println(styles.SubtleStyle.Render("    Run `ailloy cast " + display + "` to backfill the manifest, then retry."))
 			return nil
 		}
 		return err
@@ -63,7 +75,7 @@ func runUninstall(_ *cobra.Command, args []string) error {
 	if uninstallDryRun {
 		header = "Would uninstall (dry-run)"
 	}
-	fmt.Println(styles.SuccessStyle.Render(header+" ") + styles.AccentStyle.Render(source))
+	fmt.Println(styles.SuccessStyle.Render(header+" ") + styles.AccentStyle.Render(display))
 
 	if len(res.Deleted) > 0 {
 		fmt.Println(styles.SubtleStyle.Render(fmt.Sprintf("  Removed:  %d file(s)", len(res.Deleted))))
@@ -88,4 +100,50 @@ func runUninstall(_ *cobra.Command, args []string) error {
 		fmt.Println(styles.SubtleStyle.Render(fmt.Sprintf("  Already absent: %d file(s)", len(res.NotFound))))
 	}
 	return nil
+}
+
+// resolveUninstallTarget interprets the user's positional argument as a mold
+// reference. If the argument carries a //subpath, that wins. Otherwise the
+// installed manifest is consulted: a single matching entry is auto-resolved,
+// and ambiguous bare sources are rejected with a list so the user can re-run
+// with the disambiguating subpath.
+func resolveUninstallTarget(manifestPath, raw string) (source, subpath string, err error) {
+	ref, perr := foundry.ParseReference(raw)
+	if perr != nil {
+		// Fall back to treating the raw arg as an opaque source string so
+		// pre-existing scripts that pass a bare cache key still work.
+		source = raw
+	} else {
+		source = ref.CacheKey()
+		subpath = ref.Subpath
+	}
+
+	if subpath != "" {
+		return source, subpath, nil
+	}
+
+	manifest, mErr := foundry.ReadInstalledManifest(manifestPath)
+	if mErr != nil || manifest == nil {
+		return source, "", nil
+	}
+	matches := manifest.FindAllBySource(source)
+	switch len(matches) {
+	case 0, 1:
+		// 0: let UninstallMold report "not found" with its richer message.
+		// 1: the bare-source shorthand resolves unambiguously.
+		if len(matches) == 1 {
+			subpath = matches[0].Subpath
+		}
+		return source, subpath, nil
+	default:
+		var lines []string
+		for _, m := range matches {
+			sp := m.Subpath
+			if sp == "" {
+				sp = "(no subpath)"
+			}
+			lines = append(lines, "  - "+source+"//"+sp+" ("+m.Name+")")
+		}
+		return "", "", fmt.Errorf("multiple installed molds match %q; specify the full ref:\n%s", source, strings.Join(lines, "\n"))
+	}
 }

--- a/internal/tui/foundries/installed/model.go
+++ b/internal/tui/foundries/installed/model.go
@@ -127,7 +127,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 
 func uninstallCmd(it data.InventoryItem) tea.Cmd {
 	return func() tea.Msg {
-		res, err := foundry.UninstallMold(it.ManifestPath, it.Entry.Source, foundry.UninstallOptions{})
+		res, err := foundry.UninstallMold(it.ManifestPath, it.Entry.Source, it.Entry.Subpath, foundry.UninstallOptions{})
 		return uninstallDoneMsg{source: it.Entry.Source, res: res, err: err}
 	}
 }

--- a/pkg/foundry/foundry.go
+++ b/pkg/foundry/foundry.go
@@ -17,12 +17,12 @@ type InstalledFile struct {
 }
 
 // RecordInstalledFiles backfills the Files list and FileHashes map on the
-// installed-manifest entry whose Source matches. Hashes are sha256 hex of the
-// file content at install time, used by UninstallMold to detect user
-// modifications. Provenance lives on the manifest (always written by cast)
-// rather than the lock so uninstall stays available when the user has not
-// opted into ailloy.lock.
-func RecordInstalledFiles(manifestPath, source string, files []InstalledFile) error {
+// installed-manifest entry whose (source, subpath) matches. Hashes are sha256
+// hex of the file content at install time, used by UninstallMold to detect
+// user modifications. Provenance lives on the manifest (always written by
+// cast) rather than the lock so uninstall stays available when the user has
+// not opted into ailloy.lock.
+func RecordInstalledFiles(manifestPath, source, subpath string, files []InstalledFile) error {
 	m, err := ReadInstalledManifest(manifestPath)
 	if err != nil {
 		return fmt.Errorf("reading installed manifest: %w", err)
@@ -31,9 +31,9 @@ func RecordInstalledFiles(manifestPath, source string, files []InstalledFile) er
 		return fmt.Errorf("installed manifest %s does not exist", manifestPath)
 	}
 
-	entry := m.FindBySource(source)
+	entry := m.FindBySource(source, subpath)
 	if entry == nil {
-		return fmt.Errorf("no installed manifest entry for source %q", source)
+		return fmt.Errorf("no installed manifest entry for source %q (subpath %q)", source, subpath)
 	}
 
 	seen := make(map[string]struct{}, len(files))
@@ -167,7 +167,7 @@ func resolveWithMeta(ref *Reference, git GitRunner, opts ...ResolveOption) (fs.F
 		if err != nil {
 			log.Printf("warning: reading lock file: %v", err)
 		}
-		if entry := lock.FindEntry(ref.CacheKey()); entry != nil && ref.Type != Branch && ref.Type != SHA {
+		if entry := lock.FindEntry(ref.CacheKey(), ref.Subpath); entry != nil && ref.Type != Branch && ref.Type != SHA {
 			if lockedSatisfies(ref, entry) {
 				resolved = &ResolvedVersion{Tag: entry.Version, Commit: entry.Commit}
 				log.Printf("using locked version %s@%s", ref.CacheKey(), entry.Version)

--- a/pkg/foundry/foundry_test.go
+++ b/pkg/foundry/foundry_test.go
@@ -153,7 +153,7 @@ func TestRecordInstalledFiles(t *testing.T) {
 		{RelPath: "a/dir/x.md", SHA256: "hash-a"},
 	}
 
-	if err := RecordInstalledFiles(manifestPath, "github.com/x/y", files); err != nil {
+	if err := RecordInstalledFiles(manifestPath, "github.com/x/y", "", files); err != nil {
 		t.Fatalf("RecordInstalledFiles: %v", err)
 	}
 
@@ -172,7 +172,7 @@ func TestRecordInstalledFiles(t *testing.T) {
 }
 
 func TestRecordInstalledFiles_NoManifest(t *testing.T) {
-	err := RecordInstalledFiles("/nonexistent/.ailloy/installed.yaml", "github.com/x/y", []InstalledFile{{RelPath: "a"}})
+	err := RecordInstalledFiles("/nonexistent/.ailloy/installed.yaml", "github.com/x/y", "", []InstalledFile{{RelPath: "a"}})
 	if err == nil {
 		t.Error("expected error for missing manifest")
 	}
@@ -184,7 +184,7 @@ func TestRecordInstalledFiles_EntryNotFound(t *testing.T) {
 	if err := WriteInstalledManifest(manifestPath, &InstalledManifest{APIVersion: "v1"}); err != nil {
 		t.Fatal(err)
 	}
-	err := RecordInstalledFiles(manifestPath, "github.com/missing/repo", []InstalledFile{{RelPath: "a"}})
+	err := RecordInstalledFiles(manifestPath, "github.com/missing/repo", "", []InstalledFile{{RelPath: "a"}})
 	if err == nil {
 		t.Error("expected error when entry not found")
 	}

--- a/pkg/foundry/lock.go
+++ b/pkg/foundry/lock.go
@@ -61,13 +61,16 @@ func WriteLockFile(path string, lock *LockFile) error {
 	return nil
 }
 
-// FindEntry looks up a lock entry by source (cache key).
-func (lf *LockFile) FindEntry(source string) *LockEntry {
+// FindEntry looks up a lock entry by (source, subpath).
+//
+// Subpath is part of the identity because a single foundry repo can host
+// multiple molds at different subpaths.
+func (lf *LockFile) FindEntry(source, subpath string) *LockEntry {
 	if lf == nil {
 		return nil
 	}
 	for i := range lf.Molds {
-		if lf.Molds[i].Source == source {
+		if lf.Molds[i].Source == source && lf.Molds[i].Subpath == subpath {
 			return &lf.Molds[i]
 		}
 	}
@@ -104,10 +107,10 @@ func ReferenceFromEntry(entry *LockEntry) (*Reference, error) {
 	}, nil
 }
 
-// UpsertEntry adds or updates a lock entry by source.
+// UpsertEntry adds or updates a lock entry by (source, subpath).
 func (lf *LockFile) UpsertEntry(entry LockEntry) {
 	for i := range lf.Molds {
-		if lf.Molds[i].Source == entry.Source {
+		if lf.Molds[i].Source == entry.Source && lf.Molds[i].Subpath == entry.Subpath {
 			lf.Molds[i] = entry
 			return
 		}

--- a/pkg/foundry/lock_test.go
+++ b/pkg/foundry/lock_test.go
@@ -97,10 +97,12 @@ func TestLockFile_FindEntry(t *testing.T) {
 		Molds: []LockEntry{
 			{Source: "github.com/a/b", Version: "v1.0.0"},
 			{Source: "github.com/c/d", Version: "v2.0.0"},
+			{Source: "github.com/k/foundry", Subpath: "molds/shortcut", Version: "v0.3.0"},
+			{Source: "github.com/k/foundry", Subpath: "molds/linear", Version: "v0.3.0"},
 		},
 	}
 
-	e := lf.FindEntry("github.com/a/b")
+	e := lf.FindEntry("github.com/a/b", "")
 	if e == nil {
 		t.Fatal("expected entry")
 	}
@@ -108,14 +110,21 @@ func TestLockFile_FindEntry(t *testing.T) {
 		t.Errorf("Version = %q", e.Version)
 	}
 
-	if lf.FindEntry("github.com/not/found") != nil {
+	if lf.FindEntry("github.com/not/found", "") != nil {
 		t.Error("expected nil for missing entry")
+	}
+
+	if got := lf.FindEntry("github.com/k/foundry", "molds/linear"); got == nil || got.Subpath != "molds/linear" {
+		t.Errorf("FindEntry by subpath linear = %+v", got)
+	}
+	if got := lf.FindEntry("github.com/k/foundry", "molds/shortcut"); got == nil || got.Subpath != "molds/shortcut" {
+		t.Errorf("FindEntry by subpath shortcut = %+v", got)
 	}
 }
 
 func TestLockFile_FindEntry_Nil(t *testing.T) {
 	var lf *LockFile
-	if lf.FindEntry("anything") != nil {
+	if lf.FindEntry("anything", "") != nil {
 		t.Error("expected nil on nil LockFile")
 	}
 }
@@ -146,6 +155,27 @@ func TestLockFile_UpsertEntry_Update(t *testing.T) {
 	}
 	if lf.Molds[0].Version != "v2.0.0" {
 		t.Errorf("Version = %q, want v2.0.0", lf.Molds[0].Version)
+	}
+}
+
+// Regression: two molds locked from the same foundry repo at different
+// subpaths must coexist in the lock file, not collapse to one entry.
+func TestLockFile_UpsertEntry_SameSourceDifferentSubpaths(t *testing.T) {
+	lf := &LockFile{APIVersion: "v1"}
+	lf.UpsertEntry(LockEntry{Source: "github.com/k/foundry", Subpath: "molds/shortcut", Version: "v0.3.0"})
+	lf.UpsertEntry(LockEntry{Source: "github.com/k/foundry", Subpath: "molds/linear", Version: "v0.3.0"})
+
+	if len(lf.Molds) != 2 {
+		t.Fatalf("expected 2 entries (different subpaths), got %d: %+v", len(lf.Molds), lf.Molds)
+	}
+
+	// Re-upsert of same (Source, Subpath) still replaces.
+	lf.UpsertEntry(LockEntry{Source: "github.com/k/foundry", Subpath: "molds/shortcut", Version: "v0.4.0"})
+	if len(lf.Molds) != 2 {
+		t.Fatalf("re-upsert should replace, got %d entries", len(lf.Molds))
+	}
+	if got := lf.FindEntry("github.com/k/foundry", "molds/shortcut"); got == nil || got.Version != "v0.4.0" {
+		t.Errorf("upsert did not replace: %+v", got)
 	}
 }
 

--- a/pkg/foundry/manifest.go
+++ b/pkg/foundry/manifest.go
@@ -51,10 +51,14 @@ func ReadInstalledManifest(path string) (*InstalledManifest, error) {
 	return &m, nil
 }
 
-// UpsertEntry adds or updates an entry by source.
+// UpsertEntry adds or updates an entry by (source, subpath).
+//
+// Subpath is part of the identity because a single foundry repo can host
+// multiple molds at different subpaths; matching on Source alone caused the
+// second install to overwrite the first.
 func (m *InstalledManifest) UpsertEntry(entry InstalledEntry) {
 	for i := range m.Molds {
-		if m.Molds[i].Source == entry.Source {
+		if m.Molds[i].Source == entry.Source && m.Molds[i].Subpath == entry.Subpath {
 			m.Molds[i] = entry
 			return
 		}
@@ -62,17 +66,34 @@ func (m *InstalledManifest) UpsertEntry(entry InstalledEntry) {
 	m.Molds = append(m.Molds, entry)
 }
 
-// FindBySource returns the entry matching the given source, or nil.
-func (m *InstalledManifest) FindBySource(source string) *InstalledEntry {
+// FindBySource returns the entry matching the given (source, subpath), or nil.
+// Pass an empty subpath for entries installed without one.
+func (m *InstalledManifest) FindBySource(source, subpath string) *InstalledEntry {
 	if m == nil {
 		return nil
 	}
 	for i := range m.Molds {
-		if m.Molds[i].Source == source {
+		if m.Molds[i].Source == source && m.Molds[i].Subpath == subpath {
 			return &m.Molds[i]
 		}
 	}
 	return nil
+}
+
+// FindAllBySource returns every entry matching the given source, regardless of
+// subpath. Useful for CLI flows where the user passes a bare source and we
+// need to disambiguate.
+func (m *InstalledManifest) FindAllBySource(source string) []*InstalledEntry {
+	if m == nil {
+		return nil
+	}
+	var out []*InstalledEntry
+	for i := range m.Molds {
+		if m.Molds[i].Source == source {
+			out = append(out, &m.Molds[i])
+		}
+	}
+	return out
 }
 
 // FindByName returns the entry matching the given name, or nil.

--- a/pkg/foundry/manifest_test.go
+++ b/pkg/foundry/manifest_test.go
@@ -122,22 +122,70 @@ func TestInstalledManifest_UpsertEntry(t *testing.T) {
 	}
 }
 
+// Regression for the bug where two molds installed from the same foundry repo
+// at different subpaths collapsed into a single manifest entry: the second
+// install overwrote the first because UpsertEntry matched by Source alone.
+func TestInstalledManifest_UpsertEntry_SameSourceDifferentSubpaths(t *testing.T) {
+	m := &InstalledManifest{APIVersion: "v1"}
+
+	m.UpsertEntry(InstalledEntry{
+		Name:    "shortcut",
+		Source:  "github.com/kriscoleman/replicated-foundry",
+		Subpath: "molds/shortcut",
+		Version: "v0.3.0",
+		Commit:  "aaa",
+	})
+	m.UpsertEntry(InstalledEntry{
+		Name:    "linear",
+		Source:  "github.com/kriscoleman/replicated-foundry",
+		Subpath: "molds/linear",
+		Version: "v0.3.0",
+		Commit:  "bbb",
+	})
+	if len(m.Molds) != 2 {
+		t.Fatalf("expected 2 entries (different subpaths), got %d: %+v", len(m.Molds), m.Molds)
+	}
+
+	// Re-upserting the same (Source, Subpath) MUST still replace.
+	m.UpsertEntry(InstalledEntry{
+		Name:    "shortcut",
+		Source:  "github.com/kriscoleman/replicated-foundry",
+		Subpath: "molds/shortcut",
+		Version: "v0.4.0",
+		Commit:  "ccc",
+	})
+	if len(m.Molds) != 2 {
+		t.Fatalf("re-upsert of same (source,subpath) should replace, not append: got %d", len(m.Molds))
+	}
+	if got := m.FindBySource("github.com/kriscoleman/replicated-foundry", "molds/shortcut"); got == nil || got.Version != "v0.4.0" {
+		t.Errorf("upsert did not replace existing entry: %+v", got)
+	}
+}
+
 func TestInstalledManifest_FindBySource(t *testing.T) {
 	m := &InstalledManifest{
 		APIVersion: "v1",
 		Molds: []InstalledEntry{
 			{Name: "a", Source: "github.com/x/a"},
 			{Name: "b", Source: "github.com/x/b"},
+			{Name: "shortcut", Source: "github.com/k/foundry", Subpath: "molds/shortcut"},
+			{Name: "linear", Source: "github.com/k/foundry", Subpath: "molds/linear"},
 		},
 	}
-	if got := m.FindBySource("github.com/x/b"); got == nil || got.Name != "b" {
+	if got := m.FindBySource("github.com/x/b", ""); got == nil || got.Name != "b" {
 		t.Errorf("FindBySource(b) = %+v, want entry b", got)
 	}
-	if got := m.FindBySource("github.com/x/missing"); got != nil {
+	if got := m.FindBySource("github.com/x/missing", ""); got != nil {
 		t.Errorf("FindBySource(missing) = %+v, want nil", got)
 	}
+	if got := m.FindBySource("github.com/k/foundry", "molds/linear"); got == nil || got.Name != "linear" {
+		t.Errorf("FindBySource(foundry, molds/linear) = %+v, want linear", got)
+	}
+	if got := m.FindBySource("github.com/k/foundry", "molds/shortcut"); got == nil || got.Name != "shortcut" {
+		t.Errorf("FindBySource(foundry, molds/shortcut) = %+v, want shortcut", got)
+	}
 	var nilM *InstalledManifest
-	if got := nilM.FindBySource("any"); got != nil {
+	if got := nilM.FindBySource("any", ""); got != nil {
 		t.Errorf("nil manifest FindBySource = %+v, want nil", got)
 	}
 }

--- a/pkg/foundry/uninstall.go
+++ b/pkg/foundry/uninstall.go
@@ -40,7 +40,10 @@ var ErrLegacyEntry = errors.New("manifest entry has no install file list (legacy
 // manifestPath is the path to .ailloy/installed.yaml (project) or
 // ~/.ailloy/installed.yaml (global). The lock that mirrors it is derived by
 // looking for ailloy.lock alongside the manifest's containing directory.
-func UninstallMold(manifestPath, source string, opts UninstallOptions) (UninstallResult, error) {
+//
+// (source, subpath) identifies a single entry: a foundry repo can host
+// multiple molds at different subpaths.
+func UninstallMold(manifestPath, source, subpath string, opts UninstallOptions) (UninstallResult, error) {
 	var res UninstallResult
 
 	m, err := ReadInstalledManifest(manifestPath)
@@ -51,9 +54,9 @@ func UninstallMold(manifestPath, source string, opts UninstallOptions) (Uninstal
 		return res, fmt.Errorf("installed manifest %s does not exist", manifestPath)
 	}
 
-	entry := m.FindBySource(source)
+	entry := m.FindBySource(source, subpath)
 	if entry == nil {
-		return res, fmt.Errorf("no installed manifest entry for source %q", source)
+		return res, fmt.Errorf("no installed manifest entry for source %q (subpath %q)", source, subpath)
 	}
 
 	if entry.Files == nil {
@@ -61,10 +64,11 @@ func UninstallMold(manifestPath, source string, opts UninstallOptions) (Uninstal
 		return res, ErrLegacyEntry
 	}
 
-	// Build a set of paths claimed by other entries.
+	// Build a set of paths claimed by other entries (any (source, subpath)
+	// other than this one — sibling molds in the same repo can share files).
 	otherClaims := make(map[string]struct{})
 	for i := range m.Molds {
-		if m.Molds[i].Source == source {
+		if m.Molds[i].Source == source && m.Molds[i].Subpath == subpath {
 			continue
 		}
 		for _, f := range m.Molds[i].Files {
@@ -145,7 +149,7 @@ func UninstallMold(manifestPath, source string, opts UninstallOptions) (Uninstal
 	}
 
 	for i := range m.Molds {
-		if m.Molds[i].Source == source {
+		if m.Molds[i].Source == source && m.Molds[i].Subpath == subpath {
 			m.Molds = append(m.Molds[:i], m.Molds[i+1:]...)
 			break
 		}
@@ -159,7 +163,7 @@ func UninstallMold(manifestPath, source string, opts UninstallOptions) (Uninstal
 	if lock, lerr := ReadLockFile(lockPath); lerr == nil && lock != nil {
 		dropped := false
 		for i := range lock.Molds {
-			if lock.Molds[i].Source == source {
+			if lock.Molds[i].Source == source && lock.Molds[i].Subpath == subpath {
 				lock.Molds = append(lock.Molds[:i], lock.Molds[i+1:]...)
 				dropped = true
 				break

--- a/pkg/foundry/uninstall_test.go
+++ b/pkg/foundry/uninstall_test.go
@@ -58,7 +58,7 @@ func TestUninstallMold_Clean(t *testing.T) {
 	writeFileT(t, "agents.md", "hello")
 	writeFileT(t, "skills/x/y.md", "world")
 
-	res, err := UninstallMold(manifestPath, "github.com/x/y", UninstallOptions{})
+	res, err := UninstallMold(manifestPath, "github.com/x/y", "", UninstallOptions{})
 	if err != nil {
 		t.Fatalf("UninstallMold: %v", err)
 	}
@@ -83,7 +83,7 @@ func TestUninstallMold_ModifiedFile_Skipped(t *testing.T) {
 	manifestPath := setupManifest(t, []string{"agents.md"}, hashes)
 	writeFileT(t, "agents.md", "modified content")
 
-	res, err := UninstallMold(manifestPath, "github.com/x/y", UninstallOptions{})
+	res, err := UninstallMold(manifestPath, "github.com/x/y", "", UninstallOptions{})
 	if err != nil {
 		t.Fatalf("UninstallMold: %v", err)
 	}
@@ -100,7 +100,7 @@ func TestUninstallMold_ModifiedFile_Force(t *testing.T) {
 	manifestPath := setupManifest(t, []string{"agents.md"}, hashes)
 	writeFileT(t, "agents.md", "modified")
 
-	res, err := UninstallMold(manifestPath, "github.com/x/y", UninstallOptions{Force: true})
+	res, err := UninstallMold(manifestPath, "github.com/x/y", "", UninstallOptions{Force: true})
 	if err != nil {
 		t.Fatalf("UninstallMold: %v", err)
 	}
@@ -113,7 +113,7 @@ func TestUninstallMold_Missing(t *testing.T) {
 	hashes := map[string]string{"agents.md": sha256Hex("anything")}
 	manifestPath := setupManifest(t, []string{"agents.md"}, hashes)
 
-	res, err := UninstallMold(manifestPath, "github.com/x/y", UninstallOptions{})
+	res, err := UninstallMold(manifestPath, "github.com/x/y", "", UninstallOptions{})
 	if err != nil {
 		t.Fatalf("UninstallMold: %v", err)
 	}
@@ -127,7 +127,7 @@ func TestUninstallMold_DryRun(t *testing.T) {
 	manifestPath := setupManifest(t, []string{"agents.md"}, hashes)
 	writeFileT(t, "agents.md", "x")
 
-	res, err := UninstallMold(manifestPath, "github.com/x/y", UninstallOptions{DryRun: true})
+	res, err := UninstallMold(manifestPath, "github.com/x/y", "", UninstallOptions{DryRun: true})
 	if err != nil {
 		t.Fatalf("UninstallMold: %v", err)
 	}
@@ -160,7 +160,7 @@ func TestUninstallMold_SharedFile_Retained(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	res, err := UninstallMold(manifestPath, "github.com/x/y", UninstallOptions{})
+	res, err := UninstallMold(manifestPath, "github.com/x/y", "", UninstallOptions{})
 	if err != nil {
 		t.Fatalf("UninstallMold: %v", err)
 	}
@@ -187,7 +187,7 @@ func TestUninstallMold_LegacyEntry_NoFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	res, err := UninstallMold(manifestPath, "github.com/x/y", UninstallOptions{})
+	res, err := UninstallMold(manifestPath, "github.com/x/y", "", UninstallOptions{})
 	if err == nil {
 		t.Fatal("expected ErrLegacyEntry")
 	}
@@ -215,7 +215,7 @@ func TestUninstallMold_DropsLockEntryToo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := UninstallMold(manifestPath, "github.com/x/y", UninstallOptions{}); err != nil {
+	if _, err := UninstallMold(manifestPath, "github.com/x/y", "", UninstallOptions{}); err != nil {
 		t.Fatalf("UninstallMold: %v", err)
 	}
 	loaded, _ := ReadLockFile(LockFileName)


### PR DESCRIPTION
## Description

Two bugs caused multiple molds installed from the same foundry repo to silently disappear from project state.

**`installed.yaml` / `ailloy.lock` collisions on `Source`.** `UpsertEntry` and `FindEntry`/`FindBySource` matched on `Source` (= `host/owner/repo`, no subpath). Two molds at different subpaths in the same repo (e.g. `replicated-foundry//molds/shortcut` and `…//molds/linear`) shared the same key, so the second cast overwrote the first. Identity is now `(Source, Subpath)` everywhere — manifest, lock, `RecordInstalledFiles`, `UninstallMold`, and all internal Source-only loops in uninstall. CLI `ailloy uninstall` now accepts `source//subpath`; bare sources auto-resolve when unique and error with a disambiguation list when ambiguous (via new `FindAllBySource`).

**`state.yaml` overwritten / not written.** `writeInstallState` reconstructed the file from only the current cast's dirs, and `CastMold` (the foundries TUI path) never invoked it. Now it reads the existing file, unions + dedupes + sorts, and writes back, and `CastMold` invokes it for non-global installs.

## Related Issue

N/A — discovered while installing several molds from a single foundry; only the most recent appeared in `installed.yaml`.

## Testing

- New regression tests for the same-source/different-subpath case in `manifest_test.go` and `lock_test.go`.
- Extended `FindBySource` / `FindEntry` tests for subpath disambiguation.
- New `cast_state_test.go` covering merge, dedupe, and fresh-create for `state.yaml`.
- Existing `RecordInstalledFiles` and `UninstallMold` tests updated for new signatures.
- \`go vet ./...\` clean, \`golangci-lint run ./...\` 0 issues, \`go test -race ./...\` green across all packages.

## UAT

1. \`ailloy cast github.com/<owner>/<foundry>//molds/a\`
2. \`ailloy cast github.com/<owner>/<foundry>//molds/b\`
3. \`cat .ailloy/installed.yaml\` — both entries should be present (previously only the second).
4. \`cat .ailloy/state.yaml\` — \`blankDirs\` should list dirs from both casts.
5. \`ailloy uninstall github.com/<owner>/<foundry>\` errors with both subpaths listed; \`ailloy uninstall github.com/<owner>/<foundry>//molds/a\` removes just one.

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [ ] I have updated documentation (if applicable)
- [x] My commits have DCO sign-off (\`git commit -s\`)