### PR TITLE
feat: cinematic splash for ailloy root help

### DIFF
--- a/internal/commands/evolve.go
+++ b/internal/commands/evolve.go
@@ -19,7 +19,6 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/nimble-giant/ailloy/pkg/styles"
 	"github.com/spf13/cobra"
-	"golang.org/x/term"
 )
 
 const (
@@ -330,13 +329,15 @@ func evolveAnimationArt() string {
 // plain success line when stdout is not a TTY or skip is set, so CI logs and
 // non-interactive shells stay clean.
 func playEvolutionAnimation(target string, skip bool) {
-	if skip || !term.IsTerminal(int(os.Stdout.Fd())) {
+	if skip {
+		styles.SetNoAnimate(true)
+		defer styles.SetNoAnimate(false)
+	}
+
+	if !styles.ShouldAnimate() {
 		fmt.Println(styles.SuccessStyle.Render("✓ 🦊 ") + "Your ailloy evolved into " + target + "!")
 		return
 	}
-
-	art := evolveAnimationArt()
-	height := strings.Count(art, "\n") + 1
 
 	headline := lipgloss.NewStyle().Bold(true).Foreground(styles.Primary1)
 	primary := lipgloss.NewStyle().Foreground(styles.Primary1)
@@ -346,36 +347,19 @@ func playEvolutionAnimation(target string, skip bool) {
 	fmt.Println()
 	fmt.Println(headline.Render("What? AILLOY is evolving!"))
 	fmt.Println()
-	fmt.Println(primary.Render(art))
 
-	cycles := []struct {
-		useFlash bool
-		delay    time.Duration
-	}{
-		{true, 280 * time.Millisecond},
-		{false, 240 * time.Millisecond},
-		{true, 200 * time.Millisecond},
-		{false, 180 * time.Millisecond},
-		{true, 160 * time.Millisecond},
-		{false, 140 * time.Millisecond},
-		{true, 120 * time.Millisecond},
-		{false, 100 * time.Millisecond},
-	}
+	styles.FlashArt(evolveAnimationArt(), primary, flash, []styles.FlashCycle{
+		{UseFlash: true, Delay: 280 * time.Millisecond},
+		{UseFlash: false, Delay: 240 * time.Millisecond},
+		{UseFlash: true, Delay: 200 * time.Millisecond},
+		{UseFlash: false, Delay: 180 * time.Millisecond},
+		{UseFlash: true, Delay: 160 * time.Millisecond},
+		{UseFlash: false, Delay: 140 * time.Millisecond},
+		{UseFlash: true, Delay: 120 * time.Millisecond},
+		{UseFlash: false, Delay: 100 * time.Millisecond},
+	})
 
-	for _, c := range cycles {
-		time.Sleep(c.delay)
-		fmt.Printf("\033[%dA", height)
-		style := primary
-		if c.useFlash {
-			style = flash
-		}
-		for _, line := range strings.Split(art, "\n") {
-			fmt.Print("\033[K")
-			fmt.Println(style.Render(line))
-		}
-	}
-
-	time.Sleep(450 * time.Millisecond)
+	styles.Pause(450 * time.Millisecond)
 	fmt.Println()
 	fmt.Println(styles.SuccessStyle.Render("✨  Congratulations! Your AILLOY evolved into " + target + "!"))
 	fmt.Println(dim.Render("    (it learned how to update itself)"))

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -7,15 +7,19 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/lipgloss/table"
+	"github.com/nimble-giant/ailloy/internal/tui/splash"
 	"github.com/nimble-giant/ailloy/pkg/styles"
 	"github.com/spf13/cobra"
 )
+
+var rootNoAnimate bool
 
 var rootCmd = &cobra.Command{
 	Use:   "ailloy",
 	Short: "The package manager for AI instructions",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		styles.Init()
+		styles.SetNoAnimate(rootNoAnimate)
 	},
 }
 
@@ -37,36 +41,57 @@ func Execute() {
 	}
 }
 
-func buildLongDescription(version string) string {
-	banner := styles.WelcomeBanner(version)
-
-	description := styles.BoxStyle.Render(
+func descriptionBlock() string {
+	return styles.BoxStyle.Render(
 		"Ailloy is the package manager for AI instructions.\n" +
 			"Find, create, and share reusable AI workflow packages —\n" +
 			"the same way Helm manages Kubernetes applications.\n\n" +
 			"Like in metallurgy—where combining two elements yields a stronger alloy—\n" +
 			"Ailloy fuses human creativity with AI precision.",
 	)
+}
 
-	quickStart := styles.InfoBoxStyle.Render(
+func quickStartBlock() string {
+	return styles.InfoBoxStyle.Render(
 		"Quick Start:\n\n" +
 			"🦊 ailloy cast            # Cast project (alias: install)\n" +
 			"🦊 ailloy mold list       # View molds\n" +
 			"🦊 ailloy anneal          # Anneal settings (alias: configure)",
 	)
+}
 
+func buildLongDescription(version string) string {
 	return lipgloss.JoinVertical(
 		lipgloss.Left,
-		banner,
+		styles.WelcomeBanner(version),
 		"",
-		description,
+		descriptionBlock(),
 		"",
-		quickStart,
+		quickStartBlock(),
 	)
+}
+
+// animatedHelpFunc plays the splash cinematic in the alternate screen buffer
+// (when allowed by the environment) and then prints the static help into
+// normal scrollback so it persists for the user to read, scroll, and copy.
+// PersistentPreRun isn't called for help-only invocations, so we redo the
+// styles.Init / SetNoAnimate setup here.
+func animatedHelpFunc(cmd *cobra.Command, args []string) {
+	styles.Init()
+	styles.SetNoAnimate(rootNoAnimate)
+
+	if cmd == rootCmd {
+		splash.Run() // no-op when not animatable; never writes to stdout permanently
+	}
+
+	fmt.Println(cmd.Long)
+	_ = cmd.Usage()
 }
 
 func init() {
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "verbose output")
+	rootCmd.PersistentFlags().BoolVar(&rootNoAnimate, "no-animate", false, "disable terminal animations")
+	rootCmd.SetHelpFunc(animatedHelpFunc)
 
 	// Register custom template function to render commands as a styled table
 	cobra.AddTemplateFunc("commandTable", func(cmd *cobra.Command) string {

--- a/internal/tui/splash/model.go
+++ b/internal/tui/splash/model.go
@@ -1,0 +1,156 @@
+// Package splash plays a one-shot cinematic intro for the `ailloy` CLI in
+// the alternate screen buffer. When it finishes (or is skipped), control
+// returns to the caller, which is expected to print the static help into
+// normal scrollback. The splash itself prints nothing permanent.
+package splash
+
+import (
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/nimble-giant/ailloy/pkg/styles"
+)
+
+const frameInterval = 16 * time.Millisecond
+
+// Beat boundaries (cumulative milliseconds since splash start).
+const (
+	beatIgniteEnd = 400
+	beatBloomEnd  = 1100
+	beatCoolEnd   = 1350
+	beatTitleEnd  = 1850
+	beatSettleEnd = 2250
+	beatTotal     = 2350
+)
+
+type frameMsg time.Time
+
+// Model is a self-contained Bubble Tea model. The intended lifecycle is:
+//
+//	prog := tea.NewProgram(splash.New(w, h), tea.WithAltScreen())
+//	prog.Run()
+//
+// The model self-quits when the cinematic completes or any key is pressed.
+type Model struct {
+	width    int
+	height   int
+	start    time.Time
+	foxLines []string
+	foxRows  int
+	foxCols  int
+}
+
+// New constructs a splash Model. The caller passes the terminal dimensions so
+// the model can center its scene; if WindowSizeMsg arrives later it will
+// adjust. Pass 0,0 if unknown — Bubble Tea will deliver dimensions on Init.
+func New(width, height int) Model {
+	art := strings.TrimLeft(styles.AilloyFox, "\n")
+	art = strings.TrimRight(art, "\n")
+	lines := strings.Split(art, "\n")
+	cols := 0
+	for _, l := range lines {
+		if w := lipgloss.Width(l); w > cols {
+			cols = w
+		}
+	}
+	// Pad every line with trailing spaces so they're all exactly `cols`
+	// wide. Without this, lipgloss centering operations (Place,
+	// JoinVertical with Center) re-center each row independently based on
+	// its rendered width — and since the fox art relies on per-row
+	// leading whitespace to express shape, that re-centering visibly
+	// skews the silhouette. Uniform width = leading whitespace preserved.
+	for i, l := range lines {
+		if pad := cols - lipgloss.Width(l); pad > 0 {
+			lines[i] = l + strings.Repeat(" ", pad)
+		}
+	}
+	return Model{
+		width:    width,
+		height:   height,
+		foxLines: lines,
+		foxRows:  len(lines),
+		foxCols:  cols,
+	}
+}
+
+func (m Model) Init() tea.Cmd {
+	return tea.Batch(
+		func() tea.Msg {
+			return startMsg{}
+		},
+		tick(),
+	)
+}
+
+type startMsg struct{}
+
+func tick() tea.Cmd {
+	return tea.Tick(frameInterval, func(t time.Time) tea.Msg {
+		return frameMsg(t)
+	})
+}
+
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case startMsg:
+		m.start = time.Now()
+		return m, tick()
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+	case tea.KeyMsg:
+		// Any key skips the splash. We quit immediately; the wrapping
+		// command is responsible for printing the static help to
+		// scrollback. This keeps the splash a "movie" — no menu, no
+		// state survives.
+		return m, tea.Quit
+	case frameMsg:
+		if m.start.IsZero() {
+			return m, tick()
+		}
+		elapsed := time.Since(m.start)
+		if elapsed >= time.Duration(beatTotal)*time.Millisecond {
+			return m, tea.Quit
+		}
+		return m, tick()
+	}
+	return m, nil
+}
+
+func (m Model) View() string {
+	if m.width == 0 || m.height == 0 {
+		return ""
+	}
+	if m.start.IsZero() {
+		return placeBlank(m.width, m.height)
+	}
+
+	elapsedMs := float64(time.Since(m.start) / time.Millisecond)
+
+	switch {
+	case elapsedMs < beatIgniteEnd:
+		t := elapsedMs / beatIgniteEnd
+		return m.renderIgnite(styles.EaseOutCubic(t))
+	case elapsedMs < beatBloomEnd:
+		t := (elapsedMs - beatIgniteEnd) / (beatBloomEnd - beatIgniteEnd)
+		return m.renderBloom(styles.EaseOutQuad(t))
+	case elapsedMs < beatCoolEnd:
+		t := (elapsedMs - beatBloomEnd) / (beatCoolEnd - beatBloomEnd)
+		return m.renderCool(t)
+	case elapsedMs < beatTitleEnd:
+		t := (elapsedMs - beatCoolEnd) / (beatTitleEnd - beatCoolEnd)
+		return m.renderTitle(t)
+	case elapsedMs < beatSettleEnd:
+		t := (elapsedMs - beatTitleEnd) / (beatSettleEnd - beatTitleEnd)
+		return m.renderSettle(styles.EaseOutCubic(t))
+	default:
+		return m.renderSettle(1)
+	}
+}
+
+func placeBlank(w, h int) string {
+	return lipgloss.Place(w, h, lipgloss.Center, lipgloss.Center, "")
+}

--- a/internal/tui/splash/scenes.go
+++ b/internal/tui/splash/scenes.go
@@ -1,0 +1,232 @@
+package splash
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/nimble-giant/ailloy/pkg/styles"
+)
+
+// Palette
+var (
+	coldDim    = lipgloss.Color("#2a2540") // pre-bloom row tint
+	emberHot   = lipgloss.Color("#ffd28a") // bright ember/forge core
+	emberWarm  = lipgloss.Color("#ff9800") // outer bloom
+	whiteHot   = lipgloss.Color("#ffffff") // cooling sweep peak
+	finalColor = styles.Primary1           // settled fox color
+	titleBg    = styles.Primary1
+	titleFg    = styles.White
+)
+
+// renderIgnite paints a centered spark with secondary particle accents that
+// twinkle in. t ∈ [0, 1] eased. The visual: a single growing ember in the
+// dead center, two flanking dots, and a soft halo glow as t approaches 1.
+func (m Model) renderIgnite(t float64) string {
+	// Map t → ember intensity & "size" character.
+	emberChar := "·"
+	switch {
+	case t > 0.85:
+		emberChar = "✸"
+	case t > 0.6:
+		emberChar = "✦"
+	case t > 0.3:
+		emberChar = "•"
+	}
+	emberColor := styles.LerpHex(coldDim, emberHot, t)
+	ember := lipgloss.NewStyle().Foreground(emberColor).Bold(true).Render(emberChar)
+
+	// Two flanking accent particles on a small offset.
+	leftP := ""
+	rightP := ""
+	if t > 0.45 {
+		pt := (t - 0.45) / 0.55
+		c := styles.LerpHex(coldDim, emberWarm, styles.EaseOutCubic(pt))
+		leftP = lipgloss.NewStyle().Foreground(c).Render("·")
+		rightP = lipgloss.NewStyle().Foreground(c).Render("·")
+	}
+
+	// Compose a small horizontal cluster: "left   ember   right"
+	cluster := joinHoriz(leftP, "    ", ember, "    ", rightP)
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, cluster)
+}
+
+// renderBloom expands a warm gradient outward and progressively reveals the
+// fox top-to-bottom. Each row of the fox has an "appear time" based on its
+// vertical position. When t passes that row's appear time, the row begins
+// fading from coldDim → finalColor over its own per-row eased window.
+func (m Model) renderBloom(t float64) string {
+	rows := m.foxRows
+	out := make([]string, rows)
+
+	// Bloom halo sits behind the fox: a thin band of warm color whose
+	// vertical position tracks the wavefront. Implemented as a per-row
+	// background tint that shifts down. Cheap and effective.
+	wavefront := t // 0..1 normalized, top → bottom
+
+	for i, line := range m.foxLines {
+		appearAt := float64(i) / float64(rows)
+		if wavefront < appearAt {
+			// Row not yet revealed — render an empty slug so layout
+			// is stable and the fox doesn't "jump" into place.
+			out[i] = blank(lipgloss.Width(line))
+			continue
+		}
+		// Per-row eased reveal window: 0.18 of normalized phase time.
+		const revealWindow = 0.18
+		localT := (wavefront - appearAt) / revealWindow
+		if localT > 1 {
+			localT = 1
+		}
+		eased := styles.EaseOutCubic(localT)
+
+		// Color blends from cold dim → warm ember at mid → final purple.
+		// Three-point ramp: coldDim --(0..0.5)--> emberWarm --(0.5..1)--> finalColor.
+		var c lipgloss.Color
+		if eased < 0.5 {
+			c = styles.LerpHex(coldDim, emberWarm, eased*2)
+		} else {
+			c = styles.LerpHex(emberWarm, finalColor, (eased-0.5)*2)
+		}
+		out[i] = lipgloss.NewStyle().Foreground(c).Render(line)
+	}
+
+	scene := strings.Join(out, "\n")
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, scene)
+}
+
+// renderCool runs a vertical "white-hot" sweep top → bottom across the fully
+// revealed fox. Rows currently within the sweep band flash White, rows behind
+// the band have settled to finalColor, rows ahead are still finalColor (the
+// fox is fully revealed by this beat, just receiving the cool flash).
+func (m Model) renderCool(t float64) string {
+	rows := m.foxRows
+	out := make([]string, rows)
+
+	// Sweep band has a half-width of 3 rows — soft falloff via cosine-ish
+	// triangle. Center moves from row -3 to row rows+3 so the band fully
+	// enters and exits the fox.
+	bandHalf := 3.0
+	bandCenter := -bandHalf + (float64(rows)+2*bandHalf)*styles.EaseInOut(t)
+
+	for i, line := range m.foxLines {
+		dist := absF(float64(i) - bandCenter)
+		intensity := 0.0
+		if dist < bandHalf {
+			intensity = 1 - (dist / bandHalf)
+		}
+		c := styles.LerpHex(finalColor, whiteHot, intensity)
+		out[i] = lipgloss.NewStyle().Foreground(c).Render(line)
+	}
+
+	scene := strings.Join(out, "\n")
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, scene)
+}
+
+// renderTitle holds the fox in its final color and slams the AILLOY badge in
+// underneath with a single squash-and-stretch frame, then settles. The
+// subtitle and version fade in dimly during the back half of the beat.
+func (m Model) renderTitle(t float64) string {
+	fox := m.staticFox()
+
+	// Squash-and-stretch: t=0..0.15 the badge is missing (the slam hasn't
+	// started); 0.15..0.3 a single oversized frame; 0.3..0.55 settle to
+	// final padding; 0.55..1.0 subtitle + version fade in.
+	var badge string
+	switch {
+	case t < 0.15:
+		badge = ""
+	case t < 0.3:
+		badge = lipgloss.NewStyle().
+			Background(titleBg).
+			Foreground(titleFg).
+			Bold(true).
+			Padding(2, 5).
+			Render("🧠 AILLOY")
+	default:
+		badge = lipgloss.NewStyle().
+			Background(titleBg).
+			Foreground(titleFg).
+			Bold(true).
+			Padding(1, 3).
+			Render("🧠 AILLOY")
+	}
+
+	subtitle := ""
+	version := ""
+	if t > 0.55 {
+		ft := (t - 0.55) / 0.45
+		dim := styles.LerpHex(coldDim, finalColor, styles.EaseOutCubic(ft))
+		subtitle = lipgloss.NewStyle().Foreground(dim).Render("AI-powered development workflows")
+		version = lipgloss.NewStyle().Foreground(styles.LerpHex(coldDim, lipgloss.Color("#9aa0a6"), styles.EaseOutCubic(ft))).Render("forging…")
+	}
+
+	scene := lipgloss.JoinVertical(
+		lipgloss.Center,
+		fox,
+		"",
+		badge,
+		subtitle,
+		"",
+		version,
+	)
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, scene)
+}
+
+// renderSettle holds the hero composition. The description and quick-start
+// blocks are intentionally NOT shown during the splash — they live in
+// normal scrollback after exit. The splash's job is to make the fox + badge
+// land; the help text is the receipt.
+func (m Model) renderSettle(t float64) string {
+	fox := m.staticFox()
+
+	badge := lipgloss.NewStyle().
+		Background(titleBg).
+		Foreground(titleFg).
+		Bold(true).
+		Padding(1, 3).
+		Render("🧠 AILLOY")
+
+	subtitle := lipgloss.NewStyle().Foreground(finalColor).Render("AI-powered development workflows")
+
+	// The "ready" tag fades in over the settle beat to signal hand-off.
+	readyColor := styles.LerpHex(coldDim, lipgloss.Color("#9aa0a6"), t)
+	ready := lipgloss.NewStyle().Foreground(readyColor).Italic(true).Render("ready.")
+
+	scene := lipgloss.JoinVertical(
+		lipgloss.Center,
+		fox,
+		"",
+		badge,
+		subtitle,
+		"",
+		ready,
+	)
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, scene)
+}
+
+func (m Model) staticFox() string {
+	out := make([]string, m.foxRows)
+	style := lipgloss.NewStyle().Foreground(finalColor)
+	for i, line := range m.foxLines {
+		out[i] = style.Render(line)
+	}
+	return strings.Join(out, "\n")
+}
+
+func absF(v float64) float64 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+func blank(w int) string {
+	if w <= 0 {
+		return ""
+	}
+	return strings.Repeat(" ", w)
+}
+
+func joinHoriz(parts ...string) string {
+	return lipgloss.JoinHorizontal(lipgloss.Center, parts...)
+}

--- a/internal/tui/splash/splash.go
+++ b/internal/tui/splash/splash.go
@@ -1,0 +1,39 @@
+package splash
+
+import (
+	"os"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/nimble-giant/ailloy/pkg/styles"
+	"golang.org/x/term"
+)
+
+// Minimum terminal dimensions before we'll attempt the cinematic. Below
+// these, the fox doesn't fit and the layout gets ugly — so we fall back
+// to the instant static help.
+const (
+	minWidth  = 80
+	minHeight = 36
+)
+
+// Run plays the splash in the alt-screen and returns when it finishes or is
+// skipped. Returns true if the splash actually played, false if it was
+// suppressed (non-TTY, kill switch set, terminal too small, or program
+// errored). Callers should always print the static help to stdout regardless
+// of the return value — the splash never writes anything permanent.
+func Run() bool {
+	if !styles.ShouldAnimate() {
+		return false
+	}
+
+	w, h, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil || w < minWidth || h < minHeight {
+		return false
+	}
+
+	prog := tea.NewProgram(New(w, h), tea.WithAltScreen())
+	if _, err := prog.Run(); err != nil {
+		return false
+	}
+	return true
+}

--- a/pkg/styles/animate.go
+++ b/pkg/styles/animate.go
@@ -1,0 +1,86 @@
+package styles
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"golang.org/x/term"
+)
+
+// FlashCycle is one frame of a FlashArt animation: render the art with either
+// the primary or the flash style, then wait Delay before the next cycle.
+type FlashCycle struct {
+	UseFlash bool
+	Delay    time.Duration
+}
+
+var noAnimate bool
+
+// SetNoAnimate toggles the package-level animation kill switch. Wired up to
+// the root command's --no-animate persistent flag.
+func SetNoAnimate(v bool) {
+	noAnimate = v
+}
+
+// ShouldAnimate reports whether terminal animations should run. Animations are
+// suppressed when stdout is not a TTY, when standard "be quiet" environment
+// variables are set, or when the user passed --no-animate.
+func ShouldAnimate() bool {
+	if noAnimate {
+		return false
+	}
+	if os.Getenv("AILLOY_NO_ANIMATE") != "" {
+		return false
+	}
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+	if os.Getenv("CI") != "" {
+		return false
+	}
+	if t := os.Getenv("TERM"); t == "dumb" {
+		return false
+	}
+	return term.IsTerminal(int(os.Stdout.Fd()))
+}
+
+// Pause sleeps for d when animations are enabled, otherwise no-ops. Lets
+// callers sprinkle pauses without re-checking ShouldAnimate everywhere.
+func Pause(d time.Duration) {
+	if !ShouldAnimate() {
+		return
+	}
+	time.Sleep(d)
+}
+
+// FlashArt prints the multi-line art once and then re-renders it in place for
+// each cycle, alternating between primary and flashStyle. The cursor is moved
+// up and each line is cleared with ANSI escapes, so the art appears to
+// "flash" without scrolling. When ShouldAnimate is false, the art is printed
+// once with the primary style and the function returns immediately.
+func FlashArt(art string, primary, flashStyle lipgloss.Style, cycles []FlashCycle) {
+	art = strings.TrimLeft(art, "\n")
+	height := strings.Count(art, "\n") + 1
+
+	fmt.Println(primary.Render(art))
+
+	if !ShouldAnimate() {
+		return
+	}
+
+	for _, c := range cycles {
+		time.Sleep(c.Delay)
+		fmt.Printf("\033[%dA", height)
+		style := primary
+		if c.UseFlash {
+			style = flashStyle
+		}
+		for line := range strings.SplitSeq(art, "\n") {
+			fmt.Print("\033[K")
+			fmt.Println(style.Render(line))
+		}
+	}
+}

--- a/pkg/styles/animate_test.go
+++ b/pkg/styles/animate_test.go
@@ -1,0 +1,76 @@
+package styles
+
+import (
+	"os"
+	"testing"
+
+	"golang.org/x/term"
+)
+
+// stdoutIsTTY tells the test whether the process's stdout would normally be
+// considered a TTY. When running under `go test` or in CI it almost always
+// isn't, so the env-var test cases that *should* return true are conditionally
+// skipped.
+func stdoutIsTTY() bool {
+	return term.IsTerminal(int(os.Stdout.Fd()))
+}
+
+func TestShouldAnimate_KillSwitches(t *testing.T) {
+	t.Cleanup(func() { SetNoAnimate(false) })
+
+	cases := []struct {
+		name string
+		set  func(t *testing.T)
+	}{
+		{"no-animate flag", func(t *testing.T) { SetNoAnimate(true) }},
+		{"AILLOY_NO_ANIMATE", func(t *testing.T) { t.Setenv("AILLOY_NO_ANIMATE", "1") }},
+		{"NO_COLOR", func(t *testing.T) { t.Setenv("NO_COLOR", "1") }},
+		{"CI", func(t *testing.T) { t.Setenv("CI", "true") }},
+		{"TERM=dumb", func(t *testing.T) { t.Setenv("TERM", "dumb") }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			SetNoAnimate(false)
+			// Clear other kill switches so each subtest only exercises one.
+			t.Setenv("AILLOY_NO_ANIMATE", "")
+			t.Setenv("NO_COLOR", "")
+			t.Setenv("CI", "")
+			t.Setenv("TERM", "xterm-256color")
+
+			tc.set(t)
+
+			if ShouldAnimate() {
+				t.Fatalf("expected ShouldAnimate=false with %s set", tc.name)
+			}
+		})
+	}
+}
+
+func TestShouldAnimate_RequiresTTY(t *testing.T) {
+	t.Cleanup(func() { SetNoAnimate(false) })
+
+	SetNoAnimate(false)
+	t.Setenv("AILLOY_NO_ANIMATE", "")
+	t.Setenv("NO_COLOR", "")
+	t.Setenv("CI", "")
+	t.Setenv("TERM", "xterm-256color")
+
+	got := ShouldAnimate()
+	if stdoutIsTTY() {
+		if !got {
+			t.Fatal("expected ShouldAnimate=true when stdout is a TTY and no kill switch is set")
+		}
+	} else if got {
+		t.Fatal("expected ShouldAnimate=false when stdout is not a TTY")
+	}
+}
+
+func TestPause_NoOpWhenSuppressed(t *testing.T) {
+	t.Cleanup(func() { SetNoAnimate(false) })
+
+	SetNoAnimate(true)
+	// 5 seconds would be obvious if Pause actually slept; the test runner's
+	// default timeout is much shorter than that.
+	Pause(5_000_000_000)
+}

--- a/pkg/styles/color.go
+++ b/pkg/styles/color.go
@@ -1,0 +1,84 @@
+package styles
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// LerpHex returns the color t-of-the-way from a to b on a per-channel linear
+// interpolation. t is clamped to [0, 1]. Inputs must be `#rrggbb`. Falls back
+// to a when parsing fails so callers don't have to error-check colors.
+func LerpHex(a, b lipgloss.Color, t float64) lipgloss.Color {
+	if t <= 0 {
+		return a
+	}
+	if t >= 1 {
+		return b
+	}
+	ar, ag, ab, ok1 := parseHex(string(a))
+	br, bg, bb, ok2 := parseHex(string(b))
+	if !ok1 || !ok2 {
+		return a
+	}
+	r := lerpByte(ar, br, t)
+	g := lerpByte(ag, bg, t)
+	bl := lerpByte(ab, bb, t)
+	return lipgloss.Color(fmt.Sprintf("#%02x%02x%02x", r, g, bl))
+}
+
+func parseHex(s string) (r, g, b uint8, ok bool) {
+	s = strings.TrimPrefix(s, "#")
+	if len(s) != 6 {
+		return 0, 0, 0, false
+	}
+	v, err := strconv.ParseUint(s, 16, 32)
+	if err != nil {
+		return 0, 0, 0, false
+	}
+	return uint8(v >> 16), uint8(v >> 8), uint8(v), true
+}
+
+func lerpByte(a, b uint8, t float64) uint8 {
+	v := float64(a) + (float64(b)-float64(a))*t
+	if v < 0 {
+		v = 0
+	}
+	if v > 255 {
+		v = 255
+	}
+	return uint8(math.Round(v))
+}
+
+// EaseOutCubic is 1 - (1-t)^3 — fast at the start, soft at the end.
+func EaseOutCubic(t float64) float64 {
+	t = clamp01(t)
+	u := 1 - t
+	return 1 - u*u*u
+}
+
+// EaseOutQuad is 1 - (1-t)^2 — gentler version of EaseOutCubic.
+func EaseOutQuad(t float64) float64 {
+	t = clamp01(t)
+	u := 1 - t
+	return 1 - u*u
+}
+
+// EaseInOut is the classic smoothstep curve.
+func EaseInOut(t float64) float64 {
+	t = clamp01(t)
+	return t * t * (3 - 2*t)
+}
+
+func clamp01(t float64) float64 {
+	if t < 0 {
+		return 0
+	}
+	if t > 1 {
+		return 1
+	}
+	return t
+}

--- a/pkg/styles/color.go
+++ b/pkg/styles/color.go
@@ -39,7 +39,10 @@ func parseHex(s string) (r, g, b uint8, ok bool) {
 	if err != nil {
 		return 0, 0, 0, false
 	}
-	return uint8(v >> 16), uint8(v >> 8), uint8(v), true
+	// Explicit byte masks before narrowing satisfy gosec's G115
+	// (integer-overflow) rule. Each masked value is in [0, 255] by
+	// construction, so the uint8 conversion cannot truncate.
+	return uint8((v >> 16) & 0xff), uint8((v >> 8) & 0xff), uint8(v & 0xff), true
 }
 
 func lerpByte(a, b uint8, t float64) uint8 {

--- a/pkg/styles/color_test.go
+++ b/pkg/styles/color_test.go
@@ -1,0 +1,74 @@
+package styles
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func TestLerpHex_Endpoints(t *testing.T) {
+	a := lipgloss.Color("#000000")
+	b := lipgloss.Color("#ffffff")
+	if got := string(LerpHex(a, b, 0)); got != "#000000" {
+		t.Fatalf("t=0: got %s, want #000000", got)
+	}
+	if got := string(LerpHex(a, b, 1)); got != "#ffffff" {
+		t.Fatalf("t=1: got %s, want #ffffff", got)
+	}
+}
+
+func TestLerpHex_Midpoint(t *testing.T) {
+	a := lipgloss.Color("#000000")
+	b := lipgloss.Color("#ffffff")
+	got := string(LerpHex(a, b, 0.5))
+	// Midpoint of 0 and 255 is 127.5, rounded to 128 = 0x80.
+	if got != "#808080" {
+		t.Fatalf("midpoint: got %s, want #808080", got)
+	}
+}
+
+func TestLerpHex_ClampedAndInvalid(t *testing.T) {
+	a := lipgloss.Color("#112233")
+	b := lipgloss.Color("#445566")
+	if got := string(LerpHex(a, b, -1)); got != "#112233" {
+		t.Fatalf("t<0 should clamp to a: got %s", got)
+	}
+	if got := string(LerpHex(a, b, 2)); got != "#445566" {
+		t.Fatalf("t>1 should clamp to b: got %s", got)
+	}
+	bad := lipgloss.Color("not-a-color")
+	if got := string(LerpHex(bad, b, 0.5)); got != string(bad) {
+		t.Fatalf("invalid input should return a: got %s", got)
+	}
+}
+
+func TestEasings_Endpoints(t *testing.T) {
+	for _, fn := range []struct {
+		name string
+		f    func(float64) float64
+	}{
+		{"out-cubic", EaseOutCubic},
+		{"out-quad", EaseOutQuad},
+		{"in-out", EaseInOut},
+	} {
+		if got := fn.f(0); got != 0 {
+			t.Errorf("%s(0) = %v, want 0", fn.name, got)
+		}
+		if got := fn.f(1); got != 1 {
+			t.Errorf("%s(1) = %v, want 1", fn.name, got)
+		}
+		mid := fn.f(0.5)
+		if mid <= 0 || mid >= 1 {
+			t.Errorf("%s(0.5) = %v, want strictly between 0 and 1", fn.name, mid)
+		}
+	}
+}
+
+func TestEasings_Clamp(t *testing.T) {
+	if got := EaseOutCubic(-0.5); got != 0 {
+		t.Errorf("EaseOutCubic(-0.5) should clamp to 0, got %v", got)
+	}
+	if got := EaseInOut(2.0); got != 1 {
+		t.Errorf("EaseInOut(2.0) should clamp to 1, got %v", got)
+	}
+}

--- a/pkg/styles/fox.go
+++ b/pkg/styles/fox.go
@@ -186,10 +186,10 @@ func FoxArt(foxType string) string {
 	return style.Render(art)
 }
 
-// Welcome banner with ailloy fox matching the main logo
-func WelcomeBanner(ver string) string {
-	fox := FoxArt("ailloy")
-
+// WelcomeChrome is the title/subtitle/version block of the welcome banner,
+// without the fox. Useful when the fox is rendered separately so it can be
+// animated.
+func WelcomeChrome(ver string) string {
 	title := lipgloss.NewStyle().
 		Background(Primary1).
 		Foreground(White).
@@ -205,11 +205,19 @@ func WelcomeBanner(ver string) string {
 
 	return lipgloss.JoinVertical(
 		lipgloss.Center,
-		fox,
 		title,
 		subtitle,
 		"",
 		version,
+	)
+}
+
+// Welcome banner with ailloy fox matching the main logo
+func WelcomeBanner(ver string) string {
+	return lipgloss.JoinVertical(
+		lipgloss.Center,
+		FoxArt("ailloy"),
+		WelcomeChrome(ver),
 	)
 }
 


### PR DESCRIPTION
## Description

Running `ailloy` with no args dumped a ~60-line help screen at once, so users landed on the bottom (commands table) and missed the banner. This PR adds a brief Bubble Tea cinematic ("The Forge Awakens") that plays in the alt-screen on a TTY: an ignite spark blooms outward as the AilloyFox materializes top-to-bottom, a white-hot cooling sweep flashes across, and the AILLOY badge slams in with a one-frame squash-and-stretch — then exits cleanly and prints the unchanged static help into normal scrollback so it stays copyable, pipeable, and scrollable. Adds shared animation primitives in `pkg/styles` (`ShouldAnimate` kill switch, `FlashArt`, `Pause`, `LerpHex`, easing curves), a new `--no-animate` persistent flag, and `AILLOY_NO_ANIMATE` env var; refactors the existing `evolve` Pokemon flash to reuse the same helpers. Splash is suppressed on non-TTY, `NO_COLOR`, `CI`, `TERM=dumb`, `--no-animate`, and terminals smaller than 80×36; any keypress during the splash skips it instantly.

## Related Issue

N/A

## Testing

- `go build ./...`, `go vet ./...`, `gofmt -l` clean.
- `go test ./...` passes (full suite, including new `pkg/styles` unit tests for `LerpHex`, easings, and `ShouldAnimate` kill switches).
- Manual: `./bin/ailloy` in an interactive terminal — fox materializes, cool sweep fires, badge slams, hand-off to scrollback is seamless.
- Manual: `./bin/ailloy --no-animate`, `./bin/ailloy | cat`, `NO_COLOR=1`, `CI=true`, `TERM=dumb`, terminals <80×36 — all fall back to instant static help.
- Manual: keypress during splash → instant skip; `Ctrl+C` → exits cleanly with help still printed.
- `./bin/ailloy evolve` Pokemon flash still works after the helper refactor.

## UAT

Run `ailloy` in a TTY ≥ 80×36 to see the cinematic. Try `ailloy --no-animate` to confirm the legacy fast path. Pipe to `cat` or run under `CI=true` to confirm CI/automation isn't slowed down. Resize to a small window (e.g. 80×24) and run again to confirm the splash gracefully bails to static help. Hit any key during the splash to confirm instant skip.

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [ ] I have updated documentation (if applicable)
- [ ] My commits have DCO sign-off (`git commit -s`)