### PR TITLE
feat: cinematic ceremonies for the metallurgy commands

### DIFF
--- a/internal/commands/assay.go
+++ b/internal/commands/assay.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/nimble-giant/ailloy/internal/tui/ceremony"
 	"github.com/nimble-giant/ailloy/pkg/assay"
 	"github.com/nimble-giant/ailloy/pkg/mold"
 	"github.com/nimble-giant/ailloy/pkg/styles"
@@ -67,8 +68,7 @@ func runAssay(_ *cobra.Command, args []string) error {
 		return nil
 	}
 
-	fmt.Println(styles.WorkingBanner("Assaying..."))
-	fmt.Println()
+	ceremony.Open(ceremony.Assay)
 
 	// Resolve path
 	startDir := "."
@@ -148,14 +148,19 @@ func runAssay(_ *cobra.Command, args []string) error {
 		failOnSeverity = mold.SeverityError
 	}
 
+	stampSummary := fmt.Sprintf("%d file(s), %d error(s), %d warning(s), %d suggestion(s)",
+		result.FilesScanned, errors, warnings, suggestions)
+
 	if result.HasFailures(failOnSeverity) {
 		fmt.Println(styles.ErrorStyle.Render(fmt.Sprintf("%d error(s), %d warning(s), %d suggestion(s)",
 			errors, warnings, suggestions)))
+		ceremony.FailStamp(ceremony.Assay, stampSummary)
 		return fmt.Errorf("assay: findings exceed --%s threshold", assayFailOn)
 	}
 
 	fmt.Println(styles.SuccessStyle.Render(fmt.Sprintf("%d error(s), %d warning(s), %d suggestion(s)",
 		errors, warnings, suggestions)))
+	ceremony.Stamp(ceremony.Assay, stampSummary)
 
 	// Handle --fix: collect unknown frontmatter fields from all command-frontmatter diagnostics
 	// and add them to extra-allowed-fields in .ailloyrc.yaml.

--- a/internal/commands/cast.go
+++ b/internal/commands/cast.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/charmbracelet/huh"
 	"github.com/goccy/go-yaml"
+	"github.com/nimble-giant/ailloy/internal/tui/ceremony"
 	"github.com/nimble-giant/ailloy/pkg/blanks"
 	"github.com/nimble-giant/ailloy/pkg/foundry"
 	"github.com/nimble-giant/ailloy/pkg/mold"
@@ -182,9 +183,8 @@ func resolveDestPrefix() (string, error) {
 }
 
 func castProject(reader *blanks.MoldReader, source string) error {
-	// Welcome message
-	fmt.Println(styles.WorkingBanner("Casting Ailloy project structure..."))
-	fmt.Println()
+	// Welcome message — themed entrance flourish wraps the canonical banner.
+	ceremony.Open(ceremony.Cast)
 
 	// Check runtime dependencies
 	checkDependencies()
@@ -369,6 +369,7 @@ func castProject(reader *blanks.MoldReader, source string) error {
 	summary := styles.SuccessBoxStyle.Render(summaryContent)
 
 	fmt.Println(summary)
+	ceremony.Stamp(ceremony.Cast, fmt.Sprintf("%d blank dir(s) installed", len(dirs)))
 
 	// Prompt to add @AGENTS.md import to CLAUDE.md (after summary box)
 	if destPrefix == "" {

--- a/internal/commands/forge.go
+++ b/internal/commands/forge.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/nimble-giant/ailloy/internal/tui/ceremony"
 	"github.com/nimble-giant/ailloy/pkg/blanks"
 	"github.com/nimble-giant/ailloy/pkg/foundry"
 	"github.com/nimble-giant/ailloy/pkg/mold"
@@ -173,12 +174,17 @@ func runForge(_ *cobra.Command, args []string) error {
 		})
 	}
 
-	fmt.Println(styles.WorkingBanner("Forging blanks..."))
-	fmt.Println()
+	ceremony.Open(ceremony.Forge)
 
 	if forgeOutputDir != "" {
-		return writeForgeFiles(files, forgeOutputDir)
+		if err := writeForgeFiles(files, forgeOutputDir); err != nil {
+			return err
+		}
+		ceremony.Stamp(ceremony.Forge, fmt.Sprintf("%d file(s) → %s", len(files), forgeOutputDir))
+		return nil
 	}
+	// Stdout-rendered preview: skip the trailing stamp so pipe consumers
+	// (e.g. `ailloy forge | code -`) don't get an extra trailing line.
 	return printForgeFiles(files)
 }
 

--- a/internal/commands/quench.go
+++ b/internal/commands/quench.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nimble-giant/ailloy/internal/tui/ceremony"
 	"github.com/nimble-giant/ailloy/pkg/foundry"
 	"github.com/nimble-giant/ailloy/pkg/styles"
 	"github.com/spf13/cobra"
@@ -79,11 +80,12 @@ func runQuench(_ *cobra.Command, args []string) error {
 	}
 
 	if quenchVerify {
+		// Verify mode keeps the plain banner — it's a check, not a freeze.
 		fmt.Println(styles.WorkingBanner("Verifying pins..."))
+		fmt.Println()
 	} else {
-		fmt.Println(styles.WorkingBanner("Quenching dependencies..."))
+		ceremony.Open(ceremony.Quench)
 	}
-	fmt.Println()
 
 	// Verification phase: manifest <-> lock consistency.
 	failures := verifyManifestAgainstLock(entries, existingLock)
@@ -149,6 +151,7 @@ func runQuench(_ *cobra.Command, args []string) error {
 		styles.CodeStyle.Render(lockPath),
 	)
 	fmt.Printf("Run %s to update to newer versions.\n", styles.CodeStyle.Render("ailloy recast"))
+	ceremony.Stamp(ceremony.Quench, fmt.Sprintf("%d dependency pin(s) frozen", len(entries)))
 	return nil
 }
 

--- a/internal/commands/recast.go
+++ b/internal/commands/recast.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/nimble-giant/ailloy/internal/tui/ceremony"
 	"github.com/nimble-giant/ailloy/pkg/foundry"
 	"github.com/nimble-giant/ailloy/pkg/styles"
 	"github.com/spf13/cobra"
@@ -68,11 +69,13 @@ func runRecast(_ *cobra.Command, args []string) error {
 	}
 
 	if recastDryRun {
+		// Dry-run keeps the lighter informational banner — no full ceremony
+		// because nothing actually changes on disk.
 		fmt.Println(styles.WorkingBanner("Previewing dependency updates (dry run)..."))
+		fmt.Println()
 	} else {
-		fmt.Println(styles.WorkingBanner("Recasting dependencies..."))
+		ceremony.Open(ceremony.Recast)
 	}
-	fmt.Println()
 
 	git := foundry.DefaultGitRunner()
 	var changes []recastChange
@@ -177,6 +180,7 @@ func runRecast(_ *cobra.Command, args []string) error {
 		fmt.Println(styles.InfoStyle.Render("Run without --dry-run to apply these changes."))
 	} else {
 		fmt.Println(styles.SuccessBanner("Recast complete!"))
+		ceremony.Stamp(ceremony.Recast, fmt.Sprintf("%d mold(s) updated", len(changes)))
 	}
 	return nil
 }

--- a/internal/commands/smelt.go
+++ b/internal/commands/smelt.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 
+	"github.com/nimble-giant/ailloy/internal/tui/ceremony"
 	"github.com/nimble-giant/ailloy/pkg/smelt"
 	"github.com/nimble-giant/ailloy/pkg/styles"
 	"github.com/spf13/cobra"
@@ -32,8 +33,7 @@ func init() {
 }
 
 func runSmelt(_ *cobra.Command, args []string) error {
-	fmt.Println(styles.WorkingBanner("Smelting mold..."))
-	fmt.Println()
+	ceremony.Open(ceremony.Smelt)
 
 	moldDir := "."
 	if len(args) > 0 {
@@ -61,6 +61,7 @@ func runSmelt(_ *cobra.Command, args []string) error {
 
 	fmt.Println(styles.SuccessStyle.Render("Smelted: ") + styles.CodeStyle.Render(outputFile) +
 		styles.SubtleStyle.Render(fmt.Sprintf(" (%s)", humanSize(size))))
+	ceremony.Stamp(ceremony.Smelt, fmt.Sprintf("%s · %s", outputFile, humanSize(size)))
 	return nil
 }
 

--- a/internal/commands/temper.go
+++ b/internal/commands/temper.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/nimble-giant/ailloy/internal/tui/ceremony"
 	"github.com/nimble-giant/ailloy/pkg/assay"
 	"github.com/nimble-giant/ailloy/pkg/blanks"
 	"github.com/nimble-giant/ailloy/pkg/mold"
@@ -55,8 +56,7 @@ func init() {
 }
 
 func runTemper(_ *cobra.Command, args []string) error {
-	fmt.Println(styles.WorkingBanner("Tempering..."))
-	fmt.Println()
+	ceremony.Open(ceremony.Temper)
 
 	moldDir := "."
 	if len(args) > 0 {
@@ -99,11 +99,13 @@ func runTemper(_ *cobra.Command, args []string) error {
 	if result.HasErrors() {
 		fmt.Println(styles.ErrorStyle.Render(fmt.Sprintf("Validation failed: %d error(s), %d warning(s)",
 			len(errors), len(warnings))))
+		ceremony.FailStamp(ceremony.Temper, fmt.Sprintf("%d error(s), %d warning(s)", len(errors), len(warnings)))
 		return fmt.Errorf("temper: %d error(s) found", len(errors))
 	}
 
 	msg := fmt.Sprintf("Validation passed: 0 errors, %d warning(s)", len(warnings))
 	fmt.Println(styles.SuccessStyle.Render(msg))
+	ceremony.Stamp(ceremony.Temper, fmt.Sprintf("0 errors, %d warning(s)", len(warnings)))
 
 	// Run assay (lint) on rendered blanks if requested
 	if temperLint {

--- a/internal/tui/ceremony/ceremony.go
+++ b/internal/tui/ceremony/ceremony.go
@@ -1,0 +1,168 @@
+// Package ceremony provides inline cinematic accents for Ailloy's metallurgy
+// commands. Each command gets a themed entrance flourish and a
+// squash-and-stretch completion stamp. Designed to *wrap*, never replace,
+// the command's existing stdout text — every plain-text line a CI pipeline
+// or downstream tool depends on still appears post-animation, byte-identical.
+//
+// Inline only: no alt-screen takeover, no Bubble Tea program. The animations
+// are short (~250–500ms entrance, ~200ms stamp) and use ANSI cursor
+// in-place updates so they coexist with terminal scrollback. On non-TTY,
+// NO_COLOR, CI, TERM=dumb, or --no-animate, the API degrades to plain text
+// instantly.
+package ceremony
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/nimble-giant/ailloy/pkg/styles"
+)
+
+// Theme bundles a metallurgy command's visual identity. Construction is
+// declarative — each command's themes.go entry sets these once.
+type Theme struct {
+	// Name is a short lowercase identifier ("temper", "assay") used for
+	// debugging and the no-animation fallback prefix.
+	Name string
+
+	// Verb is the present-progressive verb shown during the working
+	// banner and adaptive entrance flourish, e.g. "Tempering",
+	// "Assaying". Capitalized.
+	Verb string
+
+	// StampWord is the all-caps verb on the completion stamp, e.g.
+	// "TEMPERED", "ASSAY COMPLETE".
+	StampWord string
+
+	// Glyph prefixes the stamp, e.g. "🔥", "⚗️", "❄️", "📦", "🔨".
+	Glyph string
+
+	// Primary is the dominant theme color (hex). Used for the entrance
+	// banner, success stamp border/foreground, and strike sparks.
+	Primary lipgloss.Color
+
+	// Accent is the warm/secondary theme color (hex). Used for the
+	// strike spark and the squash frame highlight on the stamp.
+	Accent lipgloss.Color
+
+	// Strikes is the number of entrance "beats" — 1 for a sweep glyph
+	// (assay's magnifier), 3 for a hammer (temper), etc. Each beat
+	// renders one frame of strikeChar before yielding.
+	Strikes int
+
+	// StrikeChar is the glyph rendered on each strike beat, e.g. "✦"
+	// for sparks, "⚒" for hammer, "🔍" for magnifier.
+	StrikeChar string
+
+	// StrikeIntervalMs is the delay between strike frames. ~110–160ms
+	// reads as "rhythm"; faster than 80ms reads as flicker; slower than
+	// 200ms feels sluggish.
+	StrikeIntervalMs int
+}
+
+// Open plays the entrance flourish and prints the working banner. Returns
+// immediately on non-animatable terminals after writing the plain-text
+// banner. Synchronous; the animation is brief by design.
+func Open(t Theme) {
+	if !styles.ShouldAnimate() {
+		fmt.Println(styles.WorkingBanner(t.Verb + "..."))
+		fmt.Println()
+		return
+	}
+
+	// Print the strike beats in place on a single line, then overwrite
+	// with the final working banner. The strikes pre-load the eye for
+	// the verb that's about to land.
+	strikes := max(t.Strikes, 1)
+	interval := t.StrikeIntervalMs
+	if interval <= 0 {
+		interval = 130
+	}
+
+	strikeStyle := lipgloss.NewStyle().Foreground(t.Accent).Bold(true)
+	primaryStyle := lipgloss.NewStyle().Foreground(t.Primary).Bold(true)
+
+	for i := 1; i <= strikes; i++ {
+		fmt.Print("\r\033[K")
+		fmt.Print(strings.Repeat(strikeStyle.Render(t.StrikeChar)+" ", i))
+		fmt.Print(primaryStyle.Render(t.Verb + "..."))
+		time.Sleep(time.Duration(interval) * time.Millisecond)
+	}
+
+	// Settle: replace the strike line with the canonical WorkingBanner
+	// so the rest of the output flows from a familiar starting point.
+	fmt.Print("\r\033[K")
+	fmt.Println(styles.WorkingBanner(t.Verb + "..."))
+	fmt.Println()
+}
+
+// Stamp prints the success completion line with a one-frame
+// squash-and-stretch entrance, then settles. The summary text is the
+// command's existing plain-text conclusion (e.g. "0 errors, 2 warnings");
+// it appears verbatim within the stamp. Falls back to plain text when not
+// animatable.
+//
+// Format on a TTY:
+//
+//	🔥 TEMPERED   — 0 errors, 2 warnings
+//
+// (One frame of oversized padding/bold, then settles to the regular form.)
+func Stamp(t Theme, summary string) {
+	stamp := composeStamp(t.Glyph, t.StampWord, summary, t.Primary, t.Accent, false)
+	if !styles.ShouldAnimate() {
+		fmt.Println(stamp)
+		return
+	}
+	// Squash frame: one over-padded, white-hot variant.
+	fmt.Println(composeStamp(t.Glyph, t.StampWord, summary, t.Accent, t.Accent, true))
+	time.Sleep(70 * time.Millisecond)
+	// Move the cursor up one line and clear it, then print the settled stamp.
+	fmt.Print("\033[1A\033[K")
+	fmt.Println(stamp)
+}
+
+// FailStamp is the error counterpart of Stamp. Uses the warning/error
+// palette. The animated frame is dimmer rather than brighter so failure
+// reads as deflation, not celebration.
+func FailStamp(t Theme, summary string) {
+	stamp := composeFailStamp(t.Glyph, t.StampWord, summary)
+	if !styles.ShouldAnimate() {
+		fmt.Println(stamp)
+		return
+	}
+	// Mute frame: dim then settle.
+	dim := lipgloss.NewStyle().Foreground(lipgloss.Color("#9aa0a6")).Render(t.Glyph + " " + t.StampWord + " FAILED — " + summary)
+	fmt.Println(dim)
+	time.Sleep(80 * time.Millisecond)
+	fmt.Print("\033[1A\033[K")
+	fmt.Println(stamp)
+}
+
+// composeStamp builds the line string. If `squash` is set, the stamp word
+// has bold + extra padding — used as the entrance frame.
+func composeStamp(glyph, word, summary string, fg, bgAccent lipgloss.Color, squash bool) string {
+	wordStyle := lipgloss.NewStyle().Foreground(fg).Bold(true)
+	if squash {
+		// One-frame stretch: oversize via padded style for visual pop.
+		wordStyle = wordStyle.
+			Background(bgAccent).
+			Foreground(styles.White).
+			Padding(0, 2)
+	}
+	tail := ""
+	if strings.TrimSpace(summary) != "" {
+		tail = lipgloss.NewStyle().Foreground(styles.Gray).Render(" — ") + summary
+	}
+	return glyph + " " + wordStyle.Render(word) + tail
+}
+
+func composeFailStamp(glyph, word, summary string) string {
+	wordStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#f44336")).Bold(true)
+	tail := ""
+	if strings.TrimSpace(summary) != "" {
+		tail = lipgloss.NewStyle().Foreground(styles.Gray).Render(" — ") + summary
+	}
+	return glyph + " " + wordStyle.Render(word+" FAILED") + tail
+}

--- a/internal/tui/ceremony/ceremony_test.go
+++ b/internal/tui/ceremony/ceremony_test.go
@@ -1,0 +1,90 @@
+package ceremony
+
+import (
+	"strings"
+	"testing"
+)
+
+// removeEscapes strips ANSI SGR sequences so we can assert visible content.
+func removeEscapes(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] == 0x1b {
+			for i < len(s) && s[i] != 'm' {
+				i++
+			}
+			continue
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}
+
+func TestComposeStamp_PlainContent(t *testing.T) {
+	got := removeEscapes(composeStamp("🔥", "TEMPERED", "0 errors, 2 warnings", Temper.Primary, Temper.Accent, false))
+	// Must contain glyph, word, separator, and the summary verbatim.
+	for _, want := range []string{"🔥", "TEMPERED", "—", "0 errors, 2 warnings"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("stamp missing %q in %q", want, got)
+		}
+	}
+}
+
+func TestComposeStamp_NoSummary(t *testing.T) {
+	got := removeEscapes(composeStamp("⚗️", "ASSAY COMPLETE", "", Assay.Primary, Assay.Accent, false))
+	if strings.Contains(got, "—") {
+		t.Errorf("empty summary should drop the separator: %q", got)
+	}
+	if !strings.Contains(got, "ASSAY COMPLETE") {
+		t.Errorf("stamp missing word: %q", got)
+	}
+}
+
+func TestComposeFailStamp_HasFailedSuffix(t *testing.T) {
+	got := removeEscapes(composeFailStamp("🔥", "TEMPER", "3 errors, 0 warnings"))
+	if !strings.Contains(got, "TEMPER FAILED") {
+		t.Errorf("fail stamp missing 'FAILED': %q", got)
+	}
+	if !strings.Contains(got, "3 errors, 0 warnings") {
+		t.Errorf("fail stamp dropped summary: %q", got)
+	}
+}
+
+func TestThemes_Populated(t *testing.T) {
+	// Sanity: every theme has the required fields. Cheap regression for
+	// future copy-pasted entries.
+	cases := []struct {
+		name string
+		th   Theme
+	}{
+		{"assay", Assay},
+		{"temper", Temper},
+		{"cast", Cast},
+		{"recast", Recast},
+		{"quench", Quench},
+		{"smelt", Smelt},
+		{"forge", Forge},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if c.th.Name == "" {
+				t.Error("Name is empty")
+			}
+			if c.th.Verb == "" {
+				t.Error("Verb is empty")
+			}
+			if c.th.StampWord == "" {
+				t.Error("StampWord is empty")
+			}
+			if c.th.Glyph == "" {
+				t.Error("Glyph is empty")
+			}
+			if c.th.StrikeChar == "" {
+				t.Error("StrikeChar is empty")
+			}
+			if c.th.Strikes < 1 {
+				t.Errorf("Strikes must be >=1, got %d", c.th.Strikes)
+			}
+		})
+	}
+}

--- a/internal/tui/ceremony/themes.go
+++ b/internal/tui/ceremony/themes.go
@@ -1,0 +1,104 @@
+package ceremony
+
+import (
+	"github.com/nimble-giant/ailloy/pkg/styles"
+)
+
+// Pre-built themes for the seven metallurgy commands. Centralizing the
+// palette/glyph/strike choices here keeps each command's wiring trivial
+// and ensures visual consistency across the family.
+
+// Assay — a chemical purity test. The metaphor is the magnifying glass
+// scanning the sample. One sweep beat (Strikes=1), magnifier glyph.
+var Assay = Theme{
+	Name:             "assay",
+	Verb:             "Assaying",
+	StampWord:        "ASSAY COMPLETE",
+	Glyph:            "⚗️",
+	Primary:          styles.Primary1,
+	Accent:           styles.Accent1,
+	Strikes:          1,
+	StrikeChar:       "🔍",
+	StrikeIntervalMs: 220,
+}
+
+// Temper — heat treatment to test strength. Three hammer strikes pace
+// the entrance like a smith testing a blade.
+var Temper = Theme{
+	Name:             "temper",
+	Verb:             "Tempering",
+	StampWord:        "TEMPERED",
+	Glyph:            "🔥",
+	Primary:          styles.Primary1,
+	Accent:           styles.Accent1,
+	Strikes:          3,
+	StrikeChar:       "✦",
+	StrikeIntervalMs: 120,
+}
+
+// Cast — pouring molten metal. Three pour beats; the molten droplet is
+// the per-beat glyph.
+var Cast = Theme{
+	Name:             "cast",
+	Verb:             "Casting",
+	StampWord:        "CAST",
+	Glyph:            "🪙",
+	Primary:          styles.Primary1,
+	Accent:           styles.Accent1,
+	Strikes:          3,
+	StrikeChar:       "•",
+	StrikeIntervalMs: 130,
+}
+
+// Recast — re-melting and re-pouring. Two strikes, dimmer accent.
+var Recast = Theme{
+	Name:             "recast",
+	Verb:             "Recasting",
+	StampWord:        "RECAST",
+	Glyph:            "♻️",
+	Primary:          styles.Primary1,
+	Accent:           styles.Accent2,
+	Strikes:          2,
+	StrikeChar:       "•",
+	StrikeIntervalMs: 140,
+}
+
+// Quench — plunging hot metal into water. One snap beat, snowflake.
+// This is the "freeze" command — the brief beat reads as a pause.
+var Quench = Theme{
+	Name:             "quench",
+	Verb:             "Quenching",
+	StampWord:        "QUENCHED",
+	Glyph:            "❄️",
+	Primary:          styles.Info,
+	Accent:           styles.White,
+	Strikes:          1,
+	StrikeChar:       "≈",
+	StrikeIntervalMs: 200,
+}
+
+// Smelt — extracting refined ingots. Three furnace pulses.
+var Smelt = Theme{
+	Name:             "smelt",
+	Verb:             "Smelting",
+	StampWord:        "INGOT READY",
+	Glyph:            "📦",
+	Primary:          styles.Accent1,
+	Accent:           styles.Warning,
+	Strikes:          3,
+	StrikeChar:       "▒",
+	StrikeIntervalMs: 130,
+}
+
+// Forge — hammer striking anvil. The brief preview beat.
+var Forge = Theme{
+	Name:             "forge",
+	Verb:             "Forging",
+	StampWord:        "PREVIEW READY",
+	Glyph:            "🔨",
+	Primary:          styles.Primary1,
+	Accent:           styles.Accent1,
+	Strikes:          3,
+	StrikeChar:       "✦",
+	StrikeIntervalMs: 110,
+}


### PR DESCRIPTION
## Description

Brings the same Disney-quality cinematic care from the splash and \`evolve\` PRs to the seven workhorse metallurgy commands — \`cast\`, \`forge\`, \`recast\`, \`quench\`, \`smelt\`, \`temper\`, and \`assay\` — by introducing a small inline \`ceremony\` package that each command calls to add a themed entrance flourish and a squash-and-stretch completion stamp without taking over the terminal or breaking parseable output. Every plain-text line a CI pipeline or downstream parser depends on remains byte-identical; ceremony additions are confined to a single themed banner above the work and a single stamp below the canonical summary line. Skip rules (non-TTY, NO_COLOR, CI, TERM=dumb, --no-animate, AILLOY_NO_ANIMATE) are inherited from \`styles.ShouldAnimate()\`. Stacked on top of #169 — once #169 merges, this rebases cleanly onto main; for review, the diff against the splash branch is just the ceremony work.

## Related Issue

N/A

## Testing

- \`go build ./...\`, \`go vet ./...\`, \`gofmt -l\` clean.
- \`go test ./...\` passes (full suite, including new \`internal/tui/ceremony\` unit tests covering stamp composition, fail-stamp content, and theme completeness).
- Manual: \`./bin/ailloy assay\` in this repo prints the existing summary line byte-identical, then a new \`⚗️ ASSAY COMPLETE — 21 file(s), 0 error(s), 52 warning(s), 1 suggestion(s)\` stamp.
- Manual: \`./bin/ailloy <cmd> --no-animate\` and piped (\`./bin/ailloy <cmd> | cat\`) produce the same output as today + the stamp line.
- Manual: \`./bin/ailloy forge | cat\` — stdout-rendered preview has no trailing stamp (pipe-consumer safe).

## UAT

- Run any of the seven commands in an interactive terminal and observe: a brief themed entrance (1–3 strike beats), the existing work output, then a stamp line with the metallurgical metaphor (TEMPERED, ASSAY COMPLETE, CAST, RECAST, QUENCHED, INGOT READY, PREVIEW READY).
- Pipe each command to \`cat\` or set \`CI=true\` and confirm zero animation noise leaks.
- Pass \`--no-animate\` to confirm the legacy fast path still works.

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [ ] I have updated documentation (if applicable)
- [ ] My commits have DCO sign-off (\`git commit -s\`)