### PR TITLE
ci: bump release workflow Go to 1.25 to match go.mod

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           cache: true
 
       - name: Run tests


### PR DESCRIPTION
## Description

The release workflow pinned Go 1.24, but `go.mod` requires `>= 1.25.8`. As a result, the `build-binaries` job failed at `go test` for v0.6.20 and v0.6.21, leaving both releases tagged on GitHub but with no binary assets attached. The homebrew tap auto-update accordingly never moved past v0.6.19, which is why `brew upgrade nimble-giant/tap/ailloy` reports 0.6.19 as the latest available version. This bumps `actions/setup-go` to `1.25` so the next release builds cleanly; v0.6.20 and v0.6.21 will be skipped (fix-forward) and the tap will pick up the next successful release on its next hourly run.

## Related Issue

N/A

## Testing

Verified locally that `go.mod` declares `go 1.25.8` and that the failing CI run (25268237333) errored with `go.mod requires go >= 1.25.8 (running go 1.24.13)`. Pre-push hook ran `go build`, `golangci-lint`, and `go test -race ./...` successfully.

## UAT

Merge, wait for the next release-please release to fire, and confirm that the `Build and Upload Binaries` job succeeds and that the resulting GitHub release has all five binaries plus `checksums.txt` attached. Then `brew update && brew upgrade nimble-giant/tap/ailloy` should move past 0.6.19 within the next tap auto-update cycle.

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [ ] I have added tests (if applicable)
- [ ] I have updated documentation (if applicable)
- [x] My commits have DCO sign-off (`git commit -s`)