### PR TITLE
fix: temper skips template validation for process:false outputs

### DIFF
--- a/pkg/mold/temper_test.go
+++ b/pkg/mold/temper_test.go
@@ -385,6 +385,81 @@ output:
 	}
 }
 
+func TestTemper_SkipsTemplateValidationForProcessFalse(t *testing.T) {
+	// Files in a `process: false` output mapping are copied as-is at cast time,
+	// so temper must not attempt Go template parsing on them. They may contain
+	// foreign template syntax (Helm, KOTS, Jinja, GitHub Actions) that would
+	// otherwise produce false-positive parse errors.
+	fsys := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte(`
+apiVersion: v1
+kind: mold
+name: test-mold
+version: 1.0.0
+`)},
+		"flux.yaml": &fstest.MapFile{Data: []byte(`
+output:
+  skills:
+    dest: .claude/skills
+    process: false
+`)},
+		"skills/helm-skill/SKILL.md": &fstest.MapFile{Data: []byte(
+			"# Helm\nUse `{{ .Values.image.tag }}` for templated image refs.\n",
+		)},
+		"skills/kots-skill/SKILL.md": &fstest.MapFile{Data: []byte(
+			"# KOTS\nUse `{{repl ConfigOption \"x\"}}` for KOTS config.\n",
+		)},
+	}
+
+	result := Temper(fsys)
+
+	for _, d := range result.Errors() {
+		if d.File == "skills/helm-skill/SKILL.md" || d.File == "skills/kots-skill/SKILL.md" {
+			t.Errorf("should not validate template syntax on process:false file %s: %s", d.File, d.Message)
+		}
+	}
+}
+
+func TestTemper_StillValidatesTemplatesForProcessTrue(t *testing.T) {
+	// A sibling output with default (process: true) must still have its template
+	// syntax validated, even when other outputs use process: false.
+	fsys := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte(`
+apiVersion: v1
+kind: mold
+name: test-mold
+version: 1.0.0
+`)},
+		"flux.yaml": &fstest.MapFile{Data: []byte(`
+output:
+  skills:
+    dest: .claude/skills
+    process: false
+  commands: .claude/commands
+`)},
+		"skills/helm/SKILL.md": &fstest.MapFile{Data: []byte("# Helm\n{{ .Values.foo }}")},
+		"commands/broken.md":   &fstest.MapFile{Data: []byte("# Broken\n{{if .foo}")},
+	}
+
+	result := Temper(fsys)
+
+	if !result.HasErrors() {
+		t.Fatal("expected template syntax error for commands/broken.md")
+	}
+	found := false
+	for _, d := range result.Errors() {
+		if d.File == "commands/broken.md" {
+			found = true
+		}
+		if d.File == "skills/helm/SKILL.md" {
+			t.Errorf("should not validate template syntax on process:false file %s: %s", d.File, d.Message)
+		}
+	}
+	if !found {
+		t.Error("expected error referencing commands/broken.md")
+	}
+}
+
 func TestTemperResult_ErrorsAndWarnings(t *testing.T) {
 	r := &TemperResult{
 		Diagnostics: []Diagnostic{

--- a/pkg/mold/validate.go
+++ b/pkg/mold/validate.go
@@ -434,7 +434,10 @@ func temperFluxSchema(fsys fs.FS, manifestFlux []FluxVar, result *TemperResult) 
 
 // validateTemplates parses .md files through Go text/template to catch syntax errors.
 // When allowedPaths is non-nil, only files in that set are validated.
-// resolveOutputPaths returns the set of source paths from the output manifest.
+// resolveOutputPaths returns the set of source paths from the output manifest
+// that will be template-processed at cast time. Files in `process: false`
+// mappings are copied as-is and therefore must not be subject to Go template
+// syntax validation (they may legitimately contain `{{` from Helm/KOTS/Jinja).
 // If output is nil (identity mode), all .md files are considered in scope.
 func resolveOutputPaths(output any, fsys fs.FS) map[string]bool {
 	resolved, err := ResolveFiles(output, fsys)
@@ -443,6 +446,9 @@ func resolveOutputPaths(output any, fsys fs.FS) map[string]bool {
 	}
 	paths := make(map[string]bool, len(resolved))
 	for _, rf := range resolved {
+		if !rf.Process {
+			continue
+		}
 		paths[rf.SrcPath] = true
 	}
 	return paths


### PR DESCRIPTION
## Description

`ailloy temper` was running Go template syntax validation on every `.md` file in a mold, including files under output mappings declared `process: false` in `flux.yaml`. Those files are copied as-is at cast time, so foreign template syntax (Helm `{{ .Values.foo }}`, KOTS `{{repl ConfigOption "x"}}`, Jinja, GitHub Actions expressions) produced false-positive parse errors and blocked CI for any foundry with knowledge-heavy molds. The fix filters `ResolvedFile` entries by their `Process` bool in `resolveOutputPaths`, mirroring the same check `cast` and temper's own `writeRenderedFiles` already use.

## Related Issue

Fixes #165

## Testing

`go test ./pkg/mold/ ./internal/commands/` — all pass, including two new tests: `TestTemper_SkipsTemplateValidationForProcessFalse` (Helm/KOTS skills under `process: false` no longer error) and `TestTemper_StillValidatesTemplatesForProcessTrue` (a sibling default mapping still catches a real `{{if .foo}` syntax error, so the skip is not over-broad).

## UAT

In a mold with `output: { skills: { dest: .claude/skills, process: false } }`, place a SKILL.md containing `{{ .Values.image.tag }}` or `{{repl ConfigOption "x"}}`. Run `ailloy temper .` — it should pass instead of reporting `template syntax error: function "repl" not defined`.

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [ ] I have updated documentation (if applicable)
- [x] My commits have DCO sign-off (`git commit -s`)