### PR TITLE
docs: replace Pokemon references with neutral wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 * add foundry temper command for index validation ([974e33d](https://github.com/nimble-giant/ailloy/commit/974e33d652b08ca924b806998c54f7ccb6dcbba7))
 * add reinstall alias to evolve ([aa564b9](https://github.com/nimble-giant/ailloy/commit/aa564b9a1f011f6bc748eaef4d7874b11e996597))
 * nested foundries — transitive mold aggregation across foundry indexes ([d1bdd54](https://github.com/nimble-giant/ailloy/commit/d1bdd548103e9341159d26265ff508930685540b))
-* rename refine to evolve and add Pokemon-style TUI animation ([c1018a1](https://github.com/nimble-giant/ailloy/commit/c1018a16394e5200d959b7553e10183205cc578a))
+* rename refine to evolve and add retro RPG-style TUI animation ([c1018a1](https://github.com/nimble-giant/ailloy/commit/c1018a16394e5200d959b7553e10183205cc578a))
 
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ by another casted mold are retained automatically.
 <details>
 <summary><strong><code>evolve</code></strong> — self-upgrade the CLI</summary>
 
-**`ailloy evolve`** (alias: `reinstall`) — Download the latest release, verify its SHA256 against the release's `checksums.txt`, and atomically swap the running binary in place. On success, plays a Pokemon-style evolution animation; falls back to a plain success line outside a TTY.
+**`ailloy evolve`** (alias: `reinstall`) — Download the latest release, verify its SHA256 against the release's `checksums.txt`, and atomically swap the running binary in place. On success, plays a retro RPG-style evolution animation; falls back to a plain success line outside a TTY.
 
 - `--check` — Print current and latest version without installing
 - `--version vX.Y.Z` — Install or downgrade to a specific release tag

--- a/internal/commands/evolve.go
+++ b/internal/commands/evolve.go
@@ -323,11 +323,11 @@ func evolveAnimationArt() string {
 	return strings.TrimLeft(styles.AilloyFox, "\n")
 }
 
-// playEvolutionAnimation prints a Pokemon-style evolution sequence ending with
-// the new version. Flashes the AilloyFox mascot between its normal color and
-// a white silhouette, mimicking the in-game evolution effect. Falls back to a
-// plain success line when stdout is not a TTY or skip is set, so CI logs and
-// non-interactive shells stay clean.
+// playEvolutionAnimation prints a retro RPG-style evolution sequence ending
+// with the new version. Flashes the AilloyFox mascot between its normal color
+// and a white silhouette, mimicking the classic in-game evolution effect.
+// Falls back to a plain success line when stdout is not a TTY or skip is set,
+// so CI logs and non-interactive shells stay clean.
 func playEvolutionAnimation(target string, skip bool) {
 	if skip {
 		styles.SetNoAnimate(true)


### PR DESCRIPTION
## Description

Removes trademarked franchise references from the codebase. Replaces "Pokemon-style" with "retro RPG-style" in the `evolve` command's doc comment, the README's `evolve` description, and a CHANGELOG entry. No behavior or user-visible TUI strings change.

## Related Issue

N/A

## Testing

`go build ./...`, `go vet ./...`, and the full pre-push suite (`golangci-lint`, `go test -race`) pass.

## UAT

`rg -i pokemon` returns no matches; `ailloy evolve` still renders the same animation.

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [ ] I have added tests (if applicable)
- [x] I have updated documentation (if applicable)
- [x] My commits have DCO sign-off (`git commit -s`)