### PR TITLE
feat: cinematic evolution sequence for ailloy evolve

### DIFF
--- a/internal/commands/evolve.go
+++ b/internal/commands/evolve.go
@@ -31,6 +31,7 @@ var (
 	evolveForce    bool
 	evolvePin      string
 	evolveSkipAnim bool
+	evolveDemo     bool
 )
 
 var (
@@ -65,12 +66,37 @@ func init() {
 	evolveCmd.Flags().BoolVar(&evolveForce, "force", false, "evolve even if installed via Homebrew")
 	evolveCmd.Flags().StringVar(&evolvePin, "version", "", "install a specific release tag (e.g. v0.6.19)")
 	evolveCmd.Flags().BoolVar(&evolveSkipAnim, "no-animate", false, "skip the evolution animation")
+	evolveCmd.Flags().BoolVar(&evolveDemo, "demo", false, "play the evolution cinematic without performing an upgrade (for QA / showing off)")
+	_ = evolveCmd.Flags().MarkHidden("demo")
 }
 
 func runEvolve(_ *cobra.Command, _ []string) error {
 	current := strings.TrimSpace(evolveCurrentVersion)
 	if current == "" {
 		current = "dev"
+	}
+
+	// --demo: play the cinematic with mock versions, no network, no swap.
+	// Hidden flag — primarily for QA but also handy for showing off.
+	if evolveDemo {
+		to := strings.TrimSpace(evolvePin)
+		if to == "" {
+			to = "v9.9.9"
+		}
+		if !strings.HasPrefix(to, "v") {
+			to = "v" + to
+		}
+		from := current
+		if !strings.HasPrefix(from, "v") && from != "dev" {
+			from = "v" + from
+		}
+		if from == "dev" {
+			// Plausible "previous" version so the digit wheel has
+			// something interesting to cycle to/from.
+			from = "v0.0.0"
+		}
+		runEvolutionDemo(from, to, evolveSkipAnim)
+		return nil
 	}
 
 	target := strings.TrimSpace(evolvePin)
@@ -352,4 +378,21 @@ func playEvolutionAnimation(target string, skip bool) {
 	// Receipt line — the alt-screen content is gone after exit, so stamp
 	// the upgrade into normal scrollback for the user's records.
 	fmt.Println(styles.SuccessStyle.Render("✨ ") + "ailloy " + current + " → " + target)
+}
+
+// runEvolutionDemo plays the cinematic with caller-supplied versions and
+// performs no network/disk work. Drives the same evolution.Run path as a
+// real upgrade so what you see here matches what a real evolve looks like.
+func runEvolutionDemo(from, to string, skip bool) {
+	if skip {
+		styles.SetNoAnimate(true)
+		defer styles.SetNoAnimate(false)
+	}
+	played := evolution.Run(from, to)
+	if !played {
+		fmt.Println(styles.SuccessStyle.Render("✓ 🦊 ") + "demo: ailloy would evolve from " + from + " to " + to)
+		fmt.Println(styles.SubtleStyle.Render("    (cinematic suppressed — set AILLOY_DEBUG=1 for the reason)"))
+		return
+	}
+	fmt.Println(styles.SuccessStyle.Render("✨ ") + "demo: ailloy " + from + " → " + to)
 }

--- a/internal/commands/evolve.go
+++ b/internal/commands/evolve.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/charmbracelet/lipgloss"
+	"github.com/nimble-giant/ailloy/internal/tui/evolution"
 	"github.com/nimble-giant/ailloy/pkg/styles"
 	"github.com/spf13/cobra"
 )
@@ -318,49 +318,38 @@ func lookupChecksum(content, name string) (string, bool) {
 }
 
 // evolveAnimationArt returns the multi-line ailloy fox art used by the
-// evolution animation. Exposed for testing.
+// evolution animation. Exposed for testing — asserts the contract that the
+// fox art is non-empty multi-line so the cinematic has something to render.
 func evolveAnimationArt() string {
 	return strings.TrimLeft(styles.AilloyFox, "\n")
 }
 
-// playEvolutionAnimation prints a retro RPG-style evolution sequence ending
-// with the new version. Flashes the AilloyFox mascot between its normal color
-// and a white silhouette, mimicking the classic in-game evolution effect.
-// Falls back to a plain success line when stdout is not a TTY or skip is set,
-// so CI logs and non-interactive shells stay clean.
+// playEvolutionAnimation runs the retro RPG-style evolution cinematic in the
+// alt-screen and prints a permanent receipt line to scrollback after exit.
+// Falls back to a plain success line when animation is suppressed (CI,
+// non-TTY, --no-animate, terminal too small), so automation stays clean.
 func playEvolutionAnimation(target string, skip bool) {
 	if skip {
 		styles.SetNoAnimate(true)
 		defer styles.SetNoAnimate(false)
 	}
 
-	if !styles.ShouldAnimate() {
+	current := strings.TrimSpace(evolveCurrentVersion)
+	if current == "" {
+		current = "dev"
+	}
+	if current != "dev" && !strings.HasPrefix(current, "v") {
+		current = "v" + current
+	}
+
+	played := evolution.Run(current, target)
+
+	if !played {
 		fmt.Println(styles.SuccessStyle.Render("✓ 🦊 ") + "Your ailloy evolved into " + target + "!")
 		return
 	}
 
-	headline := lipgloss.NewStyle().Bold(true).Foreground(styles.Primary1)
-	primary := lipgloss.NewStyle().Foreground(styles.Primary1)
-	flash := lipgloss.NewStyle().Foreground(styles.White)
-	dim := styles.SubtleStyle
-
-	fmt.Println()
-	fmt.Println(headline.Render("What? AILLOY is evolving!"))
-	fmt.Println()
-
-	styles.FlashArt(evolveAnimationArt(), primary, flash, []styles.FlashCycle{
-		{UseFlash: true, Delay: 280 * time.Millisecond},
-		{UseFlash: false, Delay: 240 * time.Millisecond},
-		{UseFlash: true, Delay: 200 * time.Millisecond},
-		{UseFlash: false, Delay: 180 * time.Millisecond},
-		{UseFlash: true, Delay: 160 * time.Millisecond},
-		{UseFlash: false, Delay: 140 * time.Millisecond},
-		{UseFlash: true, Delay: 120 * time.Millisecond},
-		{UseFlash: false, Delay: 100 * time.Millisecond},
-	})
-
-	styles.Pause(450 * time.Millisecond)
-	fmt.Println()
-	fmt.Println(styles.SuccessStyle.Render("✨  Congratulations! Your AILLOY evolved into " + target + "!"))
-	fmt.Println(dim.Render("    (it learned how to update itself)"))
+	// Receipt line — the alt-screen content is gone after exit, so stamp
+	// the upgrade into normal scrollback for the user's records.
+	fmt.Println(styles.SuccessStyle.Render("✨ ") + "ailloy " + current + " → " + target)
 }

--- a/internal/tui/cinematic/cinematic_test.go
+++ b/internal/tui/cinematic/cinematic_test.go
@@ -1,0 +1,78 @@
+package cinematic
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func TestPadFoxLines_UniformWidth(t *testing.T) {
+	lines, cols := PadFoxLines()
+	if len(lines) == 0 {
+		t.Fatal("expected non-empty fox lines")
+	}
+	if cols == 0 {
+		t.Fatal("expected non-zero fox width")
+	}
+	for i, l := range lines {
+		if w := lipgloss.Width(l); w != cols {
+			t.Errorf("line %d width = %d, want uniform %d", i, w, cols)
+		}
+	}
+}
+
+func TestPadFoxLines_NoLeadingTrailingNewlines(t *testing.T) {
+	lines, _ := PadFoxLines()
+	if strings.TrimSpace(lines[0]) == "" {
+		// The padded first line is whitespace-only? That's a sign the
+		// pre-pad strip didn't remove a leading blank. Allow it only
+		// if the original art genuinely starts with a blank-content
+		// line — fox top is decorative and may include blank rows
+		// inside, but not as the first row.
+		t.Errorf("first padded line is blank, expected art content")
+	}
+}
+
+func TestNewSparkleField_Deterministic(t *testing.T) {
+	a := NewSparkleField(10, 30, 70, 42)
+	b := NewSparkleField(10, 30, 70, 42)
+	if len(a) != 10 || len(b) != 10 {
+		t.Fatalf("expected 10 sparkles each, got %d and %d", len(a), len(b))
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			t.Errorf("sparkle %d differs between runs with same seed: %+v vs %+v", i, a[i], b[i])
+		}
+	}
+}
+
+func TestNewSparkleField_AvoidsCenterBand(t *testing.T) {
+	rows := 30
+	cols := 70
+	field := NewSparkleField(60, rows, cols, 7)
+	avoidLo := int(float64(rows) * 0.30)
+	avoidHi := int(float64(rows) * 0.70)
+	for i, s := range field {
+		if s.Row > avoidLo && s.Row < avoidHi {
+			t.Errorf("sparkle %d at row %d is inside the avoid band (%d, %d)", i, s.Row, avoidLo, avoidHi)
+		}
+		if s.Col < 0 || s.Col >= cols {
+			t.Errorf("sparkle %d col %d out of bounds [0, %d)", i, s.Col, cols)
+		}
+	}
+}
+
+func TestRenderFoxBlock_Layout(t *testing.T) {
+	lines, cols := PadFoxLines()
+	out := RenderFoxBlock(lines, lipgloss.Color("#ffffff"))
+	rendered := strings.Split(out, "\n")
+	if len(rendered) != len(lines) {
+		t.Fatalf("RenderFoxBlock changed line count: got %d, want %d", len(rendered), len(lines))
+	}
+	for i, line := range rendered {
+		if w := lipgloss.Width(line); w != cols {
+			t.Errorf("line %d rendered width = %d, want %d", i, w, cols)
+		}
+	}
+}

--- a/internal/tui/cinematic/foxcomp.go
+++ b/internal/tui/cinematic/foxcomp.go
@@ -1,0 +1,50 @@
+// Package cinematic holds shared rendering primitives for the splash and
+// evolution cinematics: the AilloyFox layout, sparkle particle field, etc.
+// Anything specific to a single scene lives in that scene's package.
+package cinematic
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/nimble-giant/ailloy/pkg/styles"
+)
+
+// PadFoxLines returns the AilloyFox lines, leading/trailing newlines stripped,
+// every line padded with trailing spaces to a uniform width. Both splash and
+// evolution call this so the fox renders without sideways skew under any
+// centering layer (lipgloss.Place, lipgloss.JoinVertical with Center) — those
+// would otherwise re-center each row independently and warp the silhouette.
+func PadFoxLines() (lines []string, cols int) {
+	art := strings.TrimLeft(styles.AilloyFox, "\n")
+	art = strings.TrimRight(art, "\n")
+	lines = strings.Split(art, "\n")
+	for _, l := range lines {
+		if w := lipgloss.Width(l); w > cols {
+			cols = w
+		}
+	}
+	for i, l := range lines {
+		if pad := cols - lipgloss.Width(l); pad > 0 {
+			lines[i] = l + strings.Repeat(" ", pad)
+		}
+	}
+	return lines, cols
+}
+
+// RenderFox composes the padded fox by calling colorFor(rowIndex) for each
+// row's foreground. Returns one multi-line string ready to feed to
+// lipgloss.Place. Caller decides the centering wrapper.
+func RenderFox(lines []string, colorFor func(row int) lipgloss.Color) string {
+	out := make([]string, len(lines))
+	for i, l := range lines {
+		out[i] = lipgloss.NewStyle().Foreground(colorFor(i)).Render(l)
+	}
+	return strings.Join(out, "\n")
+}
+
+// RenderFoxBlock composes the padded fox where every row uses the same
+// foreground color. Convenience over RenderFox for the common case.
+func RenderFoxBlock(lines []string, color lipgloss.Color) string {
+	return RenderFox(lines, func(int) lipgloss.Color { return color })
+}

--- a/internal/tui/cinematic/sparkles.go
+++ b/internal/tui/cinematic/sparkles.go
@@ -1,0 +1,126 @@
+package cinematic
+
+import (
+	"math/rand"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/nimble-giant/ailloy/pkg/styles"
+)
+
+// Sparkle is one twinkle: a position relative to the fox bounding box,
+// a glyph, and a per-particle phase offset that controls when it peaks.
+type Sparkle struct {
+	Row      int
+	Col      int
+	Glyph    string
+	PhaseOff float64 // 0..1
+}
+
+// NewSparkleField generates n deterministic sparkles around a fox-sized box.
+// Sparkles avoid the central-mass region (rows ~30-70% of the box) so the
+// fox's face stays clean. The seed is deterministic — this is a movie, not
+// RNG, and the same upgrade should look the same on every replay.
+func NewSparkleField(n, foxRows, foxCols int, seed int64) []Sparkle {
+	r := rand.New(rand.NewSource(seed)) // #nosec G404 -- visual variety, not security
+	glyphs := []string{"✦", "✧", "·", "*", "⋆", "✺"}
+	out := make([]Sparkle, 0, n)
+	avoidLo := int(float64(foxRows) * 0.30)
+	avoidHi := int(float64(foxRows) * 0.70)
+	for range n {
+		var row, col int
+		// Try a few times to land outside the avoid band; if we can't,
+		// fall back to a forced top/bottom band placement so we never
+		// loop forever.
+		for range 8 {
+			row = r.Intn(foxRows)
+			col = r.Intn(foxCols)
+			if row < avoidLo || row > avoidHi {
+				break
+			}
+		}
+		if row >= avoidLo && row <= avoidHi {
+			if r.Intn(2) == 0 {
+				row = r.Intn(avoidLo + 1)
+			} else {
+				row = avoidHi + r.Intn(foxRows-avoidHi)
+			}
+		}
+		out = append(out, Sparkle{
+			Row:      row,
+			Col:      col,
+			Glyph:    glyphs[r.Intn(len(glyphs))],
+			PhaseOff: r.Float64(),
+		})
+	}
+	return out
+}
+
+// RenderSparkles returns a multi-line overlay (foxRows tall, foxCols wide)
+// with each sparkle drawn at intensity = ease(t - PhaseOff). Empty cells are
+// spaces so the overlay can be composited via per-line max with the fox
+// underneath, but in practice we render this as a separate panel below the
+// fox in the fanfare beat — keeping the fox unobstructed.
+func RenderSparkles(sparkles []Sparkle, t float64, rows, cols int) string {
+	grid := make([][]rune, rows)
+	intensities := make([][]float64, rows)
+	for i := range grid {
+		grid[i] = make([]rune, cols)
+		intensities[i] = make([]float64, cols)
+		for j := range grid[i] {
+			grid[i][j] = ' '
+		}
+	}
+
+	for _, s := range sparkles {
+		// Each sparkle has a 0.35-wide eased window centered on PhaseOff.
+		// Outside that window: invisible. Inside: brightness peaks at the
+		// midpoint and falls off symmetrically.
+		const window = 0.35
+		dt := t - s.PhaseOff
+		if dt < 0 || dt > window {
+			continue
+		}
+		pos := dt / window
+		intensity := 1 - absF(pos-0.5)*2
+		if intensity <= 0 {
+			continue
+		}
+		if s.Row < 0 || s.Row >= rows || s.Col < 0 || s.Col >= cols {
+			continue
+		}
+		runes := []rune(s.Glyph)
+		if len(runes) == 0 {
+			continue
+		}
+		if intensity > intensities[s.Row][s.Col] {
+			grid[s.Row][s.Col] = runes[0]
+			intensities[s.Row][s.Col] = intensity
+		}
+	}
+
+	// Render line-by-line, per-glyph color picked by its intensity.
+	var b strings.Builder
+	for i := range rows {
+		for j := range cols {
+			ch := grid[i][j]
+			if ch == ' ' {
+				b.WriteByte(' ')
+				continue
+			}
+			c := styles.LerpHex(lipgloss.Color("#9aa0a6"), lipgloss.Color("#fff5cc"), intensities[i][j])
+			b.WriteString(lipgloss.NewStyle().Foreground(c).Bold(true).Render(string(ch)))
+		}
+		if i < rows-1 {
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}
+
+func absF(v float64) float64 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}

--- a/internal/tui/evolution/digitwheel.go
+++ b/internal/tui/evolution/digitwheel.go
@@ -1,0 +1,99 @@
+package evolution
+
+import (
+	"strings"
+	"unicode"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/nimble-giant/ailloy/pkg/styles"
+)
+
+// RenderDigitWheel returns a string where each rune position blends from
+// `from` to `to` based on per-position eased t. Non-digit characters (the
+// leading 'v', dots, dashes) are held constant from `to` so the layout never
+// shifts. Each digit position has its own staggered start so they appear to
+// "land" left-to-right like a flip-board / slot machine.
+//
+// During the rolling window, each position cycles through 0..9 driven by a
+// frame-derived hash for visual energy, then locks to the target value once
+// the position's lock threshold is crossed. Non-digit positions in `from` and
+// `to` must match — otherwise we fall back to the static `to`.
+//
+// `frame` is an integer ticking ~60Hz; it provides the variation during the
+// rolling window. `t` is normalized [0, 1] phase progress.
+func RenderDigitWheel(from, to string, t float64, frame int) string {
+	fromRunes := []rune(from)
+	toRunes := []rune(to)
+	if len(fromRunes) != len(toRunes) {
+		return renderStatic(to)
+	}
+
+	// Validate non-digit positions match. If they don't, the version
+	// strings have different shapes (e.g. "v0.6.21" vs "v0.7") and we
+	// can't sensibly cycle digit-by-digit.
+	for i := range toRunes {
+		if !unicode.IsDigit(toRunes[i]) && fromRunes[i] != toRunes[i] {
+			return renderStatic(to)
+		}
+	}
+
+	// Per-position lock threshold: leftmost locks first, rightmost last.
+	// Maps to a curve that gives the "left to right" reel-stop feel.
+	locks := perPositionLocks(len(toRunes))
+
+	var b strings.Builder
+	for i := range toRunes {
+		ch := toRunes[i]
+		if !unicode.IsDigit(ch) {
+			b.WriteString(staticChar(ch))
+			continue
+		}
+		if t >= locks[i] {
+			b.WriteString(lockedDigit(ch))
+			continue
+		}
+		// Cycle: pseudo-random digit derived from (position, frame).
+		digit := byte('0' + ((i*17 + frame*3) % 10))
+		b.WriteString(rollingDigit(rune(digit)))
+	}
+	return b.String()
+}
+
+// perPositionLocks returns one lock threshold per position, scaled across
+// roughly the first 80% of the phase so the last digit lands by t=0.8.
+func perPositionLocks(n int) []float64 {
+	locks := make([]float64, n)
+	if n == 0 {
+		return locks
+	}
+	for i := range n {
+		// Linearly distributed 0.15 → 0.80.
+		locks[i] = 0.15 + 0.65*float64(i)/float64(max(n-1, 1))
+	}
+	return locks
+}
+
+func renderStatic(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if unicode.IsDigit(r) {
+			b.WriteString(lockedDigit(r))
+		} else {
+			b.WriteString(staticChar(r))
+		}
+	}
+	return b.String()
+}
+
+func staticChar(r rune) string {
+	return lipgloss.NewStyle().Foreground(styles.Primary1).Render(string(r))
+}
+
+func lockedDigit(r rune) string {
+	return lipgloss.NewStyle().Foreground(styles.Primary1).Bold(true).Render(string(r))
+}
+
+func rollingDigit(r rune) string {
+	// Rolling digits are warm/ember-colored to suggest motion energy.
+	return lipgloss.NewStyle().Foreground(lipgloss.Color("#ff9800")).Bold(true).Render(string(r))
+}

--- a/internal/tui/evolution/digitwheel_test.go
+++ b/internal/tui/evolution/digitwheel_test.go
@@ -1,0 +1,83 @@
+package evolution
+
+import (
+	"strings"
+	"testing"
+)
+
+// removeEscapes strips ANSI SGR sequences so we can assert on visible
+// characters without coupling to lipgloss color output.
+func removeEscapes(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] == 0x1b { // ESC
+			for i < len(s) && s[i] != 'm' {
+				i++
+			}
+			continue
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}
+
+func TestDigitWheel_Endpoints(t *testing.T) {
+	from := "v0.6.21"
+	to := "v0.7.0 "
+	// Mismatched non-digit shapes → static fallback.
+	if got := removeEscapes(RenderDigitWheel(from, to, 0.5, 0)); got != "v0.7.0 " {
+		t.Errorf("mismatched layouts should fall back to static `to`, got %q", got)
+	}
+
+	// Same layout, t=1.0 → all locked to target.
+	from = "v0.6.21"
+	to = "v0.7.99"
+	if got := removeEscapes(RenderDigitWheel(from, to, 1.0, 0)); got != to {
+		t.Errorf("t=1 should render exactly the target, got %q want %q", got, to)
+	}
+	// t=0.0 → leftmost positions still rolling, but last position is also
+	// rolling. We assert that every digit position is in [0-9].
+	got := removeEscapes(RenderDigitWheel(from, to, 0.0, 0))
+	if len(got) != len(to) {
+		t.Fatalf("output length mismatch: got %d want %d (%q)", len(got), len(to), got)
+	}
+	for i, r := range to {
+		out := rune(got[i])
+		if !isDigit(r) {
+			if out != r {
+				t.Errorf("position %d non-digit changed: got %q want %q", i, out, r)
+			}
+			continue
+		}
+		if out < '0' || out > '9' {
+			t.Errorf("position %d should be a digit, got %q", i, out)
+		}
+	}
+}
+
+func TestDigitWheel_NonDigitsHeld(t *testing.T) {
+	from := "v0.6.21"
+	to := "v0.7.42"
+	for _, frame := range []int{0, 7, 31, 42} {
+		got := removeEscapes(RenderDigitWheel(from, to, 0.4, frame))
+		if got[0] != 'v' || got[2] != '.' || got[4] != '.' {
+			t.Errorf("frame %d: non-digit chars not held in place: %q", frame, got)
+		}
+	}
+}
+
+func TestDigitWheel_LeftLocksFirst(t *testing.T) {
+	from := "0000"
+	to := "1234"
+	// Just past leftmost lock threshold (~0.15), rightmost should still
+	// be rolling — we can't pin the exact rolling value but we can assert
+	// at least one of the rightmost positions is NOT yet the target.
+	got := removeEscapes(RenderDigitWheel(from, to, 0.16, 0))
+	if got[0] != '1' {
+		t.Errorf("leftmost should have locked at t=0.16, got %q", got)
+	}
+}
+
+func isDigit(r rune) bool {
+	return r >= '0' && r <= '9'
+}

--- a/internal/tui/evolution/evolution.go
+++ b/internal/tui/evolution/evolution.go
@@ -1,0 +1,35 @@
+package evolution
+
+import (
+	"os"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/nimble-giant/ailloy/pkg/styles"
+	"golang.org/x/term"
+)
+
+const (
+	minWidth  = 80
+	minHeight = 36
+)
+
+// Run plays the evolution cinematic in the alt-screen and returns when it
+// completes or is skipped. Returns true if it played, false if it was
+// suppressed (non-TTY, kill switch set, terminal too small, or program
+// errored). Always safe to call after a successful binary swap; the
+// cinematic itself never writes anything permanent — the caller should
+// print a receipt line to stdout regardless of the return value.
+func Run(currentVersion, targetVersion string) bool {
+	if !styles.ShouldAnimate() {
+		return false
+	}
+	w, h, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil || w < minWidth || h < minHeight {
+		return false
+	}
+	prog := tea.NewProgram(New(w, h, currentVersion, targetVersion), tea.WithAltScreen())
+	if _, err := prog.Run(); err != nil {
+		return false
+	}
+	return true
+}

--- a/internal/tui/evolution/evolution.go
+++ b/internal/tui/evolution/evolution.go
@@ -1,6 +1,7 @@
 package evolution
 
 import (
+	"fmt"
 	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -8,28 +9,50 @@ import (
 	"golang.org/x/term"
 )
 
+// Layout thresholds. Below `compactHeight`, the cinematic still plays but
+// drops the giant fox and centers a smaller composition (title + version
+// chip + flash + digit wheel + sparkles). Below `minHeight` it skips
+// entirely.
 const (
-	minWidth  = 80
-	minHeight = 36
+	minWidth      = 60
+	minHeight     = 16
+	compactHeight = 36
 )
 
 // Run plays the evolution cinematic in the alt-screen and returns when it
 // completes or is skipped. Returns true if it played, false if it was
-// suppressed (non-TTY, kill switch set, terminal too small, or program
-// errored). Always safe to call after a successful binary swap; the
+// suppressed. Always safe to call after a successful binary swap; the
 // cinematic itself never writes anything permanent — the caller should
 // print a receipt line to stdout regardless of the return value.
+//
+// When `AILLOY_DEBUG=1`, emits a one-line reason to stderr if the cinematic
+// is suppressed, so silent skips don't go unnoticed in future regressions.
 func Run(currentVersion, targetVersion string) bool {
 	if !styles.ShouldAnimate() {
+		debug("ShouldAnimate()=false")
 		return false
 	}
 	w, h, err := term.GetSize(int(os.Stdout.Fd()))
-	if err != nil || w < minWidth || h < minHeight {
+	if err != nil {
+		debug("term.GetSize: %v", err)
 		return false
 	}
-	prog := tea.NewProgram(New(w, h, currentVersion, targetVersion), tea.WithAltScreen())
+	if w < minWidth || h < minHeight {
+		debug("terminal %dx%d below minimum %dx%d", w, h, minWidth, minHeight)
+		return false
+	}
+	model := New(w, h, currentVersion, targetVersion)
+	prog := tea.NewProgram(model, tea.WithAltScreen())
 	if _, err := prog.Run(); err != nil {
+		debug("tea.Run: %v", err)
 		return false
 	}
 	return true
+}
+
+func debug(format string, args ...any) {
+	if os.Getenv("AILLOY_DEBUG") == "" {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "[evolution] "+format+"\n", args...)
 }

--- a/internal/tui/evolution/model.go
+++ b/internal/tui/evolution/model.go
@@ -1,0 +1,164 @@
+// Package evolution plays the retro RPG-style cinematic for `ailloy evolve`.
+// The animation runs in the alternate screen buffer after the binary swap
+// has already succeeded — the cinematic itself never persists anything; the
+// caller is responsible for printing a receipt line to scrollback.
+package evolution
+
+import (
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/nimble-giant/ailloy/internal/tui/cinematic"
+)
+
+const frameInterval = 16 * time.Millisecond
+
+// Beat boundaries (cumulative milliseconds since program start).
+const (
+	beatHeadlineEnd = 800
+	beatHoldEnd     = 1300
+	beatChargeEnd   = 2000
+	beatFlashEnd    = 3200
+	beatCrackEnd    = 3450
+	beatRevealEnd   = 4400
+	beatFanfareEnd  = 5300
+	beatTotal       = 5700
+)
+
+type frameMsg time.Time
+type startMsg struct{}
+
+// Model is the evolve cinematic. Lifecycle:
+//
+//	prog := tea.NewProgram(evolution.New(w, h, "v0.6.21", "v0.7.0"), tea.WithAltScreen())
+//	prog.Run()
+//
+// The model self-quits at beatTotal or on any keypress.
+type Model struct {
+	width    int
+	height   int
+	start    time.Time
+	frame    int
+	foxLines []string
+	foxRows  int
+	foxCols  int
+	sparkles []cinematic.Sparkle
+	from     string // current version, e.g. "v0.6.21"
+	to       string // target version,  e.g. "v0.7.0"
+}
+
+// New constructs an evolution Model. The version strings should be in the
+// form `vMAJOR.MINOR.PATCH` (or "dev"); the digit-wheel beat will fall back
+// to a static rendering of `to` if `from` and `to` have different shapes.
+func New(width, height int, currentVersion, targetVersion string) Model {
+	lines, cols := cinematic.PadFoxLines()
+	// 14 sparkles is enough to feel like a celebration without becoming
+	// chunky in 256-color terminals. Seeded by the target version so a
+	// given upgrade replays identically.
+	seed := stringSeed(targetVersion)
+	return Model{
+		width:    width,
+		height:   height,
+		foxLines: lines,
+		foxRows:  len(lines),
+		foxCols:  cols,
+		sparkles: cinematic.NewSparkleField(14, len(lines), cols, seed),
+		from:     currentVersion,
+		to:       targetVersion,
+	}
+}
+
+func (m Model) Init() tea.Cmd {
+	return tea.Batch(
+		func() tea.Msg { return startMsg{} },
+		tick(),
+	)
+}
+
+func tick() tea.Cmd {
+	return tea.Tick(frameInterval, func(t time.Time) tea.Msg {
+		return frameMsg(t)
+	})
+}
+
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case startMsg:
+		m.start = time.Now()
+		return m, tick()
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+	case tea.KeyMsg:
+		// Any key skips. Receipt is printed by the caller post-Quit.
+		return m, tea.Quit
+	case frameMsg:
+		if m.start.IsZero() {
+			return m, tick()
+		}
+		m.frame++
+		if time.Since(m.start) >= time.Duration(beatTotal)*time.Millisecond {
+			return m, tea.Quit
+		}
+		return m, tick()
+	}
+	return m, nil
+}
+
+func (m Model) View() string {
+	if m.width == 0 || m.height == 0 {
+		return ""
+	}
+	if m.start.IsZero() {
+		return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, "")
+	}
+
+	elapsedMs := float64(time.Since(m.start) / time.Millisecond)
+	switch {
+	case elapsedMs < beatHeadlineEnd:
+		return m.renderHeadline(normalize(elapsedMs, 0, beatHeadlineEnd))
+	case elapsedMs < beatHoldEnd:
+		return m.renderHold(normalize(elapsedMs, beatHeadlineEnd, beatHoldEnd))
+	case elapsedMs < beatChargeEnd:
+		return m.renderCharge(normalize(elapsedMs, beatHoldEnd, beatChargeEnd))
+	case elapsedMs < beatFlashEnd:
+		return m.renderFlash(normalize(elapsedMs, beatChargeEnd, beatFlashEnd))
+	case elapsedMs < beatCrackEnd:
+		return m.renderCrack(normalize(elapsedMs, beatFlashEnd, beatCrackEnd))
+	case elapsedMs < beatRevealEnd:
+		return m.renderReveal(normalize(elapsedMs, beatCrackEnd, beatRevealEnd))
+	case elapsedMs < beatFanfareEnd:
+		return m.renderFanfare(normalize(elapsedMs, beatRevealEnd, beatFanfareEnd))
+	default:
+		return m.renderFanfare(1)
+	}
+}
+
+func normalize(t, lo, hi float64) float64 {
+	if hi <= lo {
+		return 1
+	}
+	v := (t - lo) / (hi - lo)
+	if v < 0 {
+		return 0
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
+}
+
+// stringSeed turns a string into a stable int64 so the same target version
+// always seeds the same sparkle layout. Cheap djb2-like hash.
+func stringSeed(s string) int64 {
+	var h int64 = 5381
+	for _, r := range s {
+		h = h*33 + int64(r)
+	}
+	if h < 0 {
+		h = -h
+	}
+	return h
+}

--- a/internal/tui/evolution/model.go
+++ b/internal/tui/evolution/model.go
@@ -38,6 +38,7 @@ type startMsg struct{}
 type Model struct {
 	width    int
 	height   int
+	compact  bool // true when the terminal can't fit the full fox-sized layout
 	start    time.Time
 	frame    int
 	foxLines []string
@@ -51,19 +52,30 @@ type Model struct {
 // New constructs an evolution Model. The version strings should be in the
 // form `vMAJOR.MINOR.PATCH` (or "dev"); the digit-wheel beat will fall back
 // to a static rendering of `to` if `from` and `to` have different shapes.
+//
+// When the supplied terminal height is below `compactHeight`, the model
+// flips to a compact layout: no giant fox, just headline / version chip /
+// charge / flash / digit wheel / sparkle fanfare centered tightly. The
+// beat structure stays identical so timing and skip behavior are unchanged.
 func New(width, height int, currentVersion, targetVersion string) Model {
 	lines, cols := cinematic.PadFoxLines()
-	// 14 sparkles is enough to feel like a celebration without becoming
-	// chunky in 256-color terminals. Seeded by the target version so a
-	// given upgrade replays identically.
+	// Sparkles seeded by the target version so a given upgrade replays
+	// identically. 14 sparkles for the full fox layout; 6 for the
+	// compact band so it doesn't look chunky in 256-color terminals.
 	seed := stringSeed(targetVersion)
+	compact := height < compactHeight
+	sparkleCount := 14
+	if compact {
+		sparkleCount = 6
+	}
 	return Model{
 		width:    width,
 		height:   height,
+		compact:  compact,
 		foxLines: lines,
 		foxRows:  len(lines),
 		foxCols:  cols,
-		sparkles: cinematic.NewSparkleField(14, len(lines), cols, seed),
+		sparkles: cinematic.NewSparkleField(sparkleCount, len(lines), cols, seed),
 		from:     currentVersion,
 		to:       targetVersion,
 	}

--- a/internal/tui/evolution/scenes.go
+++ b/internal/tui/evolution/scenes.go
@@ -1,0 +1,345 @@
+package evolution
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/nimble-giant/ailloy/internal/tui/cinematic"
+	"github.com/nimble-giant/ailloy/pkg/styles"
+)
+
+// Palette
+var (
+	preColor   = styles.Primary1           // pre-evolve fox color
+	postColor  = styles.Primary2           // post-evolve fox color (the alloy)
+	emberWarm  = lipgloss.Color("#ff9800") // charge halo & rolling digits
+	whiteHot   = lipgloss.Color("#ffffff") // flash & crack
+	dimColor   = lipgloss.Color("#2a2540") // background pre-bloom
+	headlineFg = lipgloss.Color("#fff5cc") // warm cream for the title
+	gold       = lipgloss.Color("#ffd28a") // fanfare accent
+)
+
+// renderHeadline types out "What? AILLOY is evolving!" character-by-character
+// over the full beat, with a subtle warm underglow that brightens with t.
+func (m Model) renderHeadline(t float64) string {
+	full := "What? AILLOY is evolving!"
+	runes := []rune(full)
+	cut := min(int(float64(len(runes))*styles.EaseOutQuad(t)), len(runes))
+	visible := string(runes[:cut])
+
+	headlineStyle := lipgloss.NewStyle().
+		Foreground(headlineFg).
+		Bold(true)
+	cursor := ""
+	if cut < len(runes) && (m.frame/8)%2 == 0 {
+		cursor = lipgloss.NewStyle().Foreground(emberWarm).Render("▊")
+	}
+
+	body := headlineStyle.Render(visible) + cursor
+
+	// Underglow: a thin rule under the text whose color brightens with t.
+	rule := lipgloss.NewStyle().
+		Foreground(styles.LerpHex(dimColor, emberWarm, styles.EaseOutCubic(t))).
+		Render(strings.Repeat("─", lipgloss.Width(full)))
+
+	scene := lipgloss.JoinVertical(
+		lipgloss.Center,
+		body,
+		rule,
+	)
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, scene)
+}
+
+// renderHold shows the fox in pre-evolve color with the current version chip
+// underneath. A quiet beat — the calm before the change.
+func (m Model) renderHold(_ float64) string {
+	fox := cinematic.RenderFoxBlock(m.foxLines, preColor)
+	chip := versionChip(m.from, preColor)
+	scene := lipgloss.JoinVertical(lipgloss.Center, fox, "", chip)
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, scene)
+}
+
+// renderCharge tints the fox with a slow oscillating "warming" — alternating
+// between preColor and a warmer ember as t advances. The version chip starts
+// to flicker.
+func (m Model) renderCharge(t float64) string {
+	// Per-row oscillation: each row has a small phase offset so the warming
+	// looks like it's sweeping through the body. Amplitude grows with t.
+	amp := styles.EaseOutCubic(t)
+	colorFor := func(row int) lipgloss.Color {
+		// Triangle wave per row, 0..1.
+		phase := (float64(row)/float64(m.foxRows)*2.0 + t*4.0)
+		tri := 1 - absF(((phase-0.5)*2-1)-0.5)*2 // simple ripple
+		if tri < 0 {
+			tri = 0
+		}
+		mix := tri * amp
+		return styles.LerpHex(preColor, emberWarm, mix)
+	}
+	fox := cinematic.RenderFox(m.foxLines, colorFor)
+
+	// Flickering chip: the version glyphs alternate between dim and bright
+	// based on the frame counter so it looks unstable.
+	chipColor := preColor
+	if (m.frame/3)%2 == 0 {
+		chipColor = emberWarm
+	}
+	chip := versionChip(m.from, chipColor)
+
+	scene := lipgloss.JoinVertical(lipgloss.Center, fox, "", chip)
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, scene)
+}
+
+// renderFlash is the accelerating retro RPG-style strobe: bright→dim→bright→
+// dim→silhouette over the beat. The silhouette frame replaces non-space
+// characters with full block runes for a unified white shape — the squash.
+func (m Model) renderFlash(t float64) string {
+	// Five sub-beats; the silhouette is the last one and holds longest.
+	sub := min(int(t*5), 4)
+	var fox string
+	switch sub {
+	case 0:
+		fox = cinematic.RenderFoxBlock(m.foxLines, whiteHot)
+	case 1:
+		fox = cinematic.RenderFoxBlock(m.foxLines, preColor)
+	case 2:
+		fox = cinematic.RenderFoxBlock(m.foxLines, whiteHot)
+	case 3:
+		fox = cinematic.RenderFoxBlock(m.foxLines, preColor)
+	default:
+		fox = renderSilhouette(m.foxLines)
+	}
+
+	// Chip transitions through whitewash on the brightest frames.
+	chipColor := preColor
+	if sub%2 == 0 || sub == 4 {
+		chipColor = whiteHot
+	}
+	chip := versionChip(m.from, chipColor)
+
+	scene := lipgloss.JoinVertical(lipgloss.Center, fox, "", chip)
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, scene)
+}
+
+// renderCrack is the white-out: the fox area is rendered as solid white
+// blocks fading to postColor over a quarter-second, sweeping from the center
+// outward.
+func (m Model) renderCrack(t float64) string {
+	colorFor := func(row int) lipgloss.Color {
+		// Distance from vertical center, normalized.
+		mid := float64(m.foxRows) / 2
+		dist := absF(float64(row)-mid) / mid
+		// Sweep edge accelerates: rows further from center fade later.
+		localT := (t - dist*0.5) / 0.5
+		if localT < 0 {
+			return whiteHot
+		}
+		if localT > 1 {
+			return postColor
+		}
+		return styles.LerpHex(whiteHot, postColor, styles.EaseInOut(localT))
+	}
+	// Solid block silhouette — the shape we transition through.
+	fox := cinematic.RenderFox(silhouetteLines(m.foxLines), colorFor)
+	scene := lipgloss.JoinVertical(lipgloss.Center, fox, "", versionChip(m.from, whiteHot))
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, scene)
+}
+
+// renderReveal lands the new fox in postColor and runs the digit wheel
+// underneath, cycling from m.from → m.to.
+func (m Model) renderReveal(t float64) string {
+	// Fox fades from white-hot edge into full postColor over the first
+	// 30% of the beat, then holds.
+	colorFor := func(int) lipgloss.Color {
+		if t < 0.3 {
+			return styles.LerpHex(whiteHot, postColor, styles.EaseOutCubic(t/0.3))
+		}
+		return postColor
+	}
+	fox := cinematic.RenderFox(m.foxLines, colorFor)
+
+	wheel := RenderDigitWheel(m.from, m.to, t, m.frame)
+	chip := chipBox(wheel, postColor)
+
+	scene := lipgloss.JoinVertical(lipgloss.Center, fox, "", chip)
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, scene)
+}
+
+// renderFanfare is the celebration: stable post-evolve fox, sparkles drawn
+// in a band around it, "Congratulations!" headline, target version chip.
+func (m Model) renderFanfare(t float64) string {
+	fox := cinematic.RenderFoxBlock(m.foxLines, postColor)
+	sparkles := cinematic.RenderSparkles(m.sparkles, t, m.foxRows, m.foxCols)
+
+	headline := lipgloss.NewStyle().
+		Foreground(gold).
+		Bold(true).
+		Render("✨  Congratulations!  ✨")
+
+	subtitle := lipgloss.NewStyle().
+		Foreground(styles.LerpHex(dimColor, headlineFg, styles.EaseOutCubic(t))).
+		Render("ailloy " + m.from + " → " + m.to)
+
+	chip := versionChip(m.to, postColor)
+
+	scene := lipgloss.JoinVertical(
+		lipgloss.Center,
+		overlay(fox, sparkles),
+		"",
+		chip,
+		"",
+		headline,
+		subtitle,
+	)
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, scene)
+}
+
+// versionChip renders a [vX.Y.Z] pill in the given color.
+func versionChip(version string, color lipgloss.Color) string {
+	return chipBox(lipgloss.NewStyle().Foreground(color).Bold(true).Render(version), color)
+}
+
+func chipBox(content string, borderColor lipgloss.Color) string {
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(borderColor).
+		Padding(0, 2).
+		Render(content)
+}
+
+// silhouetteLines returns the fox lines with every non-space rune replaced
+// by '█' so the fox becomes a unified solid shape — used by the silhouette
+// flash frame and the crack white-out.
+func silhouetteLines(lines []string) []string {
+	out := make([]string, len(lines))
+	for i, line := range lines {
+		var b strings.Builder
+		for _, r := range line {
+			if r == ' ' {
+				b.WriteRune(' ')
+			} else {
+				b.WriteRune('█')
+			}
+		}
+		out[i] = b.String()
+	}
+	return out
+}
+
+func renderSilhouette(lines []string) string {
+	return cinematic.RenderFoxBlock(silhouetteLines(lines), whiteHot)
+}
+
+// overlay composites top onto bottom by replacing bottom's cells with top's
+// non-space cells. Both inputs must have matching line counts and widths;
+// caller is responsible (we use the fox dimensions).
+func overlay(bottom, top string) string {
+	bLines := strings.Split(bottom, "\n")
+	tLines := strings.Split(top, "\n")
+	if len(tLines) > len(bLines) {
+		tLines = tLines[:len(bLines)]
+	}
+	out := make([]string, len(bLines))
+	copy(out, bLines)
+	for i, t := range tLines {
+		out[i] = compositeLine(bLines[i], t)
+	}
+	return strings.Join(out, "\n")
+}
+
+// compositeLine returns top's non-space rune slots overlaid on bottom. Both
+// strings may carry ANSI escapes; we operate on rendered cells via
+// lipgloss.Width and rune iteration. For visual correctness in the alt
+// screen this is good enough — non-space top cells win, including their
+// ANSI styling.
+func compositeLine(bottom, top string) string {
+	// Strip ANSI from top to find non-space rune positions; then walk the
+	// top runes and copy them (with their preceding ANSI escapes) into
+	// the result. Bottom is left untouched at space positions.
+	bRunes := splitANSI(bottom)
+	tRunes := splitANSI(top)
+	if len(tRunes) == 0 {
+		return bottom
+	}
+	out := make([]string, max(len(bRunes), len(tRunes)))
+	copy(out, bRunes)
+	for i, tr := range tRunes {
+		if visibleRune(tr) == ' ' || visibleRune(tr) == 0 {
+			continue
+		}
+		out[i] = tr
+	}
+	return strings.Join(out, "")
+}
+
+// splitANSI splits a string into per-cell substrings, each containing the
+// rune at that cell plus any preceding ANSI escape sequence(s). Cells
+// without escapes are just the rune as a string.
+func splitANSI(s string) []string {
+	var out []string
+	var pending strings.Builder
+	i := 0
+	for i < len(s) {
+		if s[i] == 0x1b { // ESC
+			pending.WriteByte(s[i])
+			i++
+			for i < len(s) && s[i] != 'm' {
+				pending.WriteByte(s[i])
+				i++
+			}
+			if i < len(s) {
+				pending.WriteByte(s[i]) // 'm'
+				i++
+			}
+			continue
+		}
+		// Decode one rune.
+		r, sz := decodeRune(s[i:])
+		var cell strings.Builder
+		cell.WriteString(pending.String())
+		pending.Reset()
+		cell.WriteString(string(r))
+		out = append(out, cell.String())
+		i += sz
+	}
+	if pending.Len() > 0 && len(out) > 0 {
+		out[len(out)-1] += pending.String()
+	}
+	return out
+}
+
+func decodeRune(s string) (rune, int) {
+	for _, r := range s {
+		// Return the first rune and its byte length.
+		return r, len(string(r))
+	}
+	return 0, 0
+}
+
+// visibleRune returns the actual character carried by a cell string emitted
+// by splitANSI (skipping any leading ANSI escapes).
+func visibleRune(cell string) rune {
+	i := 0
+	for i < len(cell) {
+		if cell[i] == 0x1b {
+			for i < len(cell) && cell[i] != 'm' {
+				i++
+			}
+			if i < len(cell) {
+				i++
+			}
+			continue
+		}
+		for _, r := range cell[i:] {
+			return r
+		}
+	}
+	return 0
+}
+
+func absF(v float64) float64 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}

--- a/internal/tui/evolution/scenes.go
+++ b/internal/tui/evolution/scenes.go
@@ -52,7 +52,10 @@ func (m Model) renderHeadline(t float64) string {
 
 // renderHold shows the fox in pre-evolve color with the current version chip
 // underneath. A quiet beat — the calm before the change.
-func (m Model) renderHold(_ float64) string {
+func (m Model) renderHold(t float64) string {
+	if m.compact {
+		return m.renderHoldCompact(t)
+	}
 	fox := cinematic.RenderFoxBlock(m.foxLines, preColor)
 	chip := versionChip(m.from, preColor)
 	scene := lipgloss.JoinVertical(lipgloss.Center, fox, "", chip)
@@ -63,6 +66,9 @@ func (m Model) renderHold(_ float64) string {
 // between preColor and a warmer ember as t advances. The version chip starts
 // to flicker.
 func (m Model) renderCharge(t float64) string {
+	if m.compact {
+		return m.renderChargeCompact(t)
+	}
 	// Per-row oscillation: each row has a small phase offset so the warming
 	// looks like it's sweeping through the body. Amplitude grows with t.
 	amp := styles.EaseOutCubic(t)
@@ -94,6 +100,9 @@ func (m Model) renderCharge(t float64) string {
 // dim→silhouette over the beat. The silhouette frame replaces non-space
 // characters with full block runes for a unified white shape — the squash.
 func (m Model) renderFlash(t float64) string {
+	if m.compact {
+		return m.renderFlashCompact(t)
+	}
 	// Five sub-beats; the silhouette is the last one and holds longest.
 	sub := min(int(t*5), 4)
 	var fox string
@@ -125,6 +134,9 @@ func (m Model) renderFlash(t float64) string {
 // blocks fading to postColor over a quarter-second, sweeping from the center
 // outward.
 func (m Model) renderCrack(t float64) string {
+	if m.compact {
+		return m.renderCrackCompact(t)
+	}
 	colorFor := func(row int) lipgloss.Color {
 		// Distance from vertical center, normalized.
 		mid := float64(m.foxRows) / 2
@@ -148,6 +160,9 @@ func (m Model) renderCrack(t float64) string {
 // renderReveal lands the new fox in postColor and runs the digit wheel
 // underneath, cycling from m.from → m.to.
 func (m Model) renderReveal(t float64) string {
+	if m.compact {
+		return m.renderRevealCompact(t)
+	}
 	// Fox fades from white-hot edge into full postColor over the first
 	// 30% of the beat, then holds.
 	colorFor := func(int) lipgloss.Color {
@@ -168,6 +183,9 @@ func (m Model) renderReveal(t float64) string {
 // renderFanfare is the celebration: stable post-evolve fox, sparkles drawn
 // in a band around it, "Congratulations!" headline, target version chip.
 func (m Model) renderFanfare(t float64) string {
+	if m.compact {
+		return m.renderFanfareCompact(t)
+	}
 	fox := cinematic.RenderFoxBlock(m.foxLines, postColor)
 	sparkles := cinematic.RenderSparkles(m.sparkles, t, m.foxRows, m.foxCols)
 

--- a/internal/tui/evolution/scenes_compact.go
+++ b/internal/tui/evolution/scenes_compact.go
@@ -1,0 +1,194 @@
+package evolution
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/nimble-giant/ailloy/pkg/styles"
+)
+
+// Compact-mode renderers. Used when the terminal can't fit the giant fox
+// (height < compactHeight). The beats happen on a tight horizontal band
+// centered in the screen: title strip + version chip + flash + digit wheel
+// + sparkle row. Same beat structure as the full layout, just no fox.
+
+// renderHoldCompact: the title strip and current-version chip, dim and
+// quiet. The breath before the strike.
+func (m Model) renderHoldCompact(_ float64) string {
+	return placeCompact(m,
+		titleStrip(preColor),
+		"",
+		versionChip(m.from, preColor),
+	)
+}
+
+// renderChargeCompact pulses the chip color between preColor and emberWarm.
+// Pure rhythm — the dramatic warm-up.
+func (m Model) renderChargeCompact(t float64) string {
+	chipColor := preColor
+	if (m.frame/3)%2 == 0 {
+		chipColor = emberWarm
+	}
+	// Title gets a subtle glow that intensifies with t.
+	titleColor := styles.LerpHex(headlineFg, gold, styles.EaseOutCubic(t))
+	return placeCompact(m,
+		titleStripColored(titleColor),
+		"",
+		versionChip(m.from, chipColor),
+	)
+}
+
+// renderFlashCompact strobes the entire band: chip flashes, title flashes,
+// finishing on a unified white silhouette of the chip.
+func (m Model) renderFlashCompact(t float64) string {
+	sub := min(int(t*5), 4)
+	var titleColor, chipColor lipgloss.Color
+	switch sub {
+	case 1, 3:
+		titleColor = headlineFg
+		chipColor = preColor
+	default: // 0, 2, 4 — bright frames; 4 is the silhouette beat
+		titleColor = whiteHot
+		chipColor = whiteHot
+	}
+
+	chip := versionChip(m.from, chipColor)
+	if sub == 4 {
+		// Render a unified-white silhouette of the chip — Pokemon's "we
+		// can't see what's becoming yet" frame.
+		chip = silhouetteChip(m.from, whiteHot)
+	}
+	return placeCompact(m,
+		titleStripColored(titleColor),
+		"",
+		chip,
+	)
+}
+
+// renderCrackCompact is the white-out: a centered band of solid blocks
+// fading from white to postColor.
+func (m Model) renderCrackCompact(t float64) string {
+	bandColor := styles.LerpHex(whiteHot, postColor, styles.EaseInOut(t))
+	band := lipgloss.NewStyle().
+		Foreground(bandColor).
+		Bold(true).
+		Render(strings.Repeat("█", chipBandWidth(m.from, m.to)))
+	return placeCompact(m,
+		band,
+		"",
+		band,
+		"",
+		band,
+	)
+}
+
+// renderRevealCompact lands the new color and runs the digit wheel.
+func (m Model) renderRevealCompact(t float64) string {
+	titleColor := postColor
+	if t < 0.3 {
+		titleColor = styles.LerpHex(whiteHot, postColor, styles.EaseOutCubic(t/0.3))
+	}
+	wheel := RenderDigitWheel(m.from, m.to, t, m.frame)
+	chip := chipBox(wheel, postColor)
+	return placeCompact(m,
+		titleStripColored(titleColor),
+		"",
+		chip,
+	)
+}
+
+// renderFanfareCompact is the celebration: post-color chip, sparkles in a
+// thin band, "Congratulations!" headline, receipt subtitle.
+func (m Model) renderFanfareCompact(t float64) string {
+	headline := lipgloss.NewStyle().
+		Foreground(gold).
+		Bold(true).
+		Render("✨  Congratulations!  ✨")
+
+	subtitle := lipgloss.NewStyle().
+		Foreground(styles.LerpHex(dimColor, headlineFg, styles.EaseOutCubic(t))).
+		Render("ailloy " + m.from + " → " + m.to)
+
+	chip := versionChip(m.to, postColor)
+
+	// One-line sparkle band above the chip — tracks the same per-particle
+	// phase windows as the full layout but constrained to a single row.
+	sparkleRow := compactSparkleRow(m, t)
+
+	return placeCompact(m,
+		sparkleRow,
+		"",
+		chip,
+		"",
+		headline,
+		subtitle,
+	)
+}
+
+// titleStrip is the "AILLOY is evolving!" headline rendered as a styled pill.
+func titleStrip(fg lipgloss.Color) string {
+	return titleStripColored(fg)
+}
+
+func titleStripColored(fg lipgloss.Color) string {
+	return lipgloss.NewStyle().
+		Foreground(fg).
+		Bold(true).
+		Render("⚡  AILLOY is evolving  ⚡")
+}
+
+// silhouetteChip renders the version chip with all glyphs replaced by '█'
+// for the unified-white silhouette frame in the compact flash beat.
+func silhouetteChip(version string, color lipgloss.Color) string {
+	silhouette := strings.Repeat("█", lipgloss.Width(version))
+	styled := lipgloss.NewStyle().Foreground(color).Bold(true).Render(silhouette)
+	return chipBox(styled, color)
+}
+
+// chipBandWidth returns a sensible width for the white-out crack band so it
+// reads as a horizontal slash across the action.
+func chipBandWidth(from, to string) int {
+	w := lipgloss.Width(from)
+	if tw := lipgloss.Width(to); tw > w {
+		w = tw
+	}
+	return w + 8 // a little wider than the chip itself
+}
+
+// compactSparkleRow draws a single-row sparkle band above the chip during
+// fanfare, using the same per-particle phase logic as the full sparkle
+// field but flattened to one row.
+func compactSparkleRow(m Model, t float64) string {
+	const window = 0.35
+	if len(m.sparkles) == 0 {
+		return ""
+	}
+	// Width: as wide as the chip with some breathing room.
+	width := chipBandWidth(m.from, m.to)
+	cells := make([]string, width)
+	for i := range cells {
+		cells[i] = " "
+	}
+	for i, s := range m.sparkles {
+		dt := t - s.PhaseOff
+		if dt < 0 || dt > window {
+			continue
+		}
+		pos := dt / window
+		intensity := 1 - absF(pos-0.5)*2
+		if intensity <= 0 {
+			continue
+		}
+		col := (i*7 + 3) % width
+		c := styles.LerpHex(lipgloss.Color("#9aa0a6"), gold, intensity)
+		cells[col] = lipgloss.NewStyle().Foreground(c).Bold(true).Render(s.Glyph)
+	}
+	return strings.Join(cells, "")
+}
+
+// placeCompact stacks the supplied lines vertically (centered) and centers
+// the whole block within the terminal. Used by every compact-mode renderer.
+func placeCompact(m Model, parts ...string) string {
+	scene := lipgloss.JoinVertical(lipgloss.Center, parts...)
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, scene)
+}

--- a/internal/tui/splash/model.go
+++ b/internal/tui/splash/model.go
@@ -5,11 +5,11 @@
 package splash
 
 import (
-	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/nimble-giant/ailloy/internal/tui/cinematic"
 	"github.com/nimble-giant/ailloy/pkg/styles"
 )
 
@@ -46,26 +46,7 @@ type Model struct {
 // the model can center its scene; if WindowSizeMsg arrives later it will
 // adjust. Pass 0,0 if unknown — Bubble Tea will deliver dimensions on Init.
 func New(width, height int) Model {
-	art := strings.TrimLeft(styles.AilloyFox, "\n")
-	art = strings.TrimRight(art, "\n")
-	lines := strings.Split(art, "\n")
-	cols := 0
-	for _, l := range lines {
-		if w := lipgloss.Width(l); w > cols {
-			cols = w
-		}
-	}
-	// Pad every line with trailing spaces so they're all exactly `cols`
-	// wide. Without this, lipgloss centering operations (Place,
-	// JoinVertical with Center) re-center each row independently based on
-	// its rendered width — and since the fox art relies on per-row
-	// leading whitespace to express shape, that re-centering visibly
-	// skews the silhouette. Uniform width = leading whitespace preserved.
-	for i, l := range lines {
-		if pad := cols - lipgloss.Width(l); pad > 0 {
-			lines[i] = l + strings.Repeat(" ", pad)
-		}
-	}
+	lines, cols := cinematic.PadFoxLines()
 	return Model{
 		width:    width,
 		height:   height,

--- a/internal/tui/splash/scenes.go
+++ b/internal/tui/splash/scenes.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/nimble-giant/ailloy/internal/tui/cinematic"
 	"github.com/nimble-giant/ailloy/pkg/styles"
 )
 
@@ -205,12 +206,7 @@ func (m Model) renderSettle(t float64) string {
 }
 
 func (m Model) staticFox() string {
-	out := make([]string, m.foxRows)
-	style := lipgloss.NewStyle().Foreground(finalColor)
-	for i, line := range m.foxLines {
-		out[i] = style.Render(line)
-	}
-	return strings.Join(out, "\n")
+	return cinematic.RenderFoxBlock(m.foxLines, finalColor)
 }
 
 func absF(v float64) float64 {


### PR DESCRIPTION
## Description

Replaces the inline ANSI flash in \`playEvolutionAnimation\` with a Bubble Tea cinematic ("The Evolution") that runs in the alternate screen buffer after a successful \`ailloy evolve\` binary swap. Seven beats over ~5.7s: typewriter headline → pre-evolve hold → charge ripple → accelerating Pokemon flash ending in a unified white silhouette → white-out crack → fox reveal in the alloyed post-color while a slot-machine digit wheel cycles the version string from current → target → sparkle fanfare with "Congratulations!" stamp and receipt subtitle. Promotes shared rendering primitives (\`PadFoxLines\`, \`RenderFox\`/\`RenderFoxBlock\`, \`SparkleField\`) into a new \`internal/tui/cinematic\` package shared with the splash; splash refactored to use them with no behavior change.

This work was originally part of PR #169 but didn't make it into the squash merge — opening as a fresh PR off main.

## Related Issue

N/A

## Testing

- \`go build ./...\`, \`go vet ./...\`, \`gofmt -l\` clean.
- \`go test ./...\` passes (full suite, including new digit-wheel and cinematic-helper unit tests).
- Manual: \`ailloy evolve\` against a real upgrade plays the full cinematic; \`--no-animate\` and CI/non-TTY paths print the existing static \`✓ evolved into vX.Y.Z\` line.
- Manual: any keypress during the cinematic skips it instantly.

## UAT

- Run \`ailloy evolve\` against a real release upgrade (or \`ailloy evolve --version vX.Y.Z\` to pin a specific tag) in an interactive terminal — observe the seven beats land in order, hand off to scrollback with a permanent receipt line.
- \`ailloy evolve --no-animate\` to confirm the legacy fast path.
- \`ailloy evolve | cat\` and \`CI=true ailloy evolve\` to confirm zero animation noise leaks.
- Resize terminal below 80×36 and run again — splash gracefully falls back to the static line.

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [ ] I have updated documentation (if applicable)
- [ ] My commits have DCO sign-off (\`git commit -s\`)