### PR TITLE
feat: foundry temper — validate foundry.yaml in CI

### DIFF
--- a/docs/foundry.md
+++ b/docs/foundry.md
@@ -347,6 +347,46 @@ foundries:
 2. Users register it with: `ailloy foundry add https://example.com/foundry.yaml` (a bare `example.com/foundry.yaml` is also accepted and defaults to `https://`)
 3. URLs ending in `.yaml` or `.yml` are automatically detected as static files
 
+### Validating a Foundry Index
+
+`ailloy foundry temper [path]` (alias `validate`) checks a foundry index file before publishing or merging.
+
+```bash
+# Validate ./foundry.yaml (default path) — schema + every mold source + every nested foundry
+ailloy foundry temper
+
+# Validate a specific file
+ailloy foundry temper path/to/foundry.yaml
+
+# Schema check only — no network
+ailloy foundry temper --offline
+
+# Don't recurse into nested foundries (still verifies this index's own molds)
+ailloy foundry temper --no-recurse
+```
+
+What it checks:
+
+- **Schema** — `apiVersion`, `kind`, `name`, every mold's `name`/`source`, every nested foundry's `source`.
+- **Mold sources** — each direct mold's source URL is parsed and its version reference is resolved against the remote via `git ls-remote` (no clone). Per-entry errors are reported with the mold's array index and name.
+- **Nested foundries** — each nested foundry index is fetched, schema-validated, and its molds are verified the same way. Recursion is depth-first with cycle protection (a foundry referenced more than once is checked once).
+
+The command exits non-zero on the first error finding. Designed to wire into CI on a foundry-index repo:
+
+```yaml
+# .github/workflows/validate.yml
+on:
+  pull_request:
+    paths: [foundry.yaml]
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: curl -sSL https://raw.githubusercontent.com/nimble-giant/ailloy/main/install.sh | bash
+      - run: ailloy foundry temper foundry.yaml
+```
+
 ### Submitting to the Official Index
 
 To add your mold to the official Ailloy foundry index:
@@ -659,3 +699,4 @@ Remote mold references work with all mold-consuming commands:
 | `foundry remove` | `ailloy foundry remove nimble-foundry`                              |
 | `foundry update` | `ailloy foundry update`                                             |
 | `foundry install` | `ailloy foundry install foundry` or `ailloy foundry install foundry --shallow` |
+| `foundry temper` | `ailloy foundry temper foundry.yaml` (alias: `foundry validate`)             |

--- a/internal/commands/foundry_temper.go
+++ b/internal/commands/foundry_temper.go
@@ -1,0 +1,83 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/nimble-giant/ailloy/pkg/foundry/index"
+	"github.com/nimble-giant/ailloy/pkg/styles"
+	"github.com/spf13/cobra"
+)
+
+var (
+	foundryTemperOffline   bool
+	foundryTemperNoRecurse bool
+)
+
+var foundryTemperCmd = &cobra.Command{
+	Use:     "temper [path]",
+	Aliases: []string{"validate"},
+	Short:   "Validate a foundry index file",
+	Long: `Validate a foundry.yaml file.
+
+Checks performed:
+  - YAML parse and schema validation (apiVersion, kind, name, required mold/foundry fields)
+  - Each direct mold's source resolves on its remote (git ls-remote, no clone)
+  - Each nested foundry resolves and is itself valid (recursively, with cycle protection)
+
+Use --offline to skip network checks (schema only). Use --no-recurse to
+validate only this index — skipping descent into nested foundries — while
+still verifying the immediate mold sources.`,
+	Args:         cobra.MaximumNArgs(1),
+	SilenceUsage: true,
+	RunE:         runFoundryTemper,
+}
+
+func init() {
+	foundryCmd.AddCommand(foundryTemperCmd)
+	foundryTemperCmd.Flags().BoolVar(&foundryTemperOffline, "offline", false, "skip network checks (schema only)")
+	foundryTemperCmd.Flags().BoolVar(&foundryTemperNoRecurse, "no-recurse", false, "skip descent into nested foundries")
+}
+
+func runFoundryTemper(_ *cobra.Command, args []string) error {
+	path := "foundry.yaml"
+	if len(args) > 0 {
+		path = args[0]
+	}
+
+	fmt.Println(styles.WorkingBanner("Tempering " + path + "..."))
+	fmt.Println()
+
+	res, err := index.Temper(path, index.TemperOptions{
+		Offline:   foundryTemperOffline,
+		NoRecurse: foundryTemperNoRecurse,
+	})
+	if err != nil {
+		return err
+	}
+
+	if res.Index != nil && res.Index.Name != "" {
+		summary := fmt.Sprintf("Index: %s (%d molds, %d nested foundries)",
+			res.Index.Name, len(res.Index.Molds), len(res.Index.Foundries))
+		fmt.Println(styles.InfoStyle.Render(summary))
+		fmt.Println()
+	}
+
+	if !res.HasErrors() {
+		fmt.Println(styles.SuccessStyle.Render("Foundry index is valid."))
+		return nil
+	}
+
+	for _, f := range res.Findings {
+		header := styles.ErrorStyle.Render("error")
+		if f.Path != "" {
+			header += " " + styles.AccentStyle.Render(f.Path)
+		}
+		fmt.Println("  " + header)
+		if f.Source != "" {
+			fmt.Println(styles.SubtleStyle.Render("    source: " + f.Source))
+		}
+		fmt.Println(styles.SubtleStyle.Render("    " + f.Err.Error()))
+	}
+
+	return fmt.Errorf("%d finding(s) reported", len(res.Findings))
+}

--- a/pkg/foundry/index/temper.go
+++ b/pkg/foundry/index/temper.go
@@ -1,0 +1,188 @@
+package index
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/nimble-giant/ailloy/pkg/foundry"
+)
+
+// TemperOptions configures Temper behavior.
+type TemperOptions struct {
+	// Offline skips all network checks; only schema validation runs.
+	Offline bool
+	// NoRecurse skips descent into nested foundries (still validates the
+	// immediate index's own molds).
+	NoRecurse bool
+	// MoldVerifier overrides the per-mold reference check, primarily for
+	// testing. When nil, foundry.ResolveVersion via DefaultGitRunner is used.
+	MoldVerifier func(source string) error
+	// FoundryFetcher overrides nested-foundry fetching, primarily for testing.
+	// When nil, the default network-backed Fetcher is used (which also writes
+	// the on-disk cache).
+	FoundryFetcher func(source string) (*Index, error)
+}
+
+// TemperFinding is one issue found during validation.
+type TemperFinding struct {
+	Severity string // "error" today; reserved for future "warning"
+	Path     string // dotted/bracketed path to the offending field
+	Source   string // the source URL the finding refers to (mold or foundry)
+	Err      error  // underlying cause
+}
+
+// TemperResult is the aggregate output of a Temper run.
+type TemperResult struct {
+	Index    *Index // parsed root index, even when findings are present
+	Findings []TemperFinding
+}
+
+// HasErrors reports whether any finding is severity "error".
+func (r *TemperResult) HasErrors() bool {
+	for _, f := range r.Findings {
+		if f.Severity == "error" {
+			return true
+		}
+	}
+	return false
+}
+
+// Temper reads, parses, and validates a foundry index file at path.
+// See TemperBytes for the validation behaviour.
+func Temper(path string, opts TemperOptions) (*TemperResult, error) {
+	data, err := os.ReadFile(path) // #nosec G304 -- caller-supplied foundry index path
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	return TemperBytes(data, opts)
+}
+
+// TemperBytes validates an already-loaded foundry index.
+//
+// Validation order:
+//  1. Parse YAML.
+//  2. Schema validation via Index.Validate(). Failures here short-circuit
+//     remaining checks (returning a TemperResult with one finding).
+//  3. (network) Per direct mold: parse the source ref and resolve it on the
+//     remote via git ls-remote. Each failure is reported as a finding.
+//  4. (network, unless NoRecurse) Per nested foundry: fetch the child index,
+//     run the same checks recursively. Cycles are silently broken via a
+//     visited-set keyed on canonical source URL.
+//
+// Network steps are skipped entirely when opts.Offline is true.
+func TemperBytes(data []byte, opts TemperOptions) (*TemperResult, error) {
+	idx, err := ParseIndex(data)
+	if err != nil {
+		return nil, err
+	}
+
+	res := &TemperResult{Index: idx}
+	if err := idx.Validate(); err != nil {
+		res.Findings = append(res.Findings, TemperFinding{Severity: "error", Err: err})
+		return res, nil
+	}
+
+	if opts.Offline {
+		return res, nil
+	}
+
+	moldVerifier := opts.MoldVerifier
+	if moldVerifier == nil {
+		git := foundry.DefaultGitRunner()
+		moldVerifier = func(source string) error {
+			ref, err := foundry.ParseReference(source)
+			if err != nil {
+				return err
+			}
+			_, err = foundry.ResolveVersion(ref, git)
+			return err
+		}
+	}
+
+	foundryFetcher := opts.FoundryFetcher
+	if foundryFetcher == nil {
+		fetcher, err := NewFetcher(defaultGitRunnerForSearch())
+		if err != nil {
+			return nil, fmt.Errorf("constructing fetcher: %w", err)
+		}
+		foundryFetcher = func(source string) (*Index, error) {
+			url := NormalizeFoundryURL(source)
+			entry := &FoundryEntry{URL: url, Type: DetectType(url)}
+			return fetcher.FetchIndex(entry)
+		}
+	}
+
+	// Verify direct molds.
+	for i, m := range idx.Molds {
+		if err := moldVerifier(m.Source); err != nil {
+			res.Findings = append(res.Findings, TemperFinding{
+				Severity: "error",
+				Path:     fmt.Sprintf("molds[%d] (%s)", i, m.Name),
+				Source:   m.Source,
+				Err:      err,
+			})
+		}
+	}
+
+	// Recursively walk nested foundries.
+	if !opts.NoRecurse {
+		visited := map[string]bool{}
+		// Mark the root visited (using its declared source-of-record: we don't
+		// know the root's URL here, so visited[] starts empty and children
+		// short-circuit each other.)
+		for i, f := range idx.Foundries {
+			res.Findings = append(res.Findings,
+				temperNested(f.Source, fmt.Sprintf("foundries[%d] (%s)", i, f.Name),
+					visited, moldVerifier, foundryFetcher, opts.NoRecurse)...)
+		}
+	}
+
+	return res, nil
+}
+
+// temperNested validates a nested foundry by source URL: fetches the child
+// index (which also schema-validates it), then verifies each of its molds and
+// recurses into its own nested foundries. Cycles are short-circuited via the
+// shared visited map.
+func temperNested(
+	source, pathLabel string,
+	visited map[string]bool,
+	moldVerifier func(string) error,
+	foundryFetcher func(string) (*Index, error),
+	noRecurse bool,
+) []TemperFinding {
+	key := canonicalizeSource(source)
+	if visited[key] {
+		return nil
+	}
+	visited[key] = true
+
+	idx, err := foundryFetcher(source)
+	if err != nil {
+		return []TemperFinding{{
+			Severity: "error",
+			Path:     pathLabel,
+			Source:   source,
+			Err:      err,
+		}}
+	}
+
+	var out []TemperFinding
+	for i, m := range idx.Molds {
+		if err := moldVerifier(m.Source); err != nil {
+			out = append(out, TemperFinding{
+				Severity: "error",
+				Path:     fmt.Sprintf("%s -> molds[%d] (%s)", pathLabel, i, m.Name),
+				Source:   m.Source,
+				Err:      err,
+			})
+		}
+	}
+	if !noRecurse {
+		for i, f := range idx.Foundries {
+			child := fmt.Sprintf("%s -> foundries[%d] (%s)", pathLabel, i, f.Name)
+			out = append(out, temperNested(f.Source, child, visited, moldVerifier, foundryFetcher, noRecurse)...)
+		}
+	}
+	return out
+}

--- a/pkg/foundry/index/temper_test.go
+++ b/pkg/foundry/index/temper_test.go
@@ -1,0 +1,222 @@
+package index
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestTemperBytes_OfflineSchemaPasses(t *testing.T) {
+	yaml := []byte(`apiVersion: v1
+kind: foundry-index
+name: ok
+molds:
+  - name: alpha
+    source: github.com/x/alpha
+`)
+	res, err := TemperBytes(yaml, TemperOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("TemperBytes: %v", err)
+	}
+	if res.HasErrors() {
+		t.Fatalf("unexpected findings: %+v", res.Findings)
+	}
+	if res.Index.Name != "ok" {
+		t.Errorf("Index.Name = %q, want ok", res.Index.Name)
+	}
+}
+
+func TestTemperBytes_OfflineSchemaFails(t *testing.T) {
+	// Missing apiVersion + missing mold source.
+	yaml := []byte(`kind: foundry-index
+name: bad
+molds:
+  - name: m1
+`)
+	res, err := TemperBytes(yaml, TemperOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("TemperBytes: %v", err)
+	}
+	if !res.HasErrors() {
+		t.Fatal("expected schema errors, got none")
+	}
+	if got := res.Findings[0].Err.Error(); !strings.Contains(got, "apiVersion") {
+		t.Errorf("first finding %q should mention apiVersion", got)
+	}
+}
+
+func TestTemperBytes_VerifiesMoldSources(t *testing.T) {
+	yaml := []byte(`apiVersion: v1
+kind: foundry-index
+name: ok
+molds:
+  - name: good
+    source: github.com/x/good
+  - name: bad
+    source: github.com/x/bad
+`)
+	called := map[string]int{}
+	verifier := func(source string) error {
+		called[source]++
+		if source == "github.com/x/bad" {
+			return fmt.Errorf("not found")
+		}
+		return nil
+	}
+	res, err := TemperBytes(yaml, TemperOptions{
+		MoldVerifier:   verifier,
+		FoundryFetcher: func(string) (*Index, error) { t.Fatal("nested fetch not expected"); return nil, nil },
+	})
+	if err != nil {
+		t.Fatalf("TemperBytes: %v", err)
+	}
+	if called["github.com/x/good"] != 1 || called["github.com/x/bad"] != 1 {
+		t.Errorf("verifier call counts = %v, want each once", called)
+	}
+	if !res.HasErrors() {
+		t.Fatalf("expected errors, got none")
+	}
+	if len(res.Findings) != 1 {
+		t.Fatalf("got %d findings, want 1", len(res.Findings))
+	}
+	if res.Findings[0].Source != "github.com/x/bad" {
+		t.Errorf("finding.Source = %q, want github.com/x/bad", res.Findings[0].Source)
+	}
+}
+
+func TestTemperBytes_RecursesIntoNestedFoundries(t *testing.T) {
+	yaml := []byte(`apiVersion: v1
+kind: foundry-index
+name: parent
+molds:
+  - name: parent-mold
+    source: github.com/x/parent-mold
+foundries:
+  - name: child
+    source: github.com/x/child
+`)
+	moldsCalled := []string{}
+	verifier := func(source string) error {
+		moldsCalled = append(moldsCalled, source)
+		return nil
+	}
+	fetcher := func(source string) (*Index, error) {
+		if source != "github.com/x/child" {
+			return nil, fmt.Errorf("unexpected: %s", source)
+		}
+		return &Index{
+			APIVersion: "v1", Kind: "foundry-index", Name: "child",
+			Molds: []MoldEntry{{Name: "child-mold", Source: "github.com/x/child-mold"}},
+		}, nil
+	}
+	res, err := TemperBytes(yaml, TemperOptions{
+		MoldVerifier:   verifier,
+		FoundryFetcher: fetcher,
+	})
+	if err != nil {
+		t.Fatalf("TemperBytes: %v", err)
+	}
+	if res.HasErrors() {
+		t.Fatalf("unexpected findings: %+v", res.Findings)
+	}
+	want := []string{"github.com/x/parent-mold", "github.com/x/child-mold"}
+	if len(moldsCalled) != len(want) {
+		t.Fatalf("verifier called for %v, want %v", moldsCalled, want)
+	}
+	for i, w := range want {
+		if moldsCalled[i] != w {
+			t.Errorf("call[%d] = %q, want %q", i, moldsCalled[i], w)
+		}
+	}
+}
+
+func TestTemperBytes_NoRecurseSkipsChildren(t *testing.T) {
+	yaml := []byte(`apiVersion: v1
+kind: foundry-index
+name: parent
+molds: []
+foundries:
+  - name: child
+    source: github.com/x/child
+`)
+	fetcher := func(string) (*Index, error) {
+		t.Fatal("FoundryFetcher should not be invoked when NoRecurse is true")
+		return nil, nil
+	}
+	res, err := TemperBytes(yaml, TemperOptions{
+		NoRecurse:      true,
+		MoldVerifier:   func(string) error { return nil },
+		FoundryFetcher: fetcher,
+	})
+	if err != nil {
+		t.Fatalf("TemperBytes: %v", err)
+	}
+	if res.HasErrors() {
+		t.Fatalf("unexpected findings: %+v", res.Findings)
+	}
+}
+
+func TestTemperBytes_NestedFetchFailureIsReported(t *testing.T) {
+	yaml := []byte(`apiVersion: v1
+kind: foundry-index
+name: parent
+molds: []
+foundries:
+  - name: broken
+    source: github.com/x/broken
+`)
+	res, err := TemperBytes(yaml, TemperOptions{
+		MoldVerifier:   func(string) error { return nil },
+		FoundryFetcher: func(string) (*Index, error) { return nil, fmt.Errorf("network down") },
+	})
+	if err != nil {
+		t.Fatalf("TemperBytes: %v", err)
+	}
+	if !res.HasErrors() {
+		t.Fatal("expected an error finding for broken nested foundry")
+	}
+	if !strings.Contains(res.Findings[0].Err.Error(), "network down") {
+		t.Errorf("finding.Err = %v, want it to mention network down", res.Findings[0].Err)
+	}
+}
+
+func TestTemperBytes_Cycles(t *testing.T) {
+	yaml := []byte(`apiVersion: v1
+kind: foundry-index
+name: a
+molds: []
+foundries:
+  - name: b
+    source: github.com/x/b
+`)
+	calls := 0
+	fetcher := func(source string) (*Index, error) {
+		calls++
+		switch canonicalizeSource(source) {
+		case "github.com/x/b":
+			return &Index{
+				APIVersion: "v1", Kind: "foundry-index", Name: "b",
+				Foundries: []FoundryRef{{Name: "a", Source: "github.com/x/a"}},
+			}, nil
+		case "github.com/x/a":
+			return &Index{
+				APIVersion: "v1", Kind: "foundry-index", Name: "a",
+				Foundries: []FoundryRef{{Name: "b", Source: "github.com/x/b"}},
+			}, nil
+		}
+		return nil, fmt.Errorf("unexpected: %s", source)
+	}
+	res, err := TemperBytes(yaml, TemperOptions{
+		MoldVerifier:   func(string) error { return nil },
+		FoundryFetcher: fetcher,
+	})
+	if err != nil {
+		t.Fatalf("TemperBytes: %v", err)
+	}
+	if res.HasErrors() {
+		t.Fatalf("cycle should not produce errors: %+v", res.Findings)
+	}
+	if calls != 2 {
+		t.Errorf("fetcher called %d times, want 2 (each child fetched once)", calls)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `ailloy foundry temper [path]` (alias `validate`) for validating a foundry index file. The motivation is CI on foundry-index repos like `nimble-giant/foundry`: when a contributor opens a PR adding a mold or a nested foundry, the workflow runs `ailloy foundry temper foundry.yaml` and fails the check if anything's wrong before review.

## What it checks

- **Schema** — `apiVersion`, `kind`, `name`, every mold's `name`/`source`, every nested foundry's `source` (the same `Index.Validate()` Ailloy already runs at fetch time).
- **Mold sources** — for each direct mold, parse the source ref and resolve its version on the remote via `git ls-remote` (no clone). Per-entry findings include the array index and mold name so a contributor knows exactly which row is broken.
- **Nested foundries** — fetch each nested foundry's index, schema-validate it, verify its molds, and recurse. Depth-first with cycle protection (a foundry referenced more than once is checked once).

## Flags

- `--offline` — schema only, no network.
- `--no-recurse` — validate this index's own molds but don't descend into nested foundries.

The command exits non-zero on the first error finding and uses `SilenceUsage: true` so CI logs stay readable.

## Implementation notes

Validation core in `pkg/foundry/index/temper.go` exposes `TemperOptions` with injection seams (`MoldVerifier`, `FoundryFetcher`) so tests don't need network. CLI thin wrapper in `internal/commands/foundry_temper.go`. 7 unit tests cover offline schema pass/fail, mold-source verification (good + bad), nested recursion, `--no-recurse`, nested fetch failure, and cycle short-circuit.

## CI usage example (in docs/foundry.md)

```yaml
on:
  pull_request:
    paths: [foundry.yaml]
jobs:
  validate:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - run: curl -sSL https://raw.githubusercontent.com/nimble-giant/ailloy/main/install.sh | bash
      - run: ailloy foundry temper foundry.yaml
```

## Verification

- `go test ./... -count=1` — all packages pass
- `go vet ./...` — clean
- Smoke-tested manually against valid and invalid fixtures (schema-only mode); error output is per-entry and unambiguous

## Test plan

- [ ] After merging, add `.github/workflows/validate.yml` to `nimble-giant/foundry` invoking `ailloy foundry temper foundry.yaml`
- [ ] Verify `kriscoleman/use-nested-replicated-foundry` PR (#4 on the foundry repo) triggers the workflow and passes
- [ ] Try a deliberately broken PR (typo in a source URL) and confirm CI surfaces the per-entry finding