### PR TITLE
feat(cast): merge strategy for output files (#171)

### DIFF
--- a/docs/blanks.md
+++ b/docs/blanks.md
@@ -433,3 +433,7 @@ model: anthropic/claude-opus-4-20250514
 ```
 
 Keys in `set` may use dotted paths (`agent.current_target`) which expand to nested maps, or be nested maps directly. The fan-out form works for both directory mappings and individual file mappings.
+
+### Fan-in: many sources, one destination
+
+The mirror case — multiple molds (or multiple output entries within one mold) all writing to the same destination file — is solved by `strategy: merge`. When two molds each declare MCP server entries in `opencode.json`, by default the second cast overwrites the first; declaring `strategy: merge` deep-merges JSON/YAML destinations instead of clobbering. See [`strategy` in the flux reference](flux.md#strategy--merge-or-replace-output-files) for the value table, merge semantics (map order preservation, array concat-with-dedupe, type-mismatch rules), and the `--force-replace-on-parse-error` escape hatch for hand-edited destinations.

--- a/docs/flux.md
+++ b/docs/flux.md
@@ -210,6 +210,51 @@ output:
     process: false          # skip Go template processing
 ```
 
+### `strategy` — merge or replace output files
+
+Each output entry accepts an optional `strategy` field controlling how `cast`
+writes the destination when a file already exists:
+
+| value     | behavior                                                      |
+| --------- | ------------------------------------------------------------- |
+| (omitted) | Same as `replace`.                                            |
+| `replace` | Whole-file overwrite. Default.                                |
+| `merge`   | Deep-merge with the existing file (JSON/YAML only).           |
+
+**Use `strategy: merge` when multiple molds need to contribute to a shared
+config file.** The motivating example: several molds each declare MCP server
+entries in `opencode.json`, and the user expects them to combine instead of
+the last cast clobbering the first.
+
+```yaml
+output:
+  mcp:
+    - dest: opencode.json
+      strategy: merge
+      set:
+        agent.current_target: opencode
+```
+
+#### Merge semantics
+
+- Detected by extension (`.json`, `.yaml`, `.yml`). Other extensions silently fall back to replace.
+- **Maps**: deep-merge. Existing keys keep their position; new keys are appended.
+- **Arrays**: concat with deep-equality dedupe (base entries first, then overlay-only).
+- **Type mismatch** (e.g., scalar replaced by a map): overlay wins.
+- **Non-existent destination**: the new content is written verbatim.
+- **JSON output**: 2-space indented, key insertion order preserved, integers preserved as integers (no float coercion).
+- **YAML output**: 2-space indented, key insertion order preserved. Comments and anchors are *not guaranteed* to survive round-tripping.
+
+#### Malformed existing files
+
+If the destination is hand-edited and no longer parses as JSON/YAML, `cast`
+errors out by default to avoid clobbering the user's work. Re-run with
+`--force-replace-on-parse-error` to overwrite:
+
+```bash
+ailloy cast ./my-mold --force-replace-on-parse-error
+```
+
 ### String output
 
 All top-level directories go under a single parent:

--- a/docs/flux.md
+++ b/docs/flux.md
@@ -255,6 +255,8 @@ errors out by default to avoid clobbering the user's work. Re-run with
 ailloy cast ./my-mold --force-replace-on-parse-error
 ```
 
+The same `strategy: merge` behavior applies to `ailloy forge --output <dir>`, so iterative previews against an existing output directory merge instead of clobbering. `forge` (without `--output`) prints rendered content to stdout and is unaffected — there is no destination file to merge against.
+
 ### String output
 
 All top-level directories go under a single parent:

--- a/docs/flux.md
+++ b/docs/flux.md
@@ -215,11 +215,12 @@ output:
 Each output entry accepts an optional `strategy` field controlling how `cast`
 writes the destination when a file already exists:
 
-| value     | behavior                                                      |
-| --------- | ------------------------------------------------------------- |
-| (omitted) | Same as `replace`.                                            |
-| `replace` | Whole-file overwrite. Default.                                |
-| `merge`   | Deep-merge with the existing file (JSON/YAML only).           |
+| value     | behavior                                                                                                       |
+| --------- | -------------------------------------------------------------------------------------------------------------- |
+| (omitted) | Same as `replace`.                                                                                             |
+| `replace` | Whole-file overwrite. Default.                                                                                 |
+| `merge`   | Deep-merge with the existing file (JSON/YAML only).                                                            |
+| `append`  | Idempotent text append for markdown files. Each mold's content goes into a sentinel block keyed by mold name.  |
 
 **Use `strategy: merge` when multiple molds need to contribute to a shared
 config file.** The motivating example: several molds each declare MCP server
@@ -256,6 +257,32 @@ ailloy cast ./my-mold --force-replace-on-parse-error
 ```
 
 The same `strategy: merge` behavior applies to `ailloy forge --output <dir>`, so iterative previews against an existing output directory merge instead of clobbering. `forge` (without `--output`) prints rendered content to stdout and is unaffected — there is no destination file to merge against.
+
+#### `strategy: append` (markdown only)
+
+When multiple molds each contribute a section to a shared markdown file (e.g., a project `AGENTS.md`), declare `strategy: append`:
+
+```yaml
+output:
+  AGENTS.md:
+    dest: AGENTS.md
+    strategy: append
+```
+
+The cast pipeline wraps each mold's rendered content in a sentinel block keyed by the mold's name:
+
+```markdown
+<!-- ailloy:mold=wiki:start -->
+... wiki's content ...
+<!-- ailloy:mold=wiki:end -->
+```
+
+Re-casting the same mold updates only its block in place — no duplicates. Foreign content (hand-edited intros, prose between blocks) is preserved across re-casts. Casting two different molds into the same file produces two distinct blocks in cast order.
+
+**Limitations:**
+
+- v1 supports only `.md` and `.markdown` extensions. Other extensions return an error so authors get explicit feedback.
+- The sentinel format uses HTML comments (`<!-- ... -->`), which renders invisibly in markdown viewers but is syntactically a comment.
 
 ### String output
 

--- a/internal/commands/cast.go
+++ b/internal/commands/cast.go
@@ -292,7 +292,7 @@ func castProject(reader *blanks.MoldReader, source string) error {
 	fmt.Println()
 
 	// Copy resolved files from mold
-	if err := copyResolvedFiles(reader, manifest, flux, filesToCast); err != nil {
+	if err := copyResolvedFiles(reader, manifest, flux, filesToCast, castForceReplaceOnParseError); err != nil {
 		return fmt.Errorf("failed to copy files: %w", err)
 	}
 
@@ -609,7 +609,7 @@ func offerAgentsImport(claudePath string) {
 
 // copyResolvedFiles copies resolved mold files to the project, applying template
 // processing where indicated by the output mapping.
-func copyResolvedFiles(reader *blanks.MoldReader, manifest *mold.Mold, flux map[string]any, resolved []mold.ResolvedFile) error {
+func copyResolvedFiles(reader *blanks.MoldReader, manifest *mold.Mold, flux map[string]any, resolved []mold.ResolvedFile, forceReplaceOnParseError bool) error {
 	// Validate: prefer flux.schema.yaml, fall back to mold.yaml flux: section
 	var schema []mold.FluxVar
 	if s, err := reader.LoadFluxSchema(); err == nil && s != nil {
@@ -655,7 +655,7 @@ func copyResolvedFiles(reader *blanks.MoldReader, manifest *mold.Mold, flux map[
 		switch rf.Strategy {
 		case "merge":
 			err := merge.MergeFile(rf.DestPath, outputContent, merge.Options{
-				ForceReplaceOnParseError: castForceReplaceOnParseError,
+				ForceReplaceOnParseError: forceReplaceOnParseError,
 			})
 			if err != nil {
 				var pe *merge.ParseError

--- a/internal/commands/cast.go
+++ b/internal/commands/cast.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -19,6 +20,7 @@ import (
 	"github.com/nimble-giant/ailloy/internal/tui/ceremony"
 	"github.com/nimble-giant/ailloy/pkg/blanks"
 	"github.com/nimble-giant/ailloy/pkg/foundry"
+	"github.com/nimble-giant/ailloy/pkg/merge"
 	"github.com/nimble-giant/ailloy/pkg/mold"
 	"github.com/nimble-giant/ailloy/pkg/smelt"
 	"github.com/nimble-giant/ailloy/pkg/styles"
@@ -650,13 +652,31 @@ func copyResolvedFiles(reader *blanks.MoldReader, manifest *mold.Mold, flux map[
 			continue
 		}
 
-		if err := os.MkdirAll(filepath.Dir(rf.DestPath), 0750); err != nil { // #nosec G301
-			return fmt.Errorf("failed to create directory for %s: %w", rf.DestPath, err)
-		}
-
-		//#nosec G306 -- Blanks need to be readable
-		if err := os.WriteFile(rf.DestPath, outputContent, 0644); err != nil {
-			return fmt.Errorf("failed to write %s: %w", rf.DestPath, err)
+		switch rf.Strategy {
+		case "merge":
+			err := merge.MergeFile(rf.DestPath, outputContent, merge.Options{
+				ForceReplaceOnParseError: castForceReplaceOnParseError,
+			})
+			if err != nil {
+				var pe *merge.ParseError
+				if errors.As(err, &pe) {
+					return fmt.Errorf(
+						"failed to merge into %s: existing %s file could not be parsed: %w. "+
+							"Re-run with --force-replace-on-parse-error to overwrite",
+						pe.Path, pe.Format, pe.Err)
+				}
+				return fmt.Errorf("failed to merge %s: %w", rf.DestPath, err)
+			}
+		case "", "replace":
+			if err := os.MkdirAll(filepath.Dir(rf.DestPath), 0750); err != nil { // #nosec G301
+				return fmt.Errorf("failed to create directory for %s: %w", rf.DestPath, err)
+			}
+			//#nosec G306 -- Blanks need to be readable
+			if err := os.WriteFile(rf.DestPath, outputContent, 0644); err != nil {
+				return fmt.Errorf("failed to write %s: %w", rf.DestPath, err)
+			}
+		default:
+			return fmt.Errorf("unknown strategy %q on output for %s", rf.Strategy, rf.DestPath)
 		}
 
 		if !castSilent.Load() {

--- a/internal/commands/cast.go
+++ b/internal/commands/cast.go
@@ -667,6 +667,16 @@ func copyResolvedFiles(reader *blanks.MoldReader, manifest *mold.Mold, flux map[
 				}
 				return fmt.Errorf("failed to merge %s: %w", rf.DestPath, err)
 			}
+		case "append":
+			if manifest == nil {
+				return fmt.Errorf("append strategy requires a mold manifest with a name (dest %s)", rf.DestPath)
+			}
+			err := merge.AppendFile(rf.DestPath, outputContent, merge.AppendOptions{
+				MoldName: manifest.Name,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to append into %s: %w", rf.DestPath, err)
+			}
 		case "", "replace":
 			if err := os.MkdirAll(filepath.Dir(rf.DestPath), 0750); err != nil { // #nosec G301
 				return fmt.Errorf("failed to create directory for %s: %w", rf.DestPath, err)

--- a/internal/commands/cast.go
+++ b/internal/commands/cast.go
@@ -40,13 +40,14 @@ Use -g/--global to install into the user's home directory (~/) instead.`,
 }
 
 var (
-	withWorkflows        bool
-	castGlobal           bool
-	castSetFlags         []string
-	castValFiles         []string
-	castClaudePluginFlag bool
-	castPluginName       string
-	castPluginVer        string
+	withWorkflows                bool
+	castGlobal                   bool
+	castSetFlags                 []string
+	castValFiles                 []string
+	castClaudePluginFlag         bool
+	castPluginName               string
+	castPluginVer                string
+	castForceReplaceOnParseError bool
 	// castSilent suppresses interactive output from copyResolvedFiles and
 	// related helpers. Set by CastMold (the programmatic core used by the
 	// foundries TUI) so per-file "✅ Created" lines don't corrupt the
@@ -64,6 +65,10 @@ func init() {
 	castCmd.Flags().BoolVar(&castClaudePluginFlag, "claude-plugin", false, "package the rendered mold as a Claude Code plugin instead of installing blanks at their cast destinations")
 	castCmd.Flags().StringVar(&castPluginName, "plugin-name", "", "override the plugin name (defaults to the mold's name; requires a plugin output flag such as --claude-plugin)")
 	castCmd.Flags().StringVar(&castPluginVer, "plugin-version", "", "override the plugin version (defaults to the mold's version; requires a plugin output flag such as --claude-plugin)")
+	castCmd.Flags().BoolVar(&castForceReplaceOnParseError,
+		"force-replace-on-parse-error",
+		false,
+		"if a destination uses strategy: merge but is unparseable, replace it instead of erroring")
 }
 
 func runCast(_ *cobra.Command, args []string) error {

--- a/internal/commands/cast_core.go
+++ b/internal/commands/cast_core.go
@@ -20,7 +20,12 @@ type CastOptions struct {
 	WithWorkflows bool     // include .github/ workflow blanks
 	ValueFiles    []string // -f layered flux value files
 	SetOverrides  []string // --set key=val overrides
-	OnProgress    func(stage, item string)
+	// ForceReplaceOnParseError, when true, allows merge-strategy
+	// destinations whose existing on-disk file is unparseable to be
+	// replaced rather than erroring. Mirrors the
+	// --force-replace-on-parse-error CLI flag.
+	ForceReplaceOnParseError bool
+	OnProgress               func(stage, item string)
 
 	// ClaudePlugin packages the rendered mold as a Claude Code plugin under
 	// .claude/plugins/<slug>/ (or ~/.claude/plugins/<slug>/ when Global is set)
@@ -150,7 +155,7 @@ func CastMold(_ context.Context, ref string, opts CastOptions) (CastResult, erro
 		}
 	}
 
-	if err := copyResolvedFiles(reader, manifest, flux, filesToCast); err != nil {
+	if err := copyResolvedFiles(reader, manifest, flux, filesToCast, opts.ForceReplaceOnParseError); err != nil {
 		return res, fmt.Errorf("copying files: %w", err)
 	}
 

--- a/internal/commands/cast_e2e_test.go
+++ b/internal/commands/cast_e2e_test.go
@@ -1,0 +1,201 @@
+package commands
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// buildAilloyBinary compiles the ailloy CLI into a temp dir and returns the
+// binary path. Skips on Windows (different path semantics) and on non-go
+// environments.
+func buildAilloyBinary(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("e2e binary test currently skips Windows path conventions")
+	}
+	bin := filepath.Join(t.TempDir(), "ailloy")
+	// Compile from the project root (assumed two levels up from this file).
+	cmd := exec.Command("go", "build", "-o", bin, "./cmd/ailloy")
+	// Walk up to the repo root by finding go.mod.
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	root := wd
+	for {
+		if _, err := os.Stat(filepath.Join(root, "go.mod")); err == nil {
+			break
+		}
+		parent := filepath.Dir(root)
+		if parent == root {
+			t.Fatalf("could not find go.mod from %s", wd)
+		}
+		root = parent
+	}
+	cmd.Dir = root
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go build failed: %v\n%s", err, out)
+	}
+	return bin
+}
+
+// TestE2E_MergeStrategy_FullCLI builds the actual ailloy binary and runs
+// `ailloy cast` against an on-disk synthetic mold. Verifies that the merge
+// pipeline works end-to-end, not just at the function-call level.
+func TestE2E_MergeStrategy_FullCLI(t *testing.T) {
+	if testing.Short() {
+		t.Skip("e2e binary build is slow; skipping in -short mode")
+	}
+	bin := buildAilloyBinary(t)
+
+	// Set up a project dir to cast into.
+	projectDir := t.TempDir()
+	// Pre-seed an existing opencode.json with the "outline" MCP server.
+	preExisting := []byte(`{"mcp":{"outline":{"url":"https://outline"}}}`)
+	if err := os.WriteFile(filepath.Join(projectDir, "opencode.json"), preExisting, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Build a real on-disk mold dir.
+	moldDir := t.TempDir()
+	mustWrite := func(rel, content string) {
+		t.Helper()
+		full := filepath.Join(moldDir, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustWrite("mold.yaml", "apiVersion: v1\nkind: Mold\nname: e2e-test\nversion: 0.1.0\n")
+	mustWrite("flux.yaml", `output:
+  config/opencode.json:
+    dest: opencode.json
+    strategy: merge
+`)
+	mustWrite("config/opencode.json", `{"mcp":{"replicated-docs":{"url":"https://docs"}}}`)
+
+	// Run `ailloy cast <moldDir>` from the project dir.
+	cmd := exec.Command(bin, "cast", moldDir)
+	cmd.Dir = projectDir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("ailloy cast failed: %v\noutput:\n%s", err, out)
+	}
+
+	// Verify the merged file on disk.
+	got, err := os.ReadFile(filepath.Join(projectDir, "opencode.json"))
+	if err != nil {
+		t.Fatalf("readback: %v", err)
+	}
+	gs := string(got)
+	if !strings.Contains(gs, "outline") {
+		t.Errorf("outline missing after e2e merge:\n%s", gs)
+	}
+	if !strings.Contains(gs, "replicated-docs") {
+		t.Errorf("replicated-docs missing after e2e merge:\n%s", gs)
+	}
+	if strings.Index(gs, "outline") > strings.Index(gs, "replicated-docs") {
+		t.Errorf("expected outline before replicated-docs (base before overlay), got:\n%s", gs)
+	}
+}
+
+// TestE2E_MergeStrategy_HandEditedFileErrors confirms the user-facing CLI
+// error for an unparseable existing destination is actionable.
+func TestE2E_MergeStrategy_HandEditedFileErrors(t *testing.T) {
+	if testing.Short() {
+		t.Skip("e2e binary build is slow; skipping in -short mode")
+	}
+	bin := buildAilloyBinary(t)
+
+	projectDir := t.TempDir()
+	// Pre-seed unparseable JSON (simulates a hand-edit gone wrong).
+	if err := os.WriteFile(filepath.Join(projectDir, "opencode.json"), []byte("not json{{"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	moldDir := t.TempDir()
+	mustWrite := func(rel, content string) {
+		t.Helper()
+		full := filepath.Join(moldDir, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustWrite("mold.yaml", "apiVersion: v1\nkind: Mold\nname: e2e-test\nversion: 0.1.0\n")
+	mustWrite("flux.yaml", `output:
+  config/opencode.json:
+    dest: opencode.json
+    strategy: merge
+`)
+	mustWrite("config/opencode.json", `{"mcp":{"x":{}}}`)
+
+	// First run without the flag — should fail with actionable message.
+	cmd := exec.Command(bin, "cast", moldDir)
+	cmd.Dir = projectDir
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected non-zero exit on unparseable dest, got success.\nstdout/stderr:\n%s", out)
+	}
+	combinedOut := string(out)
+	for _, must := range []string{"opencode.json", "force-replace-on-parse-error"} {
+		if !strings.Contains(combinedOut, must) {
+			t.Errorf("CLI error must include %q for actionable UX; got:\n%s", must, combinedOut)
+		}
+	}
+
+	// Verify the unparseable file was NOT clobbered.
+	preserved, err := os.ReadFile(filepath.Join(projectDir, "opencode.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(preserved) != "not json{{" {
+		t.Errorf("hand-edited file was clobbered without --force; got:\n%s", preserved)
+	}
+
+	// Second run with the flag — should succeed and clobber.
+	cmd2 := exec.Command(bin, "cast", moldDir, "--force-replace-on-parse-error")
+	cmd2.Dir = projectDir
+	out2, err := cmd2.CombinedOutput()
+	if err != nil {
+		t.Fatalf("--force-replace-on-parse-error should succeed: %v\noutput:\n%s", err, out2)
+	}
+	finalBytes, _ := os.ReadFile(filepath.Join(projectDir, "opencode.json"))
+	// After --force-replace-on-parse-error, the unparseable existing file is
+	// discarded and the mold output is written through.
+	if !strings.Contains(string(finalBytes), `"x"`) {
+		t.Errorf("expected mold content (with mcp.x) after force-replace; got:\n%s", finalBytes)
+	}
+	if string(finalBytes) == "not json{{" {
+		t.Errorf("expected hand-edited content to be replaced after --force-replace-on-parse-error; still got:\n%s", finalBytes)
+	}
+}
+
+// TestE2E_MergeStrategy_HelpOutput verifies the new flag appears in
+// `ailloy cast --help` and `ailloy forge --help`.
+func TestE2E_MergeStrategy_HelpOutput(t *testing.T) {
+	if testing.Short() {
+		t.Skip("e2e binary build is slow; skipping in -short mode")
+	}
+	bin := buildAilloyBinary(t)
+
+	for _, sub := range []string{"cast", "forge"} {
+		t.Run(sub, func(t *testing.T) {
+			out, err := exec.Command(bin, sub, "--help").CombinedOutput()
+			if err != nil {
+				t.Fatalf("%s --help failed: %v\n%s", sub, err, out)
+			}
+			if !strings.Contains(string(out), "force-replace-on-parse-error") {
+				t.Errorf("ailloy %s --help should mention --force-replace-on-parse-error; got:\n%s", sub, out)
+			}
+		})
+	}
+}

--- a/internal/commands/cast_foundry_shape_test.go
+++ b/internal/commands/cast_foundry_shape_test.go
@@ -1,0 +1,412 @@
+package commands
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/nimble-giant/ailloy/pkg/blanks"
+	"github.com/nimble-giant/ailloy/pkg/mold"
+)
+
+// These tests replicate the exact mold shape used by
+// github.com/kriscoleman/replicated-foundry's "wiki" and "docs" molds, which
+// is the literal real-world scenario that motivated issue #171:
+//
+//   - Both molds declare an `mcp` output as a list of two entries (one for
+//     each agent target — claude, opencode), each setting
+//     `agent.current_target` so a per-target template gate selects the right
+//     payload at render time.
+//   - Both molds output to dest `.` (project root), producing `.mcp.json`
+//     for claude and `opencode.json` for opencode.
+//   - Casting both molds into the same project means the second cast writes
+//     the SAME files the first did. Without strategy: merge, the second
+//     mold's content clobbers the first.
+//
+// We replicate the shape as fstest.MapFS rather than fetching the live
+// foundry: the foundry's molds don't yet declare `strategy: merge` (this PR
+// introduces the field), and we want a deterministic test that exercises the
+// merge feature against a realistic shape on every CI run.
+
+// foundryWikiFlux mirrors molds/wiki/flux.yaml from
+// kriscoleman/replicated-foundry, with `strategy: merge` added on each MCP
+// list entry. The skills/mcp_server pieces from the real flux are dropped to
+// keep the test focused on the merge surface.
+const foundryWikiFlux = `agent:
+  targets:
+    - claude
+    - opencode
+
+output:
+  mcp:
+    - dest: .
+      strategy: merge
+      set:
+        agent.current_target: claude
+    - dest: .
+      strategy: merge
+      set:
+        agent.current_target: opencode
+`
+
+const foundryDocsFlux = `agent:
+  targets:
+    - claude
+    - opencode
+
+output:
+  mcp:
+    - dest: .
+      strategy: merge
+      set:
+        agent.current_target: claude
+    - dest: .
+      strategy: merge
+      set:
+        agent.current_target: opencode
+`
+
+// foundryWikiMcpClaude mirrors molds/wiki/mcp/.mcp.json from the real foundry.
+const foundryWikiMcpClaude = `{{- if and (eq .agent.current_target "claude") (has "claude" .agent.targets) -}}
+{
+  "mcpServers": {
+    "outline": {
+      "command": "node",
+      "args": [".wiki-mcp-server/dist/index.js"],
+      "env": {
+        "OUTLINE_API_KEY": ""
+      }
+    }
+  }
+}
+{{- end -}}`
+
+// foundryWikiMcpOpencode mirrors molds/wiki/mcp/opencode.json.
+const foundryWikiMcpOpencode = `{{- if and (eq .agent.current_target "opencode") (has "opencode" .agent.targets) -}}
+{
+  "mcp": {
+    "outline": {
+      "type": "local",
+      "command": ["node", ".wiki-mcp-server/dist/index.js"],
+      "enabled": true,
+      "environment": {
+        "OUTLINE_API_KEY": ""
+      }
+    }
+  }
+}
+{{- end -}}`
+
+// foundryDocsMcpClaude mirrors molds/docs/mcp/.mcp.json.
+const foundryDocsMcpClaude = `{{- if and (eq .agent.current_target "claude") (has "claude" .agent.targets) -}}
+{
+  "mcpServers": {
+    "replicated-docs": {
+      "type": "http",
+      "url": "https://replicated-docs-mcp.justicepwhite.workers.dev/mcp"
+    }
+  }
+}
+{{- end -}}`
+
+// foundryDocsMcpOpencode mirrors molds/docs/mcp/opencode.json.
+const foundryDocsMcpOpencode = `{{- if and (eq .agent.current_target "opencode") (has "opencode" .agent.targets) -}}
+{
+  "mcp": {
+    "replicated-docs": {
+      "type": "remote",
+      "url": "https://replicated-docs-mcp.justicepwhite.workers.dev/mcp",
+      "enabled": true
+    }
+  }
+}
+{{- end -}}`
+
+func castFoundryMold(t *testing.T, fs fstest.MapFS) {
+	t.Helper()
+	reader := blanks.NewMoldReader(fs)
+	manifest, err := reader.LoadManifest()
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+	flux, err := reader.LoadFluxDefaults()
+	if err != nil {
+		t.Fatalf("load flux: %v", err)
+	}
+	resolved, err := mold.ResolveFiles(flux["output"], reader.FS())
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if err := copyResolvedFiles(reader, manifest, flux, resolved, false); err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+}
+
+// TestIntegration_ReplicatedFoundryShape_WithMerge: literal acceptance
+// criterion of issue #171. Two molds matching the kriscoleman/replicated-foundry
+// wiki + docs shape, both casting into the same project with both
+// agent.targets enabled. After both casts, .mcp.json and opencode.json must
+// each contain both MCP servers (outline AND replicated-docs).
+func TestIntegration_ReplicatedFoundryShape_WithMerge(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	wiki := fstest.MapFS{
+		"mold.yaml":         &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: Mold\nname: wiki\nversion: 0.1.0\n")},
+		"flux.yaml":         &fstest.MapFile{Data: []byte(foundryWikiFlux)},
+		"mcp/.mcp.json":     &fstest.MapFile{Data: []byte(foundryWikiMcpClaude)},
+		"mcp/opencode.json": &fstest.MapFile{Data: []byte(foundryWikiMcpOpencode)},
+	}
+	docs := fstest.MapFS{
+		"mold.yaml":         &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: Mold\nname: docs\nversion: 0.1.0\n")},
+		"flux.yaml":         &fstest.MapFile{Data: []byte(foundryDocsFlux)},
+		"mcp/.mcp.json":     &fstest.MapFile{Data: []byte(foundryDocsMcpClaude)},
+		"mcp/opencode.json": &fstest.MapFile{Data: []byte(foundryDocsMcpOpencode)},
+	}
+
+	// Cast in the order a foundries TUI would: wiki first, docs second.
+	castFoundryMold(t, wiki)
+	castFoundryMold(t, docs)
+
+	// .mcp.json (claude target) must contain BOTH outline and replicated-docs.
+	mcpBytes, err := os.ReadFile(".mcp.json")
+	if err != nil {
+		t.Fatalf("readback .mcp.json: %v", err)
+	}
+	mcp := map[string]any{}
+	if err := json.Unmarshal(mcpBytes, &mcp); err != nil {
+		t.Fatalf(".mcp.json invalid JSON after merge: %v\ncontent:\n%s", err, mcpBytes)
+	}
+	mcpServers, ok := mcp["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatalf(".mcp.json missing mcpServers key: %s", mcpBytes)
+	}
+	if _, ok := mcpServers["outline"]; !ok {
+		t.Errorf("wiki's outline MCP server lost from .mcp.json:\n%s", mcpBytes)
+	}
+	if _, ok := mcpServers["replicated-docs"]; !ok {
+		t.Errorf("docs's replicated-docs MCP server missing from .mcp.json:\n%s", mcpBytes)
+	}
+
+	// opencode.json must contain BOTH outline and replicated-docs under "mcp".
+	openBytes, err := os.ReadFile("opencode.json")
+	if err != nil {
+		t.Fatalf("readback opencode.json: %v", err)
+	}
+	open := map[string]any{}
+	if err := json.Unmarshal(openBytes, &open); err != nil {
+		t.Fatalf("opencode.json invalid JSON after merge: %v\ncontent:\n%s", err, openBytes)
+	}
+	openServers, ok := open["mcp"].(map[string]any)
+	if !ok {
+		t.Fatalf("opencode.json missing mcp key: %s", openBytes)
+	}
+	if _, ok := openServers["outline"]; !ok {
+		t.Errorf("wiki's outline MCP server lost from opencode.json:\n%s", openBytes)
+	}
+	if _, ok := openServers["replicated-docs"]; !ok {
+		t.Errorf("docs's replicated-docs MCP server missing from opencode.json:\n%s", openBytes)
+	}
+
+	// Source order: wiki cast first, so outline must precede replicated-docs.
+	mcpStr := string(mcpBytes)
+	if strings.Index(mcpStr, "outline") > strings.Index(mcpStr, "replicated-docs") {
+		t.Errorf("expected outline before replicated-docs in .mcp.json (base before overlay):\n%s", mcpStr)
+	}
+}
+
+// TestIntegration_ReplicatedFoundryShape_WithoutMerge_DemonstratesClobbering:
+// the SAME mold pair without strategy: merge declared. Documents the
+// pre-fix behavior — the second cast clobbers the first — which is the
+// regression we're protecting against.
+//
+// This is a baseline test: it asserts that without the merge feature, the
+// motivating bug exists. If a future refactor accidentally enables merge
+// implicitly (e.g., by changing the default), this test fails and we
+// re-evaluate.
+func TestIntegration_ReplicatedFoundryShape_WithoutMerge_DemonstratesClobbering(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	noMergeFlux := strings.ReplaceAll(foundryWikiFlux, "      strategy: merge\n", "")
+
+	wiki := fstest.MapFS{
+		"mold.yaml":         &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: Mold\nname: wiki\nversion: 0.1.0\n")},
+		"flux.yaml":         &fstest.MapFile{Data: []byte(noMergeFlux)},
+		"mcp/.mcp.json":     &fstest.MapFile{Data: []byte(foundryWikiMcpClaude)},
+		"mcp/opencode.json": &fstest.MapFile{Data: []byte(foundryWikiMcpOpencode)},
+	}
+	docs := fstest.MapFS{
+		"mold.yaml":         &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: Mold\nname: docs\nversion: 0.1.0\n")},
+		"flux.yaml":         &fstest.MapFile{Data: []byte(noMergeFlux)},
+		"mcp/.mcp.json":     &fstest.MapFile{Data: []byte(foundryDocsMcpClaude)},
+		"mcp/opencode.json": &fstest.MapFile{Data: []byte(foundryDocsMcpOpencode)},
+	}
+
+	castFoundryMold(t, wiki)
+	castFoundryMold(t, docs)
+
+	mcpBytes, err := os.ReadFile(".mcp.json")
+	if err != nil {
+		t.Fatalf("readback .mcp.json: %v", err)
+	}
+	mcp := map[string]any{}
+	if err := json.Unmarshal(mcpBytes, &mcp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	mcpServers := mcp["mcpServers"].(map[string]any)
+
+	// Without merge: only the LAST cast's content survives.
+	if _, ok := mcpServers["outline"]; ok {
+		t.Errorf("regression: without strategy: merge, wiki's outline should have been clobbered, but it's still present:\n%s", mcpBytes)
+	}
+	if _, ok := mcpServers["replicated-docs"]; !ok {
+		t.Errorf("docs's replicated-docs missing from .mcp.json after second cast:\n%s", mcpBytes)
+	}
+}
+
+// TestIntegration_ReplicatedFoundryShape_SingleTargetOnly: variant where
+// only one agent.target is enabled. The opencode list entry's template
+// renders to empty content (the if-block is false), so it should be skipped.
+// Only .mcp.json is produced. Verifies merge still works in the simpler
+// single-target case.
+func TestIntegration_ReplicatedFoundryShape_SingleTargetOnly(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	// Same flux but only claude target enabled.
+	singleTargetFlux := strings.ReplaceAll(foundryWikiFlux, "    - opencode\n", "")
+
+	wiki := fstest.MapFS{
+		"mold.yaml":         &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: Mold\nname: wiki\nversion: 0.1.0\n")},
+		"flux.yaml":         &fstest.MapFile{Data: []byte(singleTargetFlux)},
+		"mcp/.mcp.json":     &fstest.MapFile{Data: []byte(foundryWikiMcpClaude)},
+		"mcp/opencode.json": &fstest.MapFile{Data: []byte(foundryWikiMcpOpencode)},
+	}
+	docs := fstest.MapFS{
+		"mold.yaml":         &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: Mold\nname: docs\nversion: 0.1.0\n")},
+		"flux.yaml":         &fstest.MapFile{Data: []byte(singleTargetFlux)},
+		"mcp/.mcp.json":     &fstest.MapFile{Data: []byte(foundryDocsMcpClaude)},
+		"mcp/opencode.json": &fstest.MapFile{Data: []byte(foundryDocsMcpOpencode)},
+	}
+
+	castFoundryMold(t, wiki)
+	castFoundryMold(t, docs)
+
+	// Only .mcp.json should exist — opencode.json renders to empty.
+	if _, err := os.Stat("opencode.json"); err == nil {
+		t.Error("opencode.json should not exist when only claude target enabled")
+	}
+
+	mcpBytes, err := os.ReadFile(".mcp.json")
+	if err != nil {
+		t.Fatalf("readback: %v", err)
+	}
+	mcp := map[string]any{}
+	if err := json.Unmarshal(mcpBytes, &mcp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	mcpServers := mcp["mcpServers"].(map[string]any)
+	if _, ok := mcpServers["outline"]; !ok {
+		t.Errorf("outline missing in single-target mode:\n%s", mcpBytes)
+	}
+	if _, ok := mcpServers["replicated-docs"]; !ok {
+		t.Errorf("replicated-docs missing in single-target mode:\n%s", mcpBytes)
+	}
+}
+
+// TestIntegration_ReplicatedFoundryShape_ThreeMolds: a more demanding scenario
+// — three molds all writing to the same destination files. Verifies merge
+// behaves transitively (mold C reads the result of mold A + mold B).
+func TestIntegration_ReplicatedFoundryShape_ThreeMolds(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	supportClaude := `{{- if and (eq .agent.current_target "claude") (has "claude" .agent.targets) -}}
+{
+  "mcpServers": {
+    "support": {
+      "type": "http",
+      "url": "https://support-mcp.example.com/mcp"
+    }
+  }
+}
+{{- end -}}`
+	supportOpencode := `{{- if and (eq .agent.current_target "opencode") (has "opencode" .agent.targets) -}}
+{
+  "mcp": {
+    "support": {
+      "type": "remote",
+      "url": "https://support-mcp.example.com/mcp",
+      "enabled": true
+    }
+  }
+}
+{{- end -}}`
+
+	for _, m := range []fstest.MapFS{
+		{
+			"mold.yaml":         &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: Mold\nname: wiki\nversion: 0.1.0\n")},
+			"flux.yaml":         &fstest.MapFile{Data: []byte(foundryWikiFlux)},
+			"mcp/.mcp.json":     &fstest.MapFile{Data: []byte(foundryWikiMcpClaude)},
+			"mcp/opencode.json": &fstest.MapFile{Data: []byte(foundryWikiMcpOpencode)},
+		},
+		{
+			"mold.yaml":         &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: Mold\nname: docs\nversion: 0.1.0\n")},
+			"flux.yaml":         &fstest.MapFile{Data: []byte(foundryDocsFlux)},
+			"mcp/.mcp.json":     &fstest.MapFile{Data: []byte(foundryDocsMcpClaude)},
+			"mcp/opencode.json": &fstest.MapFile{Data: []byte(foundryDocsMcpOpencode)},
+		},
+		{
+			"mold.yaml":         &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: Mold\nname: support\nversion: 0.1.0\n")},
+			"flux.yaml":         &fstest.MapFile{Data: []byte(foundryDocsFlux)},
+			"mcp/.mcp.json":     &fstest.MapFile{Data: []byte(supportClaude)},
+			"mcp/opencode.json": &fstest.MapFile{Data: []byte(supportOpencode)},
+		},
+	} {
+		castFoundryMold(t, m)
+	}
+
+	mcpBytes, err := os.ReadFile(filepath.Join(".", ".mcp.json"))
+	if err != nil {
+		t.Fatalf("readback .mcp.json: %v", err)
+	}
+	mcp := map[string]any{}
+	if err := json.Unmarshal(mcpBytes, &mcp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	servers := mcp["mcpServers"].(map[string]any)
+	for _, want := range []string{"outline", "replicated-docs", "support"} {
+		if _, ok := servers[want]; !ok {
+			t.Errorf("server %q missing after three-mold cast:\n%s", want, mcpBytes)
+		}
+	}
+
+	// Order: wiki (outline) < docs (replicated-docs) < support.
+	mcpStr := string(mcpBytes)
+	posOutline := strings.Index(mcpStr, "outline")
+	posDocs := strings.Index(mcpStr, "replicated-docs")
+	posSupport := strings.Index(mcpStr, "support")
+	if posOutline >= posDocs || posDocs >= posSupport {
+		t.Errorf("expected source order outline < replicated-docs < support, got positions %d/%d/%d in:\n%s", posOutline, posDocs, posSupport, mcpStr)
+	}
+}

--- a/internal/commands/cast_integration_test.go
+++ b/internal/commands/cast_integration_test.go
@@ -563,3 +563,62 @@ func TestIntegration_WorkflowsNotProcessed(t *testing.T) {
 		}
 	}
 }
+
+func TestIntegration_MergeStrategy_JSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	// Pre-seed an existing opencode.json with the "outline" MCP server.
+	preExisting := []byte(`{"mcp":{"outline":{"url":"https://outline"}}}`)
+	if err := os.WriteFile("opencode.json", preExisting, 0644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Build a synthetic mold that produces opencode.json with strategy: merge.
+	moldFS := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: Mold\nname: test\nversion: 0.1.0\n")},
+		"flux.yaml": &fstest.MapFile{Data: []byte(`output:
+  config/opencode.json:
+    dest: opencode.json
+    strategy: merge
+`)},
+		"config/opencode.json": &fstest.MapFile{Data: []byte(`{"mcp":{"replicated-docs":{"url":"https://docs"}}}`)},
+	}
+
+	reader := blanks.NewMoldReader(moldFS)
+	manifest, err := reader.LoadManifest()
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+	flux, err := reader.LoadFluxDefaults()
+	if err != nil {
+		t.Fatalf("load flux: %v", err)
+	}
+	resolved, err := mold.ResolveFiles(flux["output"], reader.FS())
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if err := copyResolvedFiles(reader, manifest, flux, resolved); err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+
+	got, err := os.ReadFile("opencode.json")
+	if err != nil {
+		t.Fatalf("readback: %v", err)
+	}
+	gs := string(got)
+	if !strings.Contains(gs, `"outline"`) {
+		t.Errorf("outline missing after merge:\n%s", gs)
+	}
+	if !strings.Contains(gs, `"replicated-docs"`) {
+		t.Errorf("replicated-docs missing after merge:\n%s", gs)
+	}
+	// Order: outline comes first (from pre-existing file).
+	if strings.Index(gs, "outline") > strings.Index(gs, "replicated-docs") {
+		t.Errorf("expected outline before replicated-docs, got:\n%s", gs)
+	}
+}

--- a/internal/commands/cast_integration_test.go
+++ b/internal/commands/cast_integration_test.go
@@ -763,7 +763,7 @@ func TestIntegration_Forge_MergeStrategy(t *testing.T) {
 			strategy: "merge",
 		},
 	}
-	if err := writeForgeFiles(files, outputDir, false); err != nil {
+	if err := writeForgeFiles(files, outputDir, false, "test"); err != nil {
 		t.Fatalf("writeForgeFiles: %v", err)
 	}
 	got, _ := os.ReadFile(dest)
@@ -992,5 +992,150 @@ func TestIntegration_MergeStrategy_NestedDestPath(t *testing.T) {
 	}
 	if _, err := os.Stat("nested/sub/dir/config.json"); err != nil {
 		t.Errorf("expected nested dest file to exist: %v", err)
+	}
+}
+
+// TestIntegration_AppendStrategy_TwoMoldsContributeToAGENTS verifies the
+// motivating use case: two molds each declare strategy: append on AGENTS.md;
+// after both casts, the file contains both molds' content in distinct
+// sentinel blocks.
+func TestIntegration_AppendStrategy_TwoMoldsContributeToAGENTS(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	wikiAgents := []byte("# wiki\n\nWiki agent instructions.")
+	docsAgents := []byte("# docs\n\nDocs agent instructions.")
+
+	wiki := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: Mold\nname: wiki\nversion: 0.1.0\n")},
+		"flux.yaml": &fstest.MapFile{Data: []byte(`output:
+  AGENTS.md:
+    dest: AGENTS.md
+    strategy: append
+`)},
+		"AGENTS.md": &fstest.MapFile{Data: wikiAgents},
+	}
+	docs := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: Mold\nname: docs\nversion: 0.1.0\n")},
+		"flux.yaml": &fstest.MapFile{Data: []byte(`output:
+  AGENTS.md:
+    dest: AGENTS.md
+    strategy: append
+`)},
+		"AGENTS.md": &fstest.MapFile{Data: docsAgents},
+	}
+
+	for _, m := range []fstest.MapFS{wiki, docs} {
+		reader := blanks.NewMoldReader(m)
+		manifest, err := reader.LoadManifest()
+		if err != nil {
+			t.Fatalf("load manifest: %v", err)
+		}
+		flux, err := reader.LoadFluxDefaults()
+		if err != nil {
+			t.Fatalf("load flux: %v", err)
+		}
+		resolved, err := mold.ResolveFiles(flux["output"], reader.FS())
+		if err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		if err := copyResolvedFiles(reader, manifest, flux, resolved, false); err != nil {
+			t.Fatalf("copy: %v", err)
+		}
+	}
+
+	got, err := os.ReadFile("AGENTS.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	gs := string(got)
+	for _, want := range []string{
+		"<!-- ailloy:mold=wiki:start -->",
+		"<!-- ailloy:mold=wiki:end -->",
+		"<!-- ailloy:mold=docs:start -->",
+		"<!-- ailloy:mold=docs:end -->",
+		"Wiki agent instructions.",
+		"Docs agent instructions.",
+	} {
+		if !strings.Contains(gs, want) {
+			t.Errorf("missing %q in AGENTS.md after append:\n%s", want, gs)
+		}
+	}
+}
+
+// TestIntegration_AppendStrategy_RecastIsIdempotent verifies that re-casting
+// the same mold updates its sentinel block in place rather than appending
+// a duplicate.
+func TestIntegration_AppendStrategy_RecastIsIdempotent(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	wiki := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: Mold\nname: wiki\nversion: 0.1.0\n")},
+		"flux.yaml": &fstest.MapFile{Data: []byte(`output:
+  AGENTS.md:
+    dest: AGENTS.md
+    strategy: append
+`)},
+		"AGENTS.md": &fstest.MapFile{Data: []byte("# wiki v1")},
+	}
+
+	castOnce := func() {
+		reader := blanks.NewMoldReader(wiki)
+		manifest, _ := reader.LoadManifest()
+		flux, _ := reader.LoadFluxDefaults()
+		resolved, _ := mold.ResolveFiles(flux["output"], reader.FS())
+		if err := copyResolvedFiles(reader, manifest, flux, resolved, false); err != nil {
+			t.Fatal(err)
+		}
+	}
+	castOnce()
+	castOnce()
+	castOnce()
+
+	got, _ := os.ReadFile("AGENTS.md")
+	gs := string(got)
+	if strings.Count(gs, "wiki:start") != 1 {
+		t.Errorf("re-cast duplicated sentinel block:\n%s", gs)
+	}
+}
+
+// TestIntegration_AppendStrategy_NonMarkdownErrors verifies that strategy:
+// append on a non-markdown file errors clearly.
+func TestIntegration_AppendStrategy_NonMarkdownErrors(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	moldFS := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: Mold\nname: t\nversion: 0.1.0\n")},
+		"flux.yaml": &fstest.MapFile{Data: []byte(`output:
+  src/config.json:
+    dest: config.json
+    strategy: append
+`)},
+		"src/config.json": &fstest.MapFile{Data: []byte(`{"x":1}`)},
+	}
+	reader := blanks.NewMoldReader(moldFS)
+	manifest, _ := reader.LoadManifest()
+	flux, _ := reader.LoadFluxDefaults()
+	resolved, _ := mold.ResolveFiles(flux["output"], reader.FS())
+	err := copyResolvedFiles(reader, manifest, flux, resolved, false)
+	if err == nil {
+		t.Fatal("expected error for append on non-markdown file, got nil")
+	}
+	if !strings.Contains(err.Error(), ".md") {
+		t.Errorf("error should explain markdown limitation; got: %v", err)
 	}
 }

--- a/internal/commands/cast_integration_test.go
+++ b/internal/commands/cast_integration_test.go
@@ -772,3 +772,225 @@ func TestIntegration_Forge_MergeStrategy(t *testing.T) {
 		t.Errorf("forge merge lost an entry, got: %s", gs)
 	}
 }
+
+// TestIntegration_MergeStrategy_MultiDestList: an output entry uses the LIST
+// form — strategy must propagate per-list-entry, not be applied uniformly.
+func TestIntegration_MergeStrategy_MultiDestList(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	if err := os.WriteFile("merged.json", []byte(`{"keep":"existing"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile("replaced.json", []byte(`{"will":"vanish"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	moldFS := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: Mold\nname: t\nversion: 0.1.0\n")},
+		"flux.yaml": &fstest.MapFile{Data: []byte(`output:
+  src/config.json:
+    - dest: merged.json
+      strategy: merge
+    - dest: replaced.json
+      strategy: replace
+`)},
+		"src/config.json": &fstest.MapFile{Data: []byte(`{"new":"value"}`)},
+	}
+
+	reader := blanks.NewMoldReader(moldFS)
+	manifest, err := reader.LoadManifest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	flux, err := reader.LoadFluxDefaults()
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolved, err := mold.ResolveFiles(flux["output"], reader.FS())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := copyResolvedFiles(reader, manifest, flux, resolved, false); err != nil {
+		t.Fatal(err)
+	}
+
+	mergedBytes, _ := os.ReadFile("merged.json")
+	merged := string(mergedBytes)
+	if !strings.Contains(merged, "keep") {
+		t.Errorf("merged.json should retain 'keep' from base; got: %s", merged)
+	}
+	if !strings.Contains(merged, "new") {
+		t.Errorf("merged.json should include 'new' from overlay; got: %s", merged)
+	}
+
+	replacedBytes, _ := os.ReadFile("replaced.json")
+	replaced := string(replacedBytes)
+	if strings.Contains(replaced, "vanish") {
+		t.Errorf("replaced.json should NOT retain old content; got: %s", replaced)
+	}
+	if !strings.Contains(replaced, "new") {
+		t.Errorf("replaced.json should have new content; got: %s", replaced)
+	}
+}
+
+// TestIntegration_MergeStrategy_NonMergeableExt: strategy: merge on an
+// extension we don't know how to merge silently falls back to replace.
+func TestIntegration_MergeStrategy_NonMergeableExt(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	if err := os.WriteFile("README.md", []byte("# Old"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	moldFS := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: Mold\nname: t\nversion: 0.1.0\n")},
+		"flux.yaml": &fstest.MapFile{Data: []byte(`output:
+  README.md:
+    dest: README.md
+    strategy: merge
+`)},
+		"README.md": &fstest.MapFile{Data: []byte("# New")},
+	}
+
+	reader := blanks.NewMoldReader(moldFS)
+	manifest, _ := reader.LoadManifest()
+	flux, _ := reader.LoadFluxDefaults()
+	resolved, err := mold.ResolveFiles(flux["output"], reader.FS())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := copyResolvedFiles(reader, manifest, flux, resolved, false); err != nil {
+		t.Fatalf("non-mergeable ext should silently replace, not error: %v", err)
+	}
+
+	got, _ := os.ReadFile("README.md")
+	if string(got) != "# New" {
+		t.Errorf("expected '# New' (replaced), got: %s", got)
+	}
+}
+
+// TestIntegration_MergeStrategy_CrossFormatMisconfig: mold renders YAML
+// content into a .json destination with strategy: merge. The JSON loader
+// fails on YAML syntax. New-content parse errors are programmer/template
+// bugs, NOT user-edit issues, so the error must NOT suggest force-replace.
+func TestIntegration_MergeStrategy_CrossFormatMisconfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	if err := os.WriteFile("config.json", []byte(`{"valid":"json"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	moldFS := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: Mold\nname: t\nversion: 0.1.0\n")},
+		"flux.yaml": &fstest.MapFile{Data: []byte(`output:
+  src/config.yaml:
+    dest: config.json
+    strategy: merge
+`)},
+		"src/config.yaml": &fstest.MapFile{Data: []byte("yaml_key: yaml_value\n")},
+	}
+
+	reader := blanks.NewMoldReader(moldFS)
+	manifest, _ := reader.LoadManifest()
+	flux, _ := reader.LoadFluxDefaults()
+	resolved, err := mold.ResolveFiles(flux["output"], reader.FS())
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = copyResolvedFiles(reader, manifest, flux, resolved, false)
+	if err == nil {
+		t.Fatal("expected error for YAML content into .json dest, got nil")
+	}
+	if strings.Contains(err.Error(), "force-replace-on-parse-error") {
+		t.Errorf("template-bug errors should not suggest force-replace flag; got: %v", err)
+	}
+}
+
+// TestIntegration_MergeStrategy_ErrorMessageActionable: when an existing
+// destination is unparseable, the cast user-facing error must literally
+// include the dest path, the format ("json" or "yaml"), and the flag name.
+func TestIntegration_MergeStrategy_ErrorMessageActionable(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	dest := "opencode.json"
+	if err := os.WriteFile(dest, []byte("not json{{"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	moldFS := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: Mold\nname: t\nversion: 0.1.0\n")},
+		"flux.yaml": &fstest.MapFile{Data: []byte(`output:
+  src/opencode.json:
+    dest: opencode.json
+    strategy: merge
+`)},
+		"src/opencode.json": &fstest.MapFile{Data: []byte(`{"mcp":{"x":{}}}`)},
+	}
+	reader := blanks.NewMoldReader(moldFS)
+	manifest, _ := reader.LoadManifest()
+	flux, _ := reader.LoadFluxDefaults()
+	resolved, _ := mold.ResolveFiles(flux["output"], reader.FS())
+
+	err := copyResolvedFiles(reader, manifest, flux, resolved, false)
+	if err == nil {
+		t.Fatal("expected error for unparseable existing file, got nil")
+	}
+	msg := err.Error()
+	for _, must := range []string{"opencode.json", "json", "force-replace-on-parse-error"} {
+		if !strings.Contains(msg, must) {
+			t.Errorf("error message must include %q; got:\n%s", must, msg)
+		}
+	}
+}
+
+// TestIntegration_MergeStrategy_NestedDestPath: dest in a non-existent
+// subdirectory; MergeFile must create the parent dir.
+func TestIntegration_MergeStrategy_NestedDestPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	moldFS := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: Mold\nname: t\nversion: 0.1.0\n")},
+		"flux.yaml": &fstest.MapFile{Data: []byte(`output:
+  src/config.json:
+    dest: nested/sub/dir/config.json
+    strategy: merge
+`)},
+		"src/config.json": &fstest.MapFile{Data: []byte(`{"a":1}`)},
+	}
+	reader := blanks.NewMoldReader(moldFS)
+	manifest, _ := reader.LoadManifest()
+	flux, _ := reader.LoadFluxDefaults()
+	resolved, _ := mold.ResolveFiles(flux["output"], reader.FS())
+
+	if err := copyResolvedFiles(reader, manifest, flux, resolved, false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat("nested/sub/dir/config.json"); err != nil {
+		t.Errorf("expected nested dest file to exist: %v", err)
+	}
+}

--- a/internal/commands/cast_integration_test.go
+++ b/internal/commands/cast_integration_test.go
@@ -622,3 +622,62 @@ func TestIntegration_MergeStrategy_JSON(t *testing.T) {
 		t.Errorf("expected outline before replicated-docs, got:\n%s", gs)
 	}
 }
+
+func TestIntegration_MergeStrategy_TwoMolds(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	moldA := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: Mold\nname: a\nversion: 0.1.0\n")},
+		"flux.yaml": &fstest.MapFile{Data: []byte(`output:
+  config/opencode.json:
+    dest: opencode.json
+    strategy: merge
+`)},
+		"config/opencode.json": &fstest.MapFile{Data: []byte(`{"mcp":{"outline":{"url":"https://outline"}}}`)},
+	}
+	moldB := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: Mold\nname: b\nversion: 0.1.0\n")},
+		"flux.yaml": &fstest.MapFile{Data: []byte(`output:
+  config/opencode.json:
+    dest: opencode.json
+    strategy: merge
+`)},
+		"config/opencode.json": &fstest.MapFile{Data: []byte(`{"mcp":{"replicated-docs":{"url":"https://docs"}}}`)},
+	}
+
+	for _, m := range []fstest.MapFS{moldA, moldB} {
+		reader := blanks.NewMoldReader(m)
+		manifest, err := reader.LoadManifest()
+		if err != nil {
+			t.Fatalf("load manifest: %v", err)
+		}
+		flux, err := reader.LoadFluxDefaults()
+		if err != nil {
+			t.Fatalf("load flux: %v", err)
+		}
+		resolved, err := mold.ResolveFiles(flux["output"], reader.FS())
+		if err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		if err := copyResolvedFiles(reader, manifest, flux, resolved); err != nil {
+			t.Fatalf("copy: %v", err)
+		}
+	}
+
+	got, err := os.ReadFile("opencode.json")
+	if err != nil {
+		t.Fatalf("readback: %v", err)
+	}
+	gs := string(got)
+	if !strings.Contains(gs, `"outline"`) {
+		t.Errorf("mold A's outline lost:\n%s", gs)
+	}
+	if !strings.Contains(gs, `"replicated-docs"`) {
+		t.Errorf("mold B's replicated-docs missing:\n%s", gs)
+	}
+}

--- a/internal/commands/cast_integration_test.go
+++ b/internal/commands/cast_integration_test.go
@@ -736,3 +736,39 @@ func TestIntegration_MergeStrategy_ForceReplaceOnParseError(t *testing.T) {
 		t.Errorf("force-replace should write new content; got: %s", got)
 	}
 }
+
+func TestIntegration_Forge_MergeStrategy(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	outputDir := filepath.Join(tmpDir, "preview")
+	if err := os.MkdirAll(outputDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	// Pre-seed an existing opencode.json under the output dir to simulate an
+	// iterative forge preview.
+	dest := filepath.Join(outputDir, "opencode.json")
+	if err := os.WriteFile(dest, []byte(`{"mcp":{"outline":{"url":"https://outline"}}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	files := []renderedFile{
+		{
+			destPath: "opencode.json",
+			content:  `{"mcp":{"replicated-docs":{"url":"https://docs"}}}`,
+			strategy: "merge",
+		},
+	}
+	if err := writeForgeFiles(files, outputDir, false); err != nil {
+		t.Fatalf("writeForgeFiles: %v", err)
+	}
+	got, _ := os.ReadFile(dest)
+	gs := string(got)
+	if !strings.Contains(gs, "outline") || !strings.Contains(gs, "replicated-docs") {
+		t.Errorf("forge merge lost an entry, got: %s", gs)
+	}
+}

--- a/internal/commands/cast_integration_test.go
+++ b/internal/commands/cast_integration_test.go
@@ -61,7 +61,7 @@ func TestIntegration_CopyResolvedFiles(t *testing.T) {
 		t.Fatal("expected resolved files, got none")
 	}
 
-	err = copyResolvedFiles(reader, manifest, flux, resolved)
+	err = copyResolvedFiles(reader, manifest, flux, resolved, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -124,7 +124,7 @@ func TestIntegration_CopyResolvedFiles_WithVariableSubstitution(t *testing.T) {
 		}
 	}
 
-	err = copyResolvedFiles(reader, manifest, flux, processable)
+	err = copyResolvedFiles(reader, manifest, flux, processable, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -163,7 +163,7 @@ func TestIntegration_ResolvedFilesMatchMold(t *testing.T) {
 		t.Fatalf("failed to resolve files: %v", err)
 	}
 
-	err = copyResolvedFiles(reader, manifest, flux, resolved)
+	err = copyResolvedFiles(reader, manifest, flux, resolved, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -228,7 +228,7 @@ func TestCopyResolvedFiles_SkipsEmptyRenderedFiles(t *testing.T) {
 		{SrcPath: "commands/nonempty.md", DestPath: filepath.Join(tmpDir, ".claude/commands/nonempty.md"), Process: true},
 	}
 
-	err := copyResolvedFiles(reader, nil, map[string]any{}, resolved)
+	err := copyResolvedFiles(reader, nil, map[string]any{}, resolved, false)
 	if err != nil {
 		t.Fatalf("copyResolvedFiles failed: %v", err)
 	}
@@ -346,7 +346,7 @@ func TestCopyResolvedFiles_RemovesEmptyMultiDestDirs(t *testing.T) {
 		}
 	}
 
-	if err := copyResolvedFiles(reader, nil, map[string]any{}, resolved); err != nil {
+	if err := copyResolvedFiles(reader, nil, map[string]any{}, resolved, false); err != nil {
 		t.Fatalf("copyResolvedFiles failed: %v", err)
 	}
 
@@ -423,7 +423,7 @@ func TestIntegration_FilePermissions(t *testing.T) {
 		t.Fatalf("failed to resolve files: %v", err)
 	}
 
-	err = copyResolvedFiles(reader, manifest, flux, resolved)
+	err = copyResolvedFiles(reader, manifest, flux, resolved, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -534,7 +534,7 @@ func TestIntegration_WorkflowsNotProcessed(t *testing.T) {
 		t.Fatalf("failed to resolve files: %v", err)
 	}
 
-	err = copyResolvedFiles(reader, manifest, flux, resolved)
+	err = copyResolvedFiles(reader, manifest, flux, resolved, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -602,7 +602,7 @@ func TestIntegration_MergeStrategy_JSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
-	if err := copyResolvedFiles(reader, manifest, flux, resolved); err != nil {
+	if err := copyResolvedFiles(reader, manifest, flux, resolved, false); err != nil {
 		t.Fatalf("copy: %v", err)
 	}
 
@@ -664,7 +664,7 @@ func TestIntegration_MergeStrategy_TwoMolds(t *testing.T) {
 		if err != nil {
 			t.Fatalf("resolve: %v", err)
 		}
-		if err := copyResolvedFiles(reader, manifest, flux, resolved); err != nil {
+		if err := copyResolvedFiles(reader, manifest, flux, resolved, false); err != nil {
 			t.Fatalf("copy: %v", err)
 		}
 	}
@@ -679,5 +679,60 @@ func TestIntegration_MergeStrategy_TwoMolds(t *testing.T) {
 	}
 	if !strings.Contains(gs, `"replicated-docs"`) {
 		t.Errorf("mold B's replicated-docs missing:\n%s", gs)
+	}
+}
+
+func TestIntegration_MergeStrategy_ForceReplaceOnParseError(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	// Pre-seed an unparseable opencode.json (simulating user hand-edits).
+	if err := os.WriteFile("opencode.json", []byte("not json{"), 0644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	moldFS := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: Mold\nname: test\nversion: 0.1.0\n")},
+		"flux.yaml": &fstest.MapFile{Data: []byte(`output:
+  config/opencode.json:
+    dest: opencode.json
+    strategy: merge
+`)},
+		"config/opencode.json": &fstest.MapFile{Data: []byte(`{"mcp":{"replicated-docs":{"url":"https://docs"}}}`)},
+	}
+	reader := blanks.NewMoldReader(moldFS)
+	manifest, err := reader.LoadManifest()
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+	flux, err := reader.LoadFluxDefaults()
+	if err != nil {
+		t.Fatalf("load flux: %v", err)
+	}
+	resolved, err := mold.ResolveFiles(flux["output"], reader.FS())
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+
+	// Without force-replace: should fail with ParseError-derived message.
+	err = copyResolvedFiles(reader, manifest, flux, resolved, false)
+	if err == nil {
+		t.Fatal("expected error without force-replace, got nil")
+	}
+	if !strings.Contains(err.Error(), "force-replace-on-parse-error") {
+		t.Errorf("expected error to mention the flag; got: %v", err)
+	}
+
+	// With force-replace: should clobber the unparseable file.
+	if err := copyResolvedFiles(reader, manifest, flux, resolved, true); err != nil {
+		t.Fatalf("force-replace should succeed; got: %v", err)
+	}
+	got, _ := os.ReadFile("opencode.json")
+	if !strings.Contains(string(got), "replicated-docs") {
+		t.Errorf("force-replace should write new content; got: %s", got)
 	}
 }

--- a/internal/commands/forge.go
+++ b/internal/commands/forge.go
@@ -186,7 +186,7 @@ func runForge(_ *cobra.Command, args []string) error {
 	ceremony.Open(ceremony.Forge)
 
 	if forgeOutputDir != "" {
-		if err := writeForgeFiles(files, forgeOutputDir, forgeForceReplaceOnParseError); err != nil {
+		if err := writeForgeFiles(files, forgeOutputDir, forgeForceReplaceOnParseError, manifest.Name); err != nil {
 			return err
 		}
 		ceremony.Stamp(ceremony.Forge, fmt.Sprintf("%d file(s) → %s", len(files), forgeOutputDir))
@@ -237,7 +237,7 @@ func printForgeFiles(files []renderedFile) error {
 	return nil
 }
 
-func writeForgeFiles(files []renderedFile, outputDir string, forceReplaceOnParseError bool) error {
+func writeForgeFiles(files []renderedFile, outputDir string, forceReplaceOnParseError bool, moldName string) error {
 	for _, f := range files {
 		dest := filepath.Join(outputDir, f.destPath)
 		switch f.strategy {
@@ -256,6 +256,17 @@ func writeForgeFiles(files []renderedFile, outputDir string, forceReplaceOnParse
 				return fmt.Errorf("failed to merge %s: %w", dest, err)
 			}
 			fmt.Println(styles.SuccessStyle.Render("Merged ") + styles.CodeStyle.Render(dest))
+		case "append":
+			if moldName == "" {
+				return fmt.Errorf("append strategy requires a mold name (dest %s)", dest)
+			}
+			err := merge.AppendFile(dest, []byte(f.content), merge.AppendOptions{
+				MoldName: moldName,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to append into %s: %w", dest, err)
+			}
+			fmt.Println(styles.SuccessStyle.Render("Appended ") + styles.CodeStyle.Render(dest))
 		case "", "replace":
 			if err := os.MkdirAll(filepath.Dir(dest), 0750); err != nil { // #nosec G301 -- Output directories need group read access
 				return fmt.Errorf("creating directory for %s: %w", f.destPath, err)

--- a/internal/commands/forge.go
+++ b/internal/commands/forge.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"log"
@@ -11,6 +12,7 @@ import (
 	"github.com/nimble-giant/ailloy/internal/tui/ceremony"
 	"github.com/nimble-giant/ailloy/pkg/blanks"
 	"github.com/nimble-giant/ailloy/pkg/foundry"
+	"github.com/nimble-giant/ailloy/pkg/merge"
 	"github.com/nimble-giant/ailloy/pkg/mold"
 	"github.com/nimble-giant/ailloy/pkg/smelt"
 	"github.com/nimble-giant/ailloy/pkg/styles"
@@ -32,9 +34,10 @@ By default, rendered output is printed to stdout. Use --output to write files to
 }
 
 var (
-	forgeOutputDir string
-	forgeSetValues []string
-	forgeValFiles  []string
+	forgeOutputDir                string
+	forgeSetValues                []string
+	forgeValFiles                 []string
+	forgeForceReplaceOnParseError bool
 )
 
 func init() {
@@ -43,6 +46,10 @@ func init() {
 	forgeCmd.Flags().StringVarP(&forgeOutputDir, "output", "o", "", "write rendered files to this directory instead of stdout")
 	forgeCmd.Flags().StringArrayVar(&forgeSetValues, "set", nil, "set flux values (key=value)")
 	forgeCmd.Flags().StringArrayVarP(&forgeValFiles, "values", "f", nil, "flux value files (can be repeated, later files override earlier)")
+	forgeCmd.Flags().BoolVar(&forgeForceReplaceOnParseError,
+		"force-replace-on-parse-error",
+		false,
+		"if a destination uses strategy: merge but is unparseable, replace it instead of erroring (only used with --output)")
 }
 
 // loadForgeFlux loads layered flux values using Helm-style precedence:
@@ -96,6 +103,7 @@ func renderFile(name string, content []byte, flux map[string]any, opts ...mold.T
 type renderedFile struct {
 	destPath string // relative output path (e.g. ".claude/commands/brainstorm.md")
 	content  string
+	strategy string
 }
 
 func runForge(_ *cobra.Command, args []string) error {
@@ -171,13 +179,14 @@ func runForge(_ *cobra.Command, args []string) error {
 		files = append(files, renderedFile{
 			destPath: rf.DestPath,
 			content:  rendered,
+			strategy: rf.Strategy,
 		})
 	}
 
 	ceremony.Open(ceremony.Forge)
 
 	if forgeOutputDir != "" {
-		if err := writeForgeFiles(files, forgeOutputDir); err != nil {
+		if err := writeForgeFiles(files, forgeOutputDir, forgeForceReplaceOnParseError); err != nil {
 			return err
 		}
 		ceremony.Stamp(ceremony.Forge, fmt.Sprintf("%d file(s) → %s", len(files), forgeOutputDir))
@@ -228,17 +237,37 @@ func printForgeFiles(files []renderedFile) error {
 	return nil
 }
 
-func writeForgeFiles(files []renderedFile, outputDir string) error {
+func writeForgeFiles(files []renderedFile, outputDir string, forceReplaceOnParseError bool) error {
 	for _, f := range files {
 		dest := filepath.Join(outputDir, f.destPath)
-		if err := os.MkdirAll(filepath.Dir(dest), 0750); err != nil { // #nosec G301 -- Output directories need group read access
-			return fmt.Errorf("creating directory for %s: %w", f.destPath, err)
+		switch f.strategy {
+		case "merge":
+			err := merge.MergeFile(dest, []byte(f.content), merge.Options{
+				ForceReplaceOnParseError: forceReplaceOnParseError,
+			})
+			if err != nil {
+				var pe *merge.ParseError
+				if errors.As(err, &pe) {
+					return fmt.Errorf(
+						"failed to merge into %s: existing %s file could not be parsed: %w. "+
+							"Re-run with --force-replace-on-parse-error to overwrite",
+						pe.Path, pe.Format, pe.Err)
+				}
+				return fmt.Errorf("failed to merge %s: %w", dest, err)
+			}
+			fmt.Println(styles.SuccessStyle.Render("Merged ") + styles.CodeStyle.Render(dest))
+		case "", "replace":
+			if err := os.MkdirAll(filepath.Dir(dest), 0750); err != nil { // #nosec G301 -- Output directories need group read access
+				return fmt.Errorf("creating directory for %s: %w", f.destPath, err)
+			}
+			//#nosec G306 -- Rendered blanks need to be readable
+			if err := os.WriteFile(dest, []byte(f.content), 0644); err != nil {
+				return fmt.Errorf("writing %s: %w", f.destPath, err)
+			}
+			fmt.Println(styles.SuccessStyle.Render("Wrote ") + styles.CodeStyle.Render(dest))
+		default:
+			return fmt.Errorf("unknown strategy %q on output for %s", f.strategy, dest)
 		}
-		//#nosec G306 -- Rendered blanks need to be readable
-		if err := os.WriteFile(dest, []byte(f.content), 0644); err != nil {
-			return fmt.Errorf("writing %s: %w", f.destPath, err)
-		}
-		fmt.Println(styles.SuccessStyle.Render("Wrote ") + styles.CodeStyle.Render(dest))
 	}
 	return nil
 }

--- a/pkg/merge/append.go
+++ b/pkg/merge/append.go
@@ -1,0 +1,81 @@
+package merge
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// AppendOptions configures AppendFile.
+type AppendOptions struct {
+	// MoldName is the mold whose content is being appended. Used as the key
+	// for the sentinel block so re-casting the same mold updates its block
+	// in place rather than producing duplicate entries.
+	MoldName string
+}
+
+// ErrUnsupportedAppendExt is returned when AppendFile is called with a
+// destination whose extension is not one of the markdown variants we
+// currently support. Callers should surface this to the user so they
+// understand that strategy: append works only on markdown files in v1.
+var ErrUnsupportedAppendExt = fmt.Errorf("strategy: append currently supports only .md and .markdown destinations")
+
+// AppendFile appends newContent to the file at destPath, idempotently per
+// opts.MoldName. The content is wrapped in a sentinel block:
+//
+//	<!-- ailloy:mold=<name>:start -->
+//	<newContent>
+//	<!-- ailloy:mold=<name>:end -->
+//
+// On re-cast the existing block for the mold is updated in place.
+//
+// Files are written with mode 0644.
+func AppendFile(destPath string, newContent []byte, opts AppendOptions) error {
+	if opts.MoldName == "" {
+		return fmt.Errorf("AppendFile: MoldName is required")
+	}
+	switch strings.ToLower(filepath.Ext(destPath)) {
+	case ".md", ".markdown":
+		// supported
+	default:
+		return fmt.Errorf("%w: %s", ErrUnsupportedAppendExt, destPath)
+	}
+
+	// Build the sentinel block.
+	startMark := fmt.Sprintf("<!-- ailloy:mold=%s:start -->", opts.MoldName)
+	endMark := fmt.Sprintf("<!-- ailloy:mold=%s:end -->", opts.MoldName)
+	body := bytes.TrimRight(newContent, "\n")
+	block := fmt.Sprintf("%s\n%s\n%s\n", startMark, body, endMark)
+
+	existing, err := os.ReadFile(destPath) // #nosec G304 -- caller-controlled cast destination
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("read existing %s: %w", destPath, err)
+		}
+		// Doesn't exist — create with just our block.
+		return writeAll(destPath, []byte(block))
+	}
+
+	// Look for an existing block keyed by MoldName.
+	pattern := regexp.MustCompile(
+		"(?s)" + regexp.QuoteMeta(startMark) + `\s*\n.*?` + regexp.QuoteMeta(endMark) + `\n?`,
+	)
+	if pattern.Match(existing) {
+		// Replace in place.
+		updated := pattern.ReplaceAll(existing, []byte(block))
+		return writeAll(destPath, updated)
+	}
+
+	// Append a new block. Ensure separation from existing content.
+	out := bytes.TrimRight(existing, "\n")
+	var buf bytes.Buffer
+	buf.Write(out)
+	if len(out) > 0 {
+		buf.WriteString("\n\n")
+	}
+	buf.WriteString(block)
+	return writeAll(destPath, buf.Bytes())
+}

--- a/pkg/merge/append_test.go
+++ b/pkg/merge/append_test.go
@@ -1,0 +1,174 @@
+package merge
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAppendFile_NonexistentDest(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "AGENTS.md")
+	if err := AppendFile(dest, []byte("# Wiki\n\nDocs here."), AppendOptions{MoldName: "wiki"}); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(dest)
+	want := "<!-- ailloy:mold=wiki:start -->\n# Wiki\n\nDocs here.\n<!-- ailloy:mold=wiki:end -->\n"
+	if string(got) != want {
+		t.Errorf("nonexistent dest output mismatch.\nwant:\n%q\ngot:\n%q", want, string(got))
+	}
+}
+
+func TestAppendFile_ExistingNoBlock_AppendsBlock(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "AGENTS.md")
+	if err := os.WriteFile(dest, []byte("# Project AGENTS\n\nHand-written content."), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := AppendFile(dest, []byte("From wiki."), AppendOptions{MoldName: "wiki"}); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(dest)
+	gs := string(got)
+	if !strings.HasPrefix(gs, "# Project AGENTS\n\nHand-written content.") {
+		t.Errorf("hand-written content corrupted:\n%s", gs)
+	}
+	if !strings.Contains(gs, "<!-- ailloy:mold=wiki:start -->") {
+		t.Errorf("sentinel start missing:\n%s", gs)
+	}
+	if !strings.Contains(gs, "<!-- ailloy:mold=wiki:end -->") {
+		t.Errorf("sentinel end missing:\n%s", gs)
+	}
+}
+
+func TestAppendFile_TwoMolds_BothBlocksPresent(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "AGENTS.md")
+	if err := AppendFile(dest, []byte("from wiki"), AppendOptions{MoldName: "wiki"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := AppendFile(dest, []byte("from docs"), AppendOptions{MoldName: "docs"}); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(dest)
+	gs := string(got)
+	for _, want := range []string{"<!-- ailloy:mold=wiki:start -->", "<!-- ailloy:mold=wiki:end -->",
+		"<!-- ailloy:mold=docs:start -->", "<!-- ailloy:mold=docs:end -->",
+		"from wiki", "from docs"} {
+		if !strings.Contains(gs, want) {
+			t.Errorf("missing %q in:\n%s", want, gs)
+		}
+	}
+	// Order: wiki before docs (cast order).
+	if strings.Index(gs, "wiki:start") > strings.Index(gs, "docs:start") {
+		t.Errorf("expected wiki before docs:\n%s", gs)
+	}
+}
+
+func TestAppendFile_RecastIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "AGENTS.md")
+	if err := AppendFile(dest, []byte("v1 content"), AppendOptions{MoldName: "wiki"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := AppendFile(dest, []byte("v2 content"), AppendOptions{MoldName: "wiki"}); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(dest)
+	gs := string(got)
+	if strings.Count(gs, "wiki:start") != 1 {
+		t.Errorf("re-cast should not duplicate sentinel; got:\n%s", gs)
+	}
+	if strings.Contains(gs, "v1 content") {
+		t.Errorf("re-cast should replace v1 content with v2; got:\n%s", gs)
+	}
+	if !strings.Contains(gs, "v2 content") {
+		t.Errorf("v2 content missing after re-cast:\n%s", gs)
+	}
+}
+
+func TestAppendFile_RecastPreservesOtherMoldsAndForeignContent(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "AGENTS.md")
+	// Set up: hand-written content + wiki block + foreign content + docs block + trailing hand-written
+	initial := `# Project AGENTS
+
+Hand-edited intro.
+
+<!-- ailloy:mold=wiki:start -->
+old wiki content
+<!-- ailloy:mold=wiki:end -->
+
+Some hand-written notes between blocks.
+
+<!-- ailloy:mold=docs:start -->
+docs content
+<!-- ailloy:mold=docs:end -->
+
+Trailing hand-written content.
+`
+	if err := os.WriteFile(dest, []byte(initial), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Re-cast wiki only.
+	if err := AppendFile(dest, []byte("new wiki content"), AppendOptions{MoldName: "wiki"}); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(dest)
+	gs := string(got)
+	for _, must := range []string{
+		"# Project AGENTS",
+		"Hand-edited intro.",
+		"new wiki content",
+		"Some hand-written notes between blocks.",
+		"docs content",
+		"Trailing hand-written content.",
+	} {
+		if !strings.Contains(gs, must) {
+			t.Errorf("missing %q after wiki re-cast:\n%s", must, gs)
+		}
+	}
+	if strings.Contains(gs, "old wiki content") {
+		t.Errorf("old wiki content should have been replaced:\n%s", gs)
+	}
+	// Sentinels for both molds still present, exactly once.
+	if strings.Count(gs, "wiki:start") != 1 || strings.Count(gs, "docs:start") != 1 {
+		t.Errorf("expected exactly one sentinel per mold; got:\n%s", gs)
+	}
+}
+
+func TestAppendFile_UnsupportedExtension(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "config.json")
+	err := AppendFile(dest, []byte("x"), AppendOptions{MoldName: "wiki"})
+	if err == nil {
+		t.Fatal("expected error for non-markdown ext, got nil")
+	}
+	if !errors.Is(err, ErrUnsupportedAppendExt) {
+		t.Errorf("expected ErrUnsupportedAppendExt, got: %v", err)
+	}
+}
+
+func TestAppendFile_RequiresMoldName(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "AGENTS.md")
+	err := AppendFile(dest, []byte("x"), AppendOptions{})
+	if err == nil {
+		t.Fatal("expected error when MoldName empty, got nil")
+	}
+	if !strings.Contains(err.Error(), "MoldName") {
+		t.Errorf("error should mention MoldName; got: %v", err)
+	}
+}
+
+func TestAppendFile_MarkdownExtVariants(t *testing.T) {
+	for _, ext := range []string{".md", ".MD", ".markdown", ".Markdown"} {
+		dir := t.TempDir()
+		dest := filepath.Join(dir, "AGENTS"+ext)
+		if err := AppendFile(dest, []byte("x"), AppendOptions{MoldName: "wiki"}); err != nil {
+			t.Errorf("ext %q: unexpected error: %v", ext, err)
+		}
+	}
+}

--- a/pkg/merge/deep.go
+++ b/pkg/merge/deep.go
@@ -1,0 +1,134 @@
+package merge
+
+type nodeKind int
+
+const (
+	kindScalar nodeKind = iota
+	kindMap
+	kindSeq
+)
+
+// node is a format-agnostic ordered representation used by both
+// the JSON and YAML backends. Maps preserve insertion order via `keys`.
+type node struct {
+	kind   nodeKind
+	scalar any              // for kindScalar (string, bool, nil, json.Number, int64, float64)
+	keys   []string         // ordered keys for kindMap
+	fields map[string]*node // map[string]*node for kindMap
+	seq    []*node          // ordered entries for kindSeq
+}
+
+// mergeNodes returns the result of merging overlay into base.
+//
+// Rules:
+//   - kind mismatch: overlay wins (returned as-is).
+//   - both kindScalar: overlay wins.
+//   - both kindMap: recursive deep-merge. Existing base keys keep their
+//     position; overlay keys not in base are appended at the end in
+//     overlay's declared order.
+//   - both kindSeq: concat overlay onto base, then dedupe by deep value
+//     equality. Order is preserved (base first, then overlay-only).
+//
+// mergeNodes does not mutate its inputs; the returned tree may share
+// child pointers with base/overlay.
+func mergeNodes(base, overlay *node) *node {
+	if base == nil {
+		return overlay
+	}
+	if overlay == nil {
+		return base
+	}
+	if base.kind != overlay.kind {
+		return overlay
+	}
+	switch base.kind {
+	case kindScalar:
+		return overlay
+	case kindMap:
+		out := &node{
+			kind:   kindMap,
+			fields: make(map[string]*node, len(base.fields)+len(overlay.fields)),
+		}
+		// Existing keys (in base order), recursively merged.
+		for _, k := range base.keys {
+			bv := base.fields[k]
+			if ov, ok := overlay.fields[k]; ok {
+				out.keys = append(out.keys, k)
+				out.fields[k] = mergeNodes(bv, ov)
+			} else {
+				out.keys = append(out.keys, k)
+				out.fields[k] = bv
+			}
+		}
+		// Overlay-only keys, appended.
+		for _, k := range overlay.keys {
+			if _, ok := base.fields[k]; ok {
+				continue
+			}
+			out.keys = append(out.keys, k)
+			out.fields[k] = overlay.fields[k]
+		}
+		return out
+	case kindSeq:
+		out := &node{kind: kindSeq, seq: make([]*node, 0, len(base.seq)+len(overlay.seq))}
+		out.seq = append(out.seq, base.seq...)
+		for _, oe := range overlay.seq {
+			dup := false
+			for _, be := range out.seq {
+				if nodeEqual(be, oe) {
+					dup = true
+					break
+				}
+			}
+			if !dup {
+				out.seq = append(out.seq, oe)
+			}
+		}
+		return out
+	}
+	return overlay
+}
+
+// nodeEqual is recursive structural equality.
+//   - scalars compare via Go ==
+//   - maps are equal if they have the same key set with recursive-equal values
+//     (order-insensitive — equality is a set property)
+//   - sequences are equal only if same length and element-wise equal
+//     (order-sensitive)
+func nodeEqual(a, b *node) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	if a.kind != b.kind {
+		return false
+	}
+	switch a.kind {
+	case kindScalar:
+		return a.scalar == b.scalar
+	case kindMap:
+		if len(a.fields) != len(b.fields) {
+			return false
+		}
+		for k, av := range a.fields {
+			bv, ok := b.fields[k]
+			if !ok {
+				return false
+			}
+			if !nodeEqual(av, bv) {
+				return false
+			}
+		}
+		return true
+	case kindSeq:
+		if len(a.seq) != len(b.seq) {
+			return false
+		}
+		for i := range a.seq {
+			if !nodeEqual(a.seq[i], b.seq[i]) {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}

--- a/pkg/merge/deep_test.go
+++ b/pkg/merge/deep_test.go
@@ -1,0 +1,158 @@
+package merge
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func mkScalar(v any) *node { return &node{kind: kindScalar, scalar: v} }
+
+func mkMap(entries ...any) *node {
+	if len(entries)%2 != 0 {
+		panic("mkMap: odd number of entries")
+	}
+	n := &node{kind: kindMap, fields: map[string]*node{}}
+	for i := 0; i < len(entries); i += 2 {
+		k := entries[i].(string)
+		v := entries[i+1].(*node)
+		n.keys = append(n.keys, k)
+		n.fields[k] = v
+	}
+	return n
+}
+
+func mkSeq(items ...*node) *node {
+	return &node{kind: kindSeq, seq: items}
+}
+
+func TestMergeNodes_ScalarOverwrite(t *testing.T) {
+	got := mergeNodes(mkScalar("old"), mkScalar("new"))
+	if got.kind != kindScalar || got.scalar != "new" {
+		t.Fatalf("scalar overwrite: got %+v", got)
+	}
+}
+
+func TestMergeNodes_TypeMismatchOverlayWins(t *testing.T) {
+	got := mergeNodes(mkScalar("x"), mkMap("a", mkScalar(1)))
+	if got.kind != kindMap {
+		t.Fatalf("type mismatch: overlay map should win, got kind=%v", got.kind)
+	}
+}
+
+func TestMergeNodes_MapMergePreservesOrder(t *testing.T) {
+	base := mkMap(
+		"a", mkScalar(1),
+		"b", mkScalar(2),
+		"c", mkScalar(3),
+	)
+	overlay := mkMap(
+		"b", mkScalar(20), // override existing
+		"d", mkScalar(4), // append new
+	)
+	got := mergeNodes(base, overlay)
+
+	wantKeys := []string{"a", "b", "c", "d"}
+	if len(got.keys) != len(wantKeys) {
+		t.Fatalf("keys: want %v, got %v", wantKeys, got.keys)
+	}
+	for i, k := range wantKeys {
+		if got.keys[i] != k {
+			t.Fatalf("key[%d]: want %q, got %q", i, k, got.keys[i])
+		}
+	}
+	if got.fields["b"].scalar != 20 {
+		t.Fatalf("b override: want 20, got %v", got.fields["b"].scalar)
+	}
+	if got.fields["d"].scalar != 4 {
+		t.Fatalf("d new: want 4, got %v", got.fields["d"].scalar)
+	}
+}
+
+func TestMergeNodes_NestedMapMerge(t *testing.T) {
+	base := mkMap(
+		"mcp", mkMap(
+			"outline", mkMap("url", mkScalar("https://outline")),
+		),
+	)
+	overlay := mkMap(
+		"mcp", mkMap(
+			"replicated-docs", mkMap("url", mkScalar("https://docs")),
+		),
+	)
+	got := mergeNodes(base, overlay)
+
+	mcp := got.fields["mcp"]
+	if mcp == nil || mcp.kind != kindMap {
+		t.Fatalf("mcp not a map: %+v", mcp)
+	}
+	if mcp.fields["outline"] == nil {
+		t.Error("outline missing after merge")
+	}
+	if mcp.fields["replicated-docs"] == nil {
+		t.Error("replicated-docs missing after merge")
+	}
+}
+
+func TestMergeNodes_SeqConcatDedupe(t *testing.T) {
+	base := mkSeq(mkScalar("a"), mkScalar("b"))
+	overlay := mkSeq(mkScalar("b"), mkScalar("c"))
+	got := mergeNodes(base, overlay)
+
+	if got.kind != kindSeq {
+		t.Fatalf("expected seq, got %v", got.kind)
+	}
+	if len(got.seq) != 3 {
+		t.Fatalf("expected 3 entries (a,b,c), got %d: %+v", len(got.seq), got.seq)
+	}
+	wantOrder := []string{"a", "b", "c"}
+	for i, w := range wantOrder {
+		if got.seq[i].scalar != w {
+			t.Errorf("seq[%d]: want %q, got %v", i, w, got.seq[i].scalar)
+		}
+	}
+}
+
+func TestMergeNodes_SeqDedupeDeepEqual(t *testing.T) {
+	base := mkSeq(mkMap("name", mkScalar("outline")))
+	overlay := mkSeq(
+		mkMap("name", mkScalar("outline")),         // dup
+		mkMap("name", mkScalar("replicated-docs")), // new
+	)
+	got := mergeNodes(base, overlay)
+
+	if len(got.seq) != 2 {
+		t.Fatalf("expected 2 entries (outline + replicated-docs), got %d", len(got.seq))
+	}
+}
+
+func TestNodeEqual(t *testing.T) {
+	if !nodeEqual(mkScalar(1), mkScalar(1)) {
+		t.Error("scalar 1 should equal scalar 1")
+	}
+	if nodeEqual(mkScalar(1), mkScalar(2)) {
+		t.Error("scalar 1 should NOT equal scalar 2")
+	}
+
+	a := mkMap("x", mkScalar(1), "y", mkScalar(2))
+	b := mkMap("y", mkScalar(2), "x", mkScalar(1)) // different key order
+	if !nodeEqual(a, b) {
+		t.Error("maps with same key/values but different insertion order should be equal")
+	}
+
+	if nodeEqual(mkSeq(mkScalar(1), mkScalar(2)), mkSeq(mkScalar(2), mkScalar(1))) {
+		t.Error("seq equality is order-sensitive")
+	}
+}
+
+func TestNodeEqual_JSONNumberStrings(t *testing.T) {
+	// json.Number compares by string identity inside a scalar.
+	a := mkScalar(json.Number("5"))
+	b := mkScalar(json.Number("5"))
+	if !nodeEqual(a, b) {
+		t.Error("identical json.Number scalars should be equal")
+	}
+	c := mkScalar(json.Number("5.0"))
+	if nodeEqual(a, c) {
+		t.Error("json.Number(\"5\") and json.Number(\"5.0\") differ as strings")
+	}
+}

--- a/pkg/merge/fuzz_test.go
+++ b/pkg/merge/fuzz_test.go
@@ -1,0 +1,118 @@
+package merge
+
+import (
+	"strings"
+	"testing"
+)
+
+func FuzzJSONRoundTrip(f *testing.F) {
+	// Seed corpus.
+	seeds := []string{
+		`{}`,
+		`[]`,
+		`{"a":1}`,
+		`{"mcp":{"outline":{"url":"https://outline"}}}`,
+		`{"a":{"b":{"c":[1,2,3]}}}`,
+		`{"url":"https://x.com/?a=1&b=2"}`,
+		`null`,
+		`42`,
+		`"hello"`,
+		`true`,
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, raw string) {
+		// Skip absurdly large inputs to keep fuzzing fast.
+		if len(raw) > 64*1024 {
+			t.Skip()
+		}
+		n1, err := loadJSON([]byte(raw))
+		if err != nil {
+			// Loader rejected; that's fine.
+			return
+		}
+		out1, err := dumpJSON(n1)
+		if err != nil {
+			t.Fatalf("loadJSON accepted but dumpJSON failed: %v\ninput: %q", err, raw)
+		}
+		n2, err := loadJSON(out1)
+		if err != nil {
+			t.Fatalf("dumpJSON output not parseable: %v\nout1: %s", err, out1)
+		}
+		out2, err := dumpJSON(n2)
+		if err != nil {
+			t.Fatalf("second dump failed: %v", err)
+		}
+		if string(out1) != string(out2) {
+			t.Fatalf("not a fixed point.\ninput: %q\nout1:\n%s\nout2:\n%s", raw, out1, out2)
+		}
+	})
+}
+
+func FuzzYAMLRoundTrip(f *testing.F) {
+	seeds := []string{
+		"a: 1\n",
+		"a:\n  b: 2\n",
+		"items:\n  - a\n  - b\n",
+		"port: 8080\nname: foo\n",
+		"empty: {}\n",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, raw string) {
+		if len(raw) > 64*1024 {
+			t.Skip()
+		}
+		// Skip control chars that would cause goccy/go-yaml lexer issues
+		// unrelated to merge logic.
+		if strings.ContainsAny(raw, "\x00") {
+			t.Skip()
+		}
+		n1, err := loadYAML([]byte(raw))
+		if err != nil {
+			return
+		}
+		out1, err := dumpYAML(n1)
+		if err != nil {
+			t.Fatalf("loadYAML accepted but dumpYAML failed: %v\ninput: %q", err, raw)
+		}
+		n2, err := loadYAML(out1)
+		if err != nil {
+			t.Fatalf("dumpYAML output not parseable: %v\nout1: %s", err, out1)
+		}
+		out2, err := dumpYAML(n2)
+		if err != nil {
+			t.Fatalf("second dump failed: %v", err)
+		}
+		if string(out1) != string(out2) {
+			t.Fatalf("not a fixed point.\ninput: %q\nout1:\n%s\nout2:\n%s", raw, out1, out2)
+		}
+	})
+}
+
+// FuzzMergeNodes asserts that merging two parsed trees never crashes and the
+// result is dumpable.
+func FuzzMergeNodesJSON(f *testing.F) {
+	f.Add(`{"a":1}`, `{"b":2}`)
+	f.Add(`{"items":[1,2]}`, `{"items":[2,3]}`)
+	f.Add(`{}`, `{}`)
+	f.Fuzz(func(t *testing.T, baseRaw, overlayRaw string) {
+		if len(baseRaw)+len(overlayRaw) > 64*1024 {
+			t.Skip()
+		}
+		base, err := loadJSON([]byte(baseRaw))
+		if err != nil {
+			return
+		}
+		overlay, err := loadJSON([]byte(overlayRaw))
+		if err != nil {
+			return
+		}
+		merged := mergeNodes(base, overlay)
+		if _, err := dumpJSON(merged); err != nil {
+			t.Fatalf("dumpJSON of merged tree failed: %v", err)
+		}
+	})
+}

--- a/pkg/merge/json.go
+++ b/pkg/merge/json.go
@@ -1,0 +1,185 @@
+package merge
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// loadJSON parses JSON bytes into an order-preserving *node tree.
+// Integers are preserved as json.Number to avoid float coercion.
+func loadJSON(data []byte) (*node, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	n, err := decodeJSONValue(dec)
+	if err != nil {
+		return nil, err
+	}
+	// Verify nothing left over.
+	if _, err := dec.Token(); err == nil {
+		return nil, fmt.Errorf("trailing data after JSON value")
+	}
+	return n, nil
+}
+
+func decodeJSONValue(dec *json.Decoder) (*node, error) {
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	return decodeJSONFromToken(dec, tok)
+}
+
+func decodeJSONFromToken(dec *json.Decoder, tok json.Token) (*node, error) {
+	switch v := tok.(type) {
+	case json.Delim:
+		switch v {
+		case '{':
+			n := &node{kind: kindMap, fields: map[string]*node{}}
+			for dec.More() {
+				keyTok, err := dec.Token()
+				if err != nil {
+					return nil, err
+				}
+				key, ok := keyTok.(string)
+				if !ok {
+					return nil, fmt.Errorf("non-string JSON key: %v", keyTok)
+				}
+				val, err := decodeJSONValue(dec)
+				if err != nil {
+					return nil, err
+				}
+				n.keys = append(n.keys, key)
+				n.fields[key] = val
+			}
+			// Consume closing '}'.
+			if _, err := dec.Token(); err != nil {
+				return nil, err
+			}
+			return n, nil
+		case '[':
+			n := &node{kind: kindSeq}
+			for dec.More() {
+				val, err := decodeJSONValue(dec)
+				if err != nil {
+					return nil, err
+				}
+				n.seq = append(n.seq, val)
+			}
+			// Consume closing ']'.
+			if _, err := dec.Token(); err != nil {
+				return nil, err
+			}
+			return n, nil
+		default:
+			return nil, fmt.Errorf("unexpected delim %v", v)
+		}
+	default:
+		// Scalar: string, bool, nil, or json.Number.
+		return &node{kind: kindScalar, scalar: tok}, nil
+	}
+}
+
+// dumpJSON serializes a *node tree as 2-space-indented JSON, preserving
+// map key order and trailing newline.
+func dumpJSON(n *node) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := writeJSONNode(&buf, n, 0); err != nil {
+		return nil, err
+	}
+	buf.WriteByte('\n')
+	return buf.Bytes(), nil
+}
+
+func writeJSONNode(buf *bytes.Buffer, n *node, indent int) error {
+	switch n.kind {
+	case kindScalar:
+		return writeJSONScalar(buf, n.scalar)
+	case kindMap:
+		if len(n.keys) == 0 {
+			buf.WriteString("{}")
+			return nil
+		}
+		buf.WriteString("{\n")
+		for i, k := range n.keys {
+			writeIndent(buf, indent+1)
+			if err := writeJSONString(buf, k); err != nil {
+				return err
+			}
+			buf.WriteString(": ")
+			if err := writeJSONNode(buf, n.fields[k], indent+1); err != nil {
+				return err
+			}
+			if i < len(n.keys)-1 {
+				buf.WriteByte(',')
+			}
+			buf.WriteByte('\n')
+		}
+		writeIndent(buf, indent)
+		buf.WriteByte('}')
+		return nil
+	case kindSeq:
+		if len(n.seq) == 0 {
+			buf.WriteString("[]")
+			return nil
+		}
+		buf.WriteString("[\n")
+		for i, item := range n.seq {
+			writeIndent(buf, indent+1)
+			if err := writeJSONNode(buf, item, indent+1); err != nil {
+				return err
+			}
+			if i < len(n.seq)-1 {
+				buf.WriteByte(',')
+			}
+			buf.WriteByte('\n')
+		}
+		writeIndent(buf, indent)
+		buf.WriteByte(']')
+		return nil
+	}
+	return fmt.Errorf("unknown node kind %v", n.kind)
+}
+
+func writeIndent(buf *bytes.Buffer, depth int) {
+	buf.WriteString(strings.Repeat("  ", depth))
+}
+
+func writeJSONScalar(buf *bytes.Buffer, v any) error {
+	switch s := v.(type) {
+	case nil:
+		buf.WriteString("null")
+		return nil
+	case bool:
+		if s {
+			buf.WriteString("true")
+		} else {
+			buf.WriteString("false")
+		}
+		return nil
+	case json.Number:
+		buf.WriteString(string(s))
+		return nil
+	case string:
+		return writeJSONString(buf, s)
+	default:
+		// Fallback: defer to encoding/json (covers float64, int — only
+		// reached if loaders ever produce non-Number numerics).
+		out, err := json.Marshal(v)
+		if err != nil {
+			return err
+		}
+		buf.Write(out)
+		return nil
+	}
+}
+
+func writeJSONString(buf *bytes.Buffer, s string) error {
+	out, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	buf.Write(out)
+	return nil
+}

--- a/pkg/merge/json.go
+++ b/pkg/merge/json.go
@@ -54,7 +54,9 @@ func decodeJSONFromToken(dec *json.Decoder, tok json.Token) (*node, error) {
 				if err != nil {
 					return nil, err
 				}
-				n.keys = append(n.keys, key)
+				if _, exists := n.fields[key]; !exists {
+					n.keys = append(n.keys, key)
+				}
 				n.fields[key] = val
 			}
 			// Consume closing '}'.

--- a/pkg/merge/json.go
+++ b/pkg/merge/json.go
@@ -3,7 +3,9 @@ package merge
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"strings"
 )
 
@@ -16,9 +18,11 @@ func loadJSON(data []byte) (*node, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Verify nothing left over.
-	if _, err := dec.Token(); err == nil {
-		return nil, fmt.Errorf("trailing data after JSON value")
+	// Anything other than EOF means there's trailing content.
+	if tok, err := dec.Token(); err == nil {
+		return nil, fmt.Errorf("trailing data after JSON value: %v", tok)
+	} else if !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("trailing data after JSON value: %w", err)
 	}
 	return n, nil
 }
@@ -176,9 +180,16 @@ func writeJSONScalar(buf *bytes.Buffer, v any) error {
 }
 
 func writeJSONString(buf *bytes.Buffer, s string) error {
-	out, err := json.Marshal(s)
-	if err != nil {
+	var tmp bytes.Buffer
+	enc := json.NewEncoder(&tmp)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(s); err != nil {
 		return err
+	}
+	// Encoder.Encode appends a trailing newline; strip it.
+	out := tmp.Bytes()
+	if len(out) > 0 && out[len(out)-1] == '\n' {
+		out = out[:len(out)-1]
 	}
 	buf.Write(out)
 	return nil

--- a/pkg/merge/json_test.go
+++ b/pkg/merge/json_test.go
@@ -1,0 +1,108 @@
+package merge
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLoadJSON_PreservesOrderAndNumbers(t *testing.T) {
+	in := []byte(`{"b": 2, "a": 1, "nested": {"y": "Y", "x": "X"}, "items": [1, 2, 3]}`)
+	got, err := loadJSON(in)
+	if err != nil {
+		t.Fatalf("loadJSON: %v", err)
+	}
+	if got.kind != kindMap {
+		t.Fatalf("want kindMap, got %v", got.kind)
+	}
+	wantKeys := []string{"b", "a", "nested", "items"}
+	if len(got.keys) != len(wantKeys) {
+		t.Fatalf("keys: want %v, got %v", wantKeys, got.keys)
+	}
+	for i, k := range wantKeys {
+		if got.keys[i] != k {
+			t.Fatalf("key[%d]: want %q, got %q", i, k, got.keys[i])
+		}
+	}
+	// Integer should round-trip as json.Number "1", not float64.
+	if s := got.fields["a"].scalar; s == nil {
+		t.Fatal("a scalar nil")
+	}
+	if got.fields["items"].kind != kindSeq {
+		t.Fatalf("items: want kindSeq, got %v", got.fields["items"].kind)
+	}
+	if len(got.fields["items"].seq) != 3 {
+		t.Fatalf("items length: want 3, got %d", len(got.fields["items"].seq))
+	}
+}
+
+func TestDumpJSON_RoundTrip(t *testing.T) {
+	in := []byte(`{"b":2,"a":1,"nested":{"y":"Y","x":"X"},"items":[1,2,3],"flag":true,"none":null}`)
+	n, err := loadJSON(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := dumpJSON(n)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 2-space indented, key order preserved.
+	want := `{
+  "b": 2,
+  "a": 1,
+  "nested": {
+    "y": "Y",
+    "x": "X"
+  },
+  "items": [
+    1,
+    2,
+    3
+  ],
+  "flag": true,
+  "none": null
+}
+`
+	if string(out) != want {
+		t.Errorf("dumpJSON mismatch.\nwant:\n%s\ngot:\n%s", want, string(out))
+	}
+}
+
+func TestDumpJSON_StringEscaping(t *testing.T) {
+	n := mkMap("msg", mkScalar("he said \"hi\"\nok"))
+	out, err := dumpJSON(n)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(out), `"msg": "he said \"hi\"\nok"`) {
+		t.Errorf("escaping wrong, got: %s", string(out))
+	}
+}
+
+func TestMCPMergeRoundTrip(t *testing.T) {
+	base := []byte(`{"mcp":{"outline":{"url":"https://outline"}}}`)
+	overlay := []byte(`{"mcp":{"replicated-docs":{"url":"https://docs"}}}`)
+	bn, err := loadJSON(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	on, err := loadJSON(overlay)
+	if err != nil {
+		t.Fatal(err)
+	}
+	merged := mergeNodes(bn, on)
+	out, err := dumpJSON(merged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !strings.Contains(got, `"outline"`) {
+		t.Errorf("outline missing: %s", got)
+	}
+	if !strings.Contains(got, `"replicated-docs"`) {
+		t.Errorf("replicated-docs missing: %s", got)
+	}
+	// Order: outline before replicated-docs (base before overlay).
+	if strings.Index(got, `"outline"`) > strings.Index(got, `"replicated-docs"`) {
+		t.Errorf("expected outline before replicated-docs, got: %s", got)
+	}
+}

--- a/pkg/merge/json_test.go
+++ b/pkg/merge/json_test.go
@@ -141,3 +141,28 @@ func TestLoadJSON_RejectsTrailingGarbage(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadJSON_DuplicateKeysLastWins(t *testing.T) {
+	// JSON syntactically allows duplicate keys; we choose last-wins (matches
+	// every mainstream parser) and ensure n.keys has no duplicate entry so
+	// dumpJSON produces valid output.
+	in := []byte(`{"a":1,"a":2}`)
+	n, err := loadJSON(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(n.keys) != 1 {
+		t.Fatalf("expected single key entry, got %d: %v", len(n.keys), n.keys)
+	}
+	if got := n.fields["a"].scalar; got == nil {
+		t.Fatal("a value missing")
+	}
+	out, err := dumpJSON(n)
+	if err != nil {
+		t.Fatalf("dumpJSON: %v", err)
+	}
+	// Re-loading the dump must succeed (no duplicate keys in output).
+	if _, err := loadJSON(out); err != nil {
+		t.Errorf("dump produced invalid JSON with duplicates: %v\nout: %s", err, out)
+	}
+}

--- a/pkg/merge/json_test.go
+++ b/pkg/merge/json_test.go
@@ -106,3 +106,38 @@ func TestMCPMergeRoundTrip(t *testing.T) {
 		t.Errorf("expected outline before replicated-docs, got: %s", got)
 	}
 }
+
+func TestDumpJSON_DoesNotHTMLEscapeURLs(t *testing.T) {
+	in := []byte(`{"url":"https://example.com/?a=1&b=2"}`)
+	n, err := loadJSON(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := dumpJSON(n)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "?a=1&b=2") {
+		t.Errorf("expected raw &; got: %s", got)
+	}
+	if strings.Contains(got, "\\u0026") {
+		t.Errorf("expected no \\u0026 escape; got: %s", got)
+	}
+}
+
+func TestLoadJSON_RejectsTrailingGarbage(t *testing.T) {
+	cases := []string{
+		`{"a":1} extra`,  // unexpected token after value
+		`{"a":1}null`,    // valid trailing JSON value
+		`{"a":1}{"b":2}`, // two top-level objects
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			_, err := loadJSON([]byte(in))
+			if err == nil {
+				t.Errorf("expected error for input %q, got nil", in)
+			}
+		})
+	}
+}

--- a/pkg/merge/merge.go
+++ b/pkg/merge/merge.go
@@ -102,7 +102,7 @@ func writeAll(destPath string, data []byte) error {
 	if err := os.MkdirAll(filepath.Dir(destPath), 0750); err != nil { // #nosec G301 -- project directories need group read access
 		return fmt.Errorf("create dir for %s: %w", destPath, err)
 	}
-	//#nosec G306 -- mold outputs need to be readable
+	//#nosec G306,G703 -- mold outputs need to be readable; destPath is caller-controlled cast destination
 	if err := os.WriteFile(destPath, data, 0644); err != nil {
 		return fmt.Errorf("write %s: %w", destPath, err)
 	}

--- a/pkg/merge/merge.go
+++ b/pkg/merge/merge.go
@@ -2,7 +2,13 @@
 // `ailloy cast --strategy=merge` output entries. See issue #171.
 package merge
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
 
 // Options configures MergeFile.
 type Options struct {
@@ -37,5 +43,68 @@ func (e *ParseError) Unwrap() error { return e.Err }
 //
 // Files are written with mode 0644.
 func MergeFile(destPath string, newContent []byte, opts Options) error {
-	return fmt.Errorf("merge: not implemented")
+	format := detectFormat(destPath)
+
+	// Unknown ext or no existing file → replace.
+	if format == "" {
+		return writeAll(destPath, newContent)
+	}
+	existing, err := os.ReadFile(destPath) // #nosec G304 -- caller-controlled cast destination
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return writeAll(destPath, newContent)
+		}
+		return fmt.Errorf("read existing %s: %w", destPath, err)
+	}
+
+	loadFn, dumpFn := loaderFor(format)
+	baseTree, perr := loadFn(existing)
+	if perr != nil {
+		if opts.ForceReplaceOnParseError {
+			return writeAll(destPath, newContent)
+		}
+		return &ParseError{Path: destPath, Format: format, Err: perr}
+	}
+	overlayTree, oerr := loadFn(newContent)
+	if oerr != nil {
+		// New content failed to parse. This is a programmer / template bug,
+		// not a user-edited file. Surface plainly.
+		return fmt.Errorf("merge: cannot parse new %s content for %s: %w", format, destPath, oerr)
+	}
+
+	merged := mergeNodes(baseTree, overlayTree)
+	out, derr := dumpFn(merged)
+	if derr != nil {
+		return fmt.Errorf("merge: serialize %s: %w", destPath, derr)
+	}
+	return writeAll(destPath, out)
+}
+
+func detectFormat(p string) string {
+	switch strings.ToLower(filepath.Ext(p)) {
+	case ".json":
+		return "json"
+	case ".yaml", ".yml":
+		return "yaml"
+	default:
+		return ""
+	}
+}
+
+func loaderFor(format string) (func([]byte) (*node, error), func(*node) ([]byte, error)) {
+	if format == "json" {
+		return loadJSON, dumpJSON
+	}
+	return loadYAML, dumpYAML
+}
+
+func writeAll(destPath string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(destPath), 0750); err != nil { // #nosec G301 -- project directories need group read access
+		return fmt.Errorf("create dir for %s: %w", destPath, err)
+	}
+	//#nosec G306 -- mold outputs need to be readable
+	if err := os.WriteFile(destPath, data, 0644); err != nil {
+		return fmt.Errorf("write %s: %w", destPath, err)
+	}
+	return nil
 }

--- a/pkg/merge/merge.go
+++ b/pkg/merge/merge.go
@@ -1,0 +1,41 @@
+// Package merge implements deep-merge of JSON and YAML files for
+// `ailloy cast --strategy=merge` output entries. See issue #171.
+package merge
+
+import "fmt"
+
+// Options configures MergeFile.
+type Options struct {
+	// ForceReplaceOnParseError causes MergeFile to replace an existing
+	// destination file with newContent (instead of returning a *ParseError)
+	// when the on-disk file cannot be parsed in its expected format.
+	ForceReplaceOnParseError bool
+}
+
+// ParseError is returned when MergeFile cannot parse the existing file at
+// destPath. Callers can detect it with errors.As to suggest the
+// --force-replace-on-parse-error flag.
+type ParseError struct {
+	Path   string
+	Format string // "json" or "yaml"
+	Err    error
+}
+
+func (e *ParseError) Error() string {
+	return fmt.Sprintf("merge: cannot parse existing %s file %s: %v", e.Format, e.Path, e.Err)
+}
+
+func (e *ParseError) Unwrap() error { return e.Err }
+
+// MergeFile merges newContent into the file at destPath.
+//
+// Behavior:
+//   - destPath does not exist: write newContent verbatim, creating parent dirs.
+//   - extension not .json/.yaml/.yml: write newContent verbatim (replace).
+//   - existing file unparseable: return *ParseError unless opts.ForceReplaceOnParseError.
+//   - otherwise: parse both, deep-merge, serialize, atomically replace destPath.
+//
+// Files are written with mode 0644.
+func MergeFile(destPath string, newContent []byte, opts Options) error {
+	return fmt.Errorf("merge: not implemented")
+}

--- a/pkg/merge/merge_test.go
+++ b/pkg/merge/merge_test.go
@@ -1,0 +1,17 @@
+package merge
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestParseError_ErrorAndUnwrap(t *testing.T) {
+	inner := errors.New("oops")
+	pe := &ParseError{Path: "x.json", Format: "json", Err: inner}
+	if got := pe.Error(); got == "" {
+		t.Fatal("ParseError.Error returned empty string")
+	}
+	if !errors.Is(pe, inner) {
+		t.Fatal("errors.Is should match wrapped inner")
+	}
+}

--- a/pkg/merge/merge_test.go
+++ b/pkg/merge/merge_test.go
@@ -2,6 +2,9 @@ package merge
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -13,5 +16,106 @@ func TestParseError_ErrorAndUnwrap(t *testing.T) {
 	}
 	if !errors.Is(pe, inner) {
 		t.Fatal("errors.Is should match wrapped inner")
+	}
+}
+
+func TestMergeFile_NonexistentDest_WritesVerbatim(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "sub", "opencode.json")
+	content := []byte(`{"mcp":{"outline":{"url":"https://outline"}}}`)
+	if err := MergeFile(dest, content, Options{}); err != nil {
+		t.Fatalf("MergeFile: %v", err)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("readback: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("nonexistent dest should write verbatim.\nwant: %s\ngot:  %s", content, got)
+	}
+}
+
+func TestMergeFile_UnknownExt_WritesVerbatim(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "README.md")
+	if err := os.WriteFile(dest, []byte("# old"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	newContent := []byte("# new")
+	if err := MergeFile(dest, newContent, Options{}); err != nil {
+		t.Fatalf("MergeFile: %v", err)
+	}
+	got, _ := os.ReadFile(dest)
+	if string(got) != "# new" {
+		t.Errorf("unknown ext should replace.\ngot: %s", got)
+	}
+}
+
+func TestMergeFile_JSON_Merges(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "opencode.json")
+	if err := os.WriteFile(dest, []byte(`{"mcp":{"outline":{"url":"https://outline"}}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	overlay := []byte(`{"mcp":{"replicated-docs":{"url":"https://docs"}}}`)
+	if err := MergeFile(dest, overlay, Options{}); err != nil {
+		t.Fatalf("MergeFile: %v", err)
+	}
+	got, _ := os.ReadFile(dest)
+	gs := string(got)
+	if !strings.Contains(gs, "outline") || !strings.Contains(gs, "replicated-docs") {
+		t.Errorf("expected both servers, got: %s", gs)
+	}
+}
+
+func TestMergeFile_YAML_Merges(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(dest, []byte("a: 1\nb: 2\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	overlay := []byte("c: 3\n")
+	if err := MergeFile(dest, overlay, Options{}); err != nil {
+		t.Fatalf("MergeFile: %v", err)
+	}
+	got, _ := os.ReadFile(dest)
+	gs := string(got)
+	if !strings.Contains(gs, "a:") || !strings.Contains(gs, "b:") || !strings.Contains(gs, "c:") {
+		t.Errorf("merged YAML missing keys, got: %s", gs)
+	}
+}
+
+func TestMergeFile_Malformed_ReturnsParseError(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "broken.json")
+	if err := os.WriteFile(dest, []byte("not json{"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	err := MergeFile(dest, []byte(`{"a":1}`), Options{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var pe *ParseError
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected *ParseError, got %T: %v", err, err)
+	}
+	if pe.Format != "json" {
+		t.Errorf("Format: want json, got %s", pe.Format)
+	}
+}
+
+func TestMergeFile_Malformed_ForceReplaceClobbers(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "broken.json")
+	if err := os.WriteFile(dest, []byte("not json{"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	newContent := []byte(`{"a":1}`)
+	if err := MergeFile(dest, newContent, Options{ForceReplaceOnParseError: true}); err != nil {
+		t.Fatalf("MergeFile: %v", err)
+	}
+	got, _ := os.ReadFile(dest)
+	if string(got) != string(newContent) {
+		t.Errorf("force-replace should clobber.\nwant: %s\ngot:  %s", newContent, got)
 	}
 }

--- a/pkg/merge/merge_test.go
+++ b/pkg/merge/merge_test.go
@@ -119,3 +119,54 @@ func TestMergeFile_Malformed_ForceReplaceClobbers(t *testing.T) {
 		t.Errorf("force-replace should clobber.\nwant: %s\ngot:  %s", newContent, got)
 	}
 }
+
+func TestMergeFile_ReadError_NonENOENT(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root bypasses permission checks")
+	}
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "opencode.json")
+	if err := os.WriteFile(dest, []byte(`{"a":1}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Make the file unreadable to trigger a non-ENOENT error from os.ReadFile.
+	if err := os.Chmod(dest, 0); err != nil {
+		t.Fatalf("chmod 0: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dest, 0644) })
+
+	err := MergeFile(dest, []byte(`{"b":2}`), Options{})
+	if err == nil {
+		t.Fatal("expected error reading unreadable file, got nil")
+	}
+	// Must NOT be a *ParseError — it's a read error, not a parse error.
+	var pe *ParseError
+	if errors.As(err, &pe) {
+		t.Errorf("expected non-ParseError, got *ParseError: %v", err)
+	}
+	if !strings.Contains(err.Error(), "read existing") {
+		t.Errorf("expected error message to mention 'read existing', got: %v", err)
+	}
+}
+
+func TestMergeFile_MalformedNewContent_NotParseError(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "opencode.json")
+	// Existing file is valid.
+	if err := os.WriteFile(dest, []byte(`{"a":1}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// New content is malformed — would be a template/programmer bug in production.
+	err := MergeFile(dest, []byte("not json{"), Options{})
+	if err == nil {
+		t.Fatal("expected error for malformed new content, got nil")
+	}
+	// Must NOT be a *ParseError — that type is reserved for the on-disk file.
+	var pe *ParseError
+	if errors.As(err, &pe) {
+		t.Errorf("expected plain error for malformed new content, got *ParseError: %v", err)
+	}
+	if !strings.Contains(err.Error(), "cannot parse new") {
+		t.Errorf("expected message about new content; got: %v", err)
+	}
+}

--- a/pkg/merge/realistic_test.go
+++ b/pkg/merge/realistic_test.go
@@ -1,0 +1,321 @@
+package merge
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestJSONMerge_FullMCPConfig verifies a realistic opencode.json merge — two
+// molds each declaring a complete MCP server entry with command, args, and
+// env. End state must contain BOTH servers in source order, AND the inner
+// fields (command/args/env) must be intact for both.
+func TestJSONMerge_FullMCPConfig(t *testing.T) {
+	base := []byte(`{
+  "mcp": {
+    "outline": {
+      "command": "npx",
+      "args": ["-y", "outline-mcp"],
+      "env": {
+        "OUTLINE_API_TOKEN": "$OUTLINE_API_TOKEN",
+        "OUTLINE_API_URL": "https://outline.example.com/api"
+      }
+    }
+  },
+  "version": 1
+}
+`)
+	overlay := []byte(`{
+  "mcp": {
+    "replicated-docs": {
+      "command": "docs-server",
+      "args": ["--port", "8080", "--verbose"],
+      "env": {
+        "DOCS_DB_PATH": "/var/lib/docs.db"
+      }
+    }
+  }
+}
+`)
+	bn, err := loadJSON(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	on, err := loadJSON(overlay)
+	if err != nil {
+		t.Fatal(err)
+	}
+	merged := mergeNodes(bn, on)
+	out, err := dumpJSON(merged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+
+	for _, s := range []string{"outline", "replicated-docs", "OUTLINE_API_TOKEN", "DOCS_DB_PATH", "outline-mcp", "--port", "8080", "--verbose"} {
+		if !strings.Contains(got, s) {
+			t.Errorf("expected %q in merged output, missing.\nfull output:\n%s", s, got)
+		}
+	}
+
+	if strings.Index(got, "outline") > strings.Index(got, "replicated-docs") {
+		t.Errorf("expected outline before replicated-docs, got:\n%s", got)
+	}
+
+	if !strings.Contains(got, `"version": 1`) {
+		t.Errorf("base-only top-level key 'version' lost:\n%s", got)
+	}
+
+	if _, err := loadJSON(out); err != nil {
+		t.Errorf("merged JSON invalid on re-load: %v", err)
+	}
+}
+
+func TestJSONMerge_NestedArrayOfObjects(t *testing.T) {
+	base := []byte(`{
+  "plugins": [
+    {"name": "linter", "version": "1.0"},
+    {"name": "formatter", "version": "2.0"}
+  ]
+}
+`)
+	overlay := []byte(`{
+  "plugins": [
+    {"name": "formatter", "version": "2.0"},
+    {"name": "tests", "version": "3.0"}
+  ]
+}
+`)
+	bn, _ := loadJSON(base)
+	on, _ := loadJSON(overlay)
+	merged := mergeNodes(bn, on)
+
+	plugins := merged.fields["plugins"]
+	if plugins == nil || plugins.kind != kindSeq {
+		t.Fatalf("plugins not a sequence: %+v", plugins)
+	}
+	if len(plugins.seq) != 3 {
+		t.Fatalf("expected 3 plugins (linter, formatter, tests), got %d:\n%+v", len(plugins.seq), plugins.seq)
+	}
+}
+
+func TestYAMLMerge_FullMCPConfig(t *testing.T) {
+	base := []byte(`mcp:
+  outline:
+    command: npx
+    args:
+      - -y
+      - outline-mcp
+    env:
+      OUTLINE_API_TOKEN: $OUTLINE_API_TOKEN
+      OUTLINE_API_URL: https://outline.example.com/api
+version: 1
+`)
+	overlay := []byte(`mcp:
+  replicated-docs:
+    command: docs-server
+    args:
+      - --port
+      - "8080"
+      - --verbose
+    env:
+      DOCS_DB_PATH: /var/lib/docs.db
+`)
+	bn, err := loadYAML(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	on, err := loadYAML(overlay)
+	if err != nil {
+		t.Fatal(err)
+	}
+	merged := mergeNodes(bn, on)
+	out, err := dumpYAML(merged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+
+	for _, s := range []string{"outline", "replicated-docs", "OUTLINE_API_TOKEN", "DOCS_DB_PATH", "outline-mcp", "docs-server"} {
+		if !strings.Contains(got, s) {
+			t.Errorf("expected %q in merged YAML, missing.\nfull output:\n%s", s, got)
+		}
+	}
+	if strings.Index(got, "outline") > strings.Index(got, "replicated-docs") {
+		t.Errorf("expected outline before replicated-docs, got:\n%s", got)
+	}
+	if _, err := loadYAML(out); err != nil {
+		t.Errorf("merged YAML invalid on re-load: %v", err)
+	}
+}
+
+// TestYAMLMerge_NorwayProblem documents goccy's behavior on the classic YAML
+// 1.1 quirk where bare NO/YES/ON/OFF can parse as booleans. We assert
+// round-trip stability rather than a specific value.
+func TestYAMLMerge_NorwayProblem(t *testing.T) {
+	in := []byte("country: NO\n")
+	n, err := loadYAML(in)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	out, err := dumpYAML(n)
+	if err != nil {
+		t.Fatal(err)
+	}
+	n2, err := loadYAML(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !nodeEqual(n, n2) {
+		t.Errorf("Norway problem: %q does not round-trip\nfirst:  %+v\nsecond: %+v\ndumped:\n%s", in, n, n2, out)
+	}
+}
+
+func TestYAMLMerge_TopLevelSequence(t *testing.T) {
+	in := []byte("- a\n- b\n- c\n")
+	n, err := loadYAML(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n.kind != kindSeq {
+		t.Fatalf("expected kindSeq at root, got %v", n.kind)
+	}
+	out, err := dumpYAML(n)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadYAML(out); err != nil {
+		t.Errorf("top-level seq round-trip failed: %v\nout:\n%s", err, out)
+	}
+}
+
+func TestJSONMerge_TopLevelArray(t *testing.T) {
+	in := []byte(`[1, 2, 3]`)
+	n, err := loadJSON(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n.kind != kindSeq {
+		t.Fatalf("expected kindSeq, got %v", n.kind)
+	}
+	out, err := dumpJSON(n)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadJSON(out); err != nil {
+		t.Errorf("top-level array round-trip failed: %v\nout: %s", err, out)
+	}
+}
+
+func TestYAMLMerge_BlockScalar(t *testing.T) {
+	cases := map[string]string{
+		"literal_block": "description: |\n  line one\n  line two\n",
+		"folded_block":  "description: >\n  long\n  paragraph\n",
+	}
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			n, err := loadYAML([]byte(in))
+			if err != nil {
+				t.Fatalf("load: %v", err)
+			}
+			out, err := dumpYAML(n)
+			if err != nil {
+				t.Fatalf("dump: %v", err)
+			}
+			n2, err := loadYAML(out)
+			if err != nil {
+				t.Fatalf("reload: %v\nout:\n%s", err, out)
+			}
+			if !nodeEqual(n, n2) {
+				t.Errorf("%s: not stable across round-trip\nfirst-dump:\n%s", name, out)
+			}
+		})
+	}
+}
+
+func TestYAMLMerge_DeeplyNested(t *testing.T) {
+	var b strings.Builder
+	for i := range 20 {
+		b.WriteString(strings.Repeat("  ", i))
+		b.WriteString("level0:\n")
+	}
+	b.WriteString(strings.Repeat("  ", 20))
+	b.WriteString("leaf: 1\n")
+	in := []byte(b.String())
+	n, err := loadYAML(in)
+	if err != nil {
+		t.Skipf("goccy may have nesting limits; skipping if so: %v", err)
+	}
+	out, err := dumpYAML(n)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadYAML(out); err != nil {
+		t.Errorf("20-level YAML round-trip failed: %v", err)
+	}
+}
+
+func TestJSONMerge_DeeplyNested(t *testing.T) {
+	in := []byte(strings.Repeat(`{"x":`, 50) + `1` + strings.Repeat(`}`, 50))
+	n, err := loadJSON(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := dumpJSON(n)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadJSON(out); err != nil {
+		t.Errorf("50-level JSON round-trip failed: %v", err)
+	}
+}
+
+func TestJSONMerge_LargeIntegers(t *testing.T) {
+	in := []byte(`{"timestamp_ns": 1700000000123456789, "id": 9223372036854775807}`)
+	n, err := loadJSON(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := dumpJSON(n)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	for _, want := range []string{"1700000000123456789", "9223372036854775807"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("large integer %q lost precision; got:\n%s", want, got)
+		}
+	}
+}
+
+func TestJSONMerge_UnicodeStrings(t *testing.T) {
+	in := []byte(`{"emoji":"hello 🌍","jp":"こんにちは","arabic":"مرحبا"}`)
+	n, err := loadJSON(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := dumpJSON(n)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	for _, want := range []string{"🌍", "こんにちは", "مرحبا"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("unicode %q not preserved; got:\n%s", want, got)
+		}
+	}
+}
+
+func TestMergeFile_PreservesCanonicalFormat(t *testing.T) {
+	in := []byte("{\n    \"a\": 1\n}\n")
+	n, err := loadJSON(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := dumpJSON(n)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(out), `  "a": 1`) {
+		t.Errorf("expected 2-space indent in canonical output; got:\n%s", out)
+	}
+}

--- a/pkg/merge/roundtrip_test.go
+++ b/pkg/merge/roundtrip_test.go
@@ -1,0 +1,170 @@
+package merge
+
+import (
+	"strings"
+	"testing"
+)
+
+// jsonFixedPoint asserts that loadJSON → dumpJSON is a fixed point: the second
+// dump equals the first. This is the canonical-form property — any valid input
+// converges to a unique canonical serialization in one round-trip.
+func jsonFixedPoint(t *testing.T, name, input string) {
+	t.Helper()
+	t.Run(name, func(t *testing.T) {
+		n1, err := loadJSON([]byte(input))
+		if err != nil {
+			t.Fatalf("load1: %v\ninput: %s", err, input)
+		}
+		out1, err := dumpJSON(n1)
+		if err != nil {
+			t.Fatalf("dump1: %v", err)
+		}
+		n2, err := loadJSON(out1)
+		if err != nil {
+			t.Fatalf("load2: %v\nout1: %s", err, out1)
+		}
+		out2, err := dumpJSON(n2)
+		if err != nil {
+			t.Fatalf("dump2: %v", err)
+		}
+		if string(out1) != string(out2) {
+			t.Errorf("not a fixed point.\nout1:\n%s\nout2:\n%s", out1, out2)
+		}
+	})
+}
+
+func yamlFixedPoint(t *testing.T, name, input string) {
+	t.Helper()
+	t.Run(name, func(t *testing.T) {
+		n1, err := loadYAML([]byte(input))
+		if err != nil {
+			t.Fatalf("load1: %v\ninput: %s", err, input)
+		}
+		out1, err := dumpYAML(n1)
+		if err != nil {
+			t.Fatalf("dump1: %v", err)
+		}
+		n2, err := loadYAML(out1)
+		if err != nil {
+			t.Fatalf("load2: %v\nout1: %s", err, out1)
+		}
+		out2, err := dumpYAML(n2)
+		if err != nil {
+			t.Fatalf("dump2: %v", err)
+		}
+		if string(out1) != string(out2) {
+			t.Errorf("not a fixed point.\nout1:\n%s\nout2:\n%s", out1, out2)
+		}
+	})
+}
+
+func TestJSONFixedPoint(t *testing.T) {
+	jsonFixedPoint(t, "empty_object", `{}`)
+	jsonFixedPoint(t, "empty_array", `[]`)
+	jsonFixedPoint(t, "scalar_string", `"hello"`)
+	jsonFixedPoint(t, "scalar_number", `42`)
+	jsonFixedPoint(t, "scalar_bool", `true`)
+	jsonFixedPoint(t, "scalar_null", `null`)
+	jsonFixedPoint(t, "nested_object", `{"a":{"b":{"c":1}}}`)
+	jsonFixedPoint(t, "nested_array", `[[[1,2],[3,4]],[[5,6]]]`)
+	jsonFixedPoint(t, "mixed_types", `{"s":"x","n":1,"b":true,"z":null,"a":[1,2],"o":{"k":"v"}}`)
+	jsonFixedPoint(t, "negative_numbers", `{"n":-42,"f":-3.14}`)
+	jsonFixedPoint(t, "large_integer", `{"big":9007199254740993}`) // > 2^53, requires json.Number to survive
+	jsonFixedPoint(t, "scientific_notation", `{"e":1.5e10}`)
+	jsonFixedPoint(t, "url_with_ampersand", `{"url":"https://x.com/?a=1&b=2"}`)
+	jsonFixedPoint(t, "html_chars", `{"html":"<div class=\"x\">&amp;</div>"}`)
+	jsonFixedPoint(t, "newline_in_string", `{"s":"line1\nline2"}`)
+	jsonFixedPoint(t, "tab_in_string", `{"s":"a\tb"}`)
+	jsonFixedPoint(t, "unicode_string", `{"emoji":"hello 🌍"}`)
+	jsonFixedPoint(t, "deep_nesting", strings.Repeat(`{"x":`, 20)+`1`+strings.Repeat(`}`, 20))
+	jsonFixedPoint(t, "mcp_realistic", `{"mcp":{"outline":{"command":"npx","args":["-y","outline-mcp"],"env":{"OUTLINE_API_TOKEN":"$OUTLINE_API_TOKEN"}},"replicated-docs":{"command":"docs-server","args":["--port","8080"]}}}`)
+}
+
+func TestYAMLFixedPoint(t *testing.T) {
+	yamlFixedPoint(t, "single_key", "a: 1\n")
+	yamlFixedPoint(t, "nested", "a:\n  b:\n    c: 1\n")
+	yamlFixedPoint(t, "sequence", "items:\n  - a\n  - b\n  - c\n")
+	yamlFixedPoint(t, "mixed", "name: foo\nport: 8080\nenabled: true\nargs:\n  - --verbose\n  - --debug\n")
+	yamlFixedPoint(t, "empty_object_value", "empty: {}\n")
+	yamlFixedPoint(t, "empty_seq_value", "empty: []\n")
+	yamlFixedPoint(t, "string_with_special_chars", "url: https://x.com/?a=1\n")
+	yamlFixedPoint(t, "mcp_realistic", `mcp:
+  outline:
+    command: npx
+    args:
+      - -y
+      - outline-mcp
+    env:
+      OUTLINE_API_TOKEN: $OUTLINE_API_TOKEN
+  replicated-docs:
+    command: docs-server
+    args:
+      - --port
+      - "8080"
+`)
+}
+
+// Cross-property: merging a tree with itself (mergeNodes(n, n)) should be
+// idempotent — the result must equal the original by nodeEqual.
+func TestMergeNodes_IdempotentJSON(t *testing.T) {
+	cases := []string{
+		`{"a":1}`,
+		`{"mcp":{"outline":{"url":"https://outline"}}}`,
+		`{"items":[1,2,3]}`,
+		`{"nested":{"a":{"b":{"c":1}}}}`,
+	}
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			n, err := loadJSON([]byte(c))
+			if err != nil {
+				t.Fatal(err)
+			}
+			merged := mergeNodes(n, n)
+			if !nodeEqual(n, merged) {
+				t.Errorf("merge(n, n) should equal n for %q", c)
+			}
+		})
+	}
+}
+
+// mergeNodes(base, empty) and mergeNodes(empty, base) should both equal base.
+func TestMergeNodes_IdentityElement(t *testing.T) {
+	base, _ := loadJSON([]byte(`{"a":1,"b":[1,2]}`))
+	empty := &node{kind: kindMap, fields: map[string]*node{}}
+
+	left := mergeNodes(empty, base)
+	right := mergeNodes(base, empty)
+	if !nodeEqual(base, left) {
+		t.Error("merge(empty, base) should equal base")
+	}
+	if !nodeEqual(base, right) {
+		t.Error("merge(base, empty) should equal base")
+	}
+}
+
+// Non-mutation: a merge must not change either input.
+func TestMergeNodes_DoesNotMutateInputs(t *testing.T) {
+	baseInput := `{"a":{"b":1},"items":[1,2]}`
+	overlayInput := `{"a":{"c":2},"items":[2,3]}`
+
+	base, _ := loadJSON([]byte(baseInput))
+	overlay, _ := loadJSON([]byte(overlayInput))
+
+	_ = mergeNodes(base, overlay)
+
+	// After merge, dumping base/overlay should still produce the original output.
+	baseAfter, _ := dumpJSON(base)
+	overlayAfter, _ := dumpJSON(overlay)
+
+	baseExpected, _ := loadJSON([]byte(baseInput))
+	overlayExpected, _ := loadJSON([]byte(overlayInput))
+	baseExpectedDump, _ := dumpJSON(baseExpected)
+	overlayExpectedDump, _ := dumpJSON(overlayExpected)
+
+	if string(baseAfter) != string(baseExpectedDump) {
+		t.Errorf("base mutated by merge.\nbefore: %s\nafter:  %s", baseExpectedDump, baseAfter)
+	}
+	if string(overlayAfter) != string(overlayExpectedDump) {
+		t.Errorf("overlay mutated by merge.\nbefore: %s\nafter:  %s", overlayExpectedDump, overlayAfter)
+	}
+}

--- a/pkg/merge/testdata/fuzz/FuzzYAMLRoundTrip/11a19f17b23898e9
+++ b/pkg/merge/testdata/fuzz/FuzzYAMLRoundTrip/11a19f17b23898e9
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("<<:")

--- a/pkg/merge/testdata/fuzz/FuzzYAMLRoundTrip/1206db8857347c60
+++ b/pkg/merge/testdata/fuzz/FuzzYAMLRoundTrip/1206db8857347c60
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("---:\n-")

--- a/pkg/merge/testdata/fuzz/FuzzYAMLRoundTrip/44a2709168f0219b
+++ b/pkg/merge/testdata/fuzz/FuzzYAMLRoundTrip/44a2709168f0219b
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("0:\n00:")

--- a/pkg/merge/testdata/fuzz/FuzzYAMLRoundTrip/98be089480278156
+++ b/pkg/merge/testdata/fuzz/FuzzYAMLRoundTrip/98be089480278156
@@ -1,0 +1,2 @@
+go test fuzz v1
+string(" ---")

--- a/pkg/merge/testdata/fuzz/FuzzYAMLRoundTrip/f4e683f76ad5a38c
+++ b/pkg/merge/testdata/fuzz/FuzzYAMLRoundTrip/f4e683f76ad5a38c
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("|+0")

--- a/pkg/merge/yaml.go
+++ b/pkg/merge/yaml.go
@@ -79,7 +79,7 @@ func dumpYAML(n *node) ([]byte, error) {
 type yamlAmbiguousStringScalar string
 
 func (s yamlAmbiguousStringScalar) MarshalYAML() ([]byte, error) {
-	return []byte(fmt.Sprintf("%q", string(s))), nil
+	return fmt.Appendf(nil, "%q", string(s)), nil
 }
 
 // yamlForceQuotedItem and yamlForceQuotedMap let us emit a YAML mapping where
@@ -106,7 +106,7 @@ func (m yamlForceQuotedMap) MarshalYAML() ([]byte, error) {
 			buf.WriteByte('\n')
 		}
 		if needsForceQuoteAsYAMLKey(it.key) {
-			buf.WriteString(fmt.Sprintf("%q", it.key))
+			fmt.Fprintf(&buf, "%q", it.key)
 		} else {
 			// Defer to goccy for non-problematic keys.
 			kb, err := yaml.Marshal(it.key)

--- a/pkg/merge/yaml.go
+++ b/pkg/merge/yaml.go
@@ -26,7 +26,7 @@ func yamlToNode(v any) (*node, error) {
 		for _, item := range x {
 			ks, ok := item.Key.(string)
 			if !ok {
-				ks = fmt.Sprintf("%v", item.Key)
+				return nil, fmt.Errorf("non-string YAML key: %v (only string keys are supported)", item.Key)
 			}
 			child, err := yamlToNode(item.Value)
 			if err != nil {
@@ -47,18 +47,10 @@ func yamlToNode(v any) (*node, error) {
 		}
 		return n, nil
 	case map[string]any:
-		// Fallback for unordered map (shouldn't happen with UseOrderedMap,
-		// but be defensive — keys appear in arbitrary order).
-		n := &node{kind: kindMap, fields: map[string]*node{}}
-		for k, vv := range x {
-			child, err := yamlToNode(vv)
-			if err != nil {
-				return nil, err
-			}
-			n.keys = append(n.keys, k)
-			n.fields[k] = child
-		}
-		return n, nil
+		// UseOrderedMap should always produce yaml.MapSlice. Hitting this
+		// branch means key order has already been lost, which would make
+		// merge output non-deterministic across runs.
+		return nil, fmt.Errorf("yaml decoded as unordered map; UseOrderedMap not applied")
 	default:
 		return &node{kind: kindScalar, scalar: x}, nil
 	}

--- a/pkg/merge/yaml.go
+++ b/pkg/merge/yaml.go
@@ -117,17 +117,25 @@ func (m yamlForceQuotedMap) MarshalYAML() ([]byte, error) {
 			kb = bytes.TrimRight(kb, "\n")
 			buf.Write(kb)
 		}
-		buf.WriteString(": ")
+		buf.WriteString(":")
 		vb, err := yaml.MarshalWithOptions(it.value, yaml.Indent(2))
 		if err != nil {
 			return nil, err
 		}
-		// If the value is a multi-line block, indent continuation lines.
 		vbStr := string(bytes.TrimRight(vb, "\n"))
-		if strings.Contains(vbStr, "\n") {
-			// Place value on next line, indented.
+		// Non-scalar values (sequences and mappings) must start on a new
+		// indented line. Multi-line scalars likewise need each line indented.
+		// Detect non-scalar by value type rather than by output shape.
+		nonScalar := false
+		switch it.value.(type) {
+		case yaml.MapSlice, []any, yamlForceQuotedMap:
+			nonScalar = true
+		}
+		if nonScalar || strings.Contains(vbStr, "\n") {
 			buf.WriteString("\n  ")
 			vbStr = strings.ReplaceAll(vbStr, "\n", "\n  ")
+		} else {
+			buf.WriteByte(' ')
 		}
 		buf.WriteString(vbStr)
 	}

--- a/pkg/merge/yaml.go
+++ b/pkg/merge/yaml.go
@@ -1,7 +1,9 @@
 package merge
 
 import (
+	"bytes"
 	"fmt"
+	"strings"
 
 	"github.com/goccy/go-yaml"
 )
@@ -68,18 +70,146 @@ func dumpYAML(n *node) ([]byte, error) {
 	return yaml.MarshalWithOptions(v, yaml.Indent(2))
 }
 
+// yamlAmbiguousStringScalar is a string wrapper whose MarshalYAML emits the
+// value in double-quoted form. goccy/go-yaml's default marshaler leaves a few
+// strings bare that should be quoted — notably the document-separator tokens
+// "---" / "...", whitespace-only strings, and strings containing newlines —
+// which means re-parsing the dump yields a different value (often nil or "")
+// rather than the original string. We wrap such values to force quoting.
+type yamlAmbiguousStringScalar string
+
+func (s yamlAmbiguousStringScalar) MarshalYAML() ([]byte, error) {
+	return []byte(fmt.Sprintf("%q", string(s))), nil
+}
+
+// yamlForceQuotedItem and yamlForceQuotedMap let us emit a YAML mapping where
+// specific keys that goccy/go-yaml would otherwise emit bare (and which would
+// then fail to re-parse — e.g., the merge key "<<") are force-quoted. Goccy's
+// MapSlice encoder requires string keys and won't honor a custom MarshalYAML
+// at the key level, so we hand off the entire mapping to a custom marshaler.
+type yamlForceQuotedItem struct {
+	key   string
+	value any
+}
+
+type yamlForceQuotedMap struct {
+	items []yamlForceQuotedItem
+}
+
+func (m yamlForceQuotedMap) MarshalYAML() ([]byte, error) {
+	if len(m.items) == 0 {
+		return []byte("{}"), nil
+	}
+	var buf bytes.Buffer
+	for i, it := range m.items {
+		if i > 0 {
+			buf.WriteByte('\n')
+		}
+		if needsForceQuoteAsYAMLKey(it.key) {
+			buf.WriteString(fmt.Sprintf("%q", it.key))
+		} else {
+			// Defer to goccy for non-problematic keys.
+			kb, err := yaml.Marshal(it.key)
+			if err != nil {
+				return nil, err
+			}
+			// Strip trailing newline.
+			kb = bytes.TrimRight(kb, "\n")
+			buf.Write(kb)
+		}
+		buf.WriteString(": ")
+		vb, err := yaml.MarshalWithOptions(it.value, yaml.Indent(2))
+		if err != nil {
+			return nil, err
+		}
+		// If the value is a multi-line block, indent continuation lines.
+		vbStr := string(bytes.TrimRight(vb, "\n"))
+		if strings.Contains(vbStr, "\n") {
+			// Place value on next line, indented.
+			buf.WriteString("\n  ")
+			vbStr = strings.ReplaceAll(vbStr, "\n", "\n  ")
+		}
+		buf.WriteString(vbStr)
+	}
+	return buf.Bytes(), nil
+}
+
+// needsForceQuoteForYAML reports whether a string scalar would round-trip as a
+// different value (or fail to parse) when emitted bare by goccy/go-yaml. We
+// determine this empirically: marshal the value, re-parse it, and compare.
+// Any inequality means we must force quoting.
+func needsForceQuoteForYAML(s string) bool {
+	out, err := yaml.Marshal(s)
+	if err != nil {
+		return true
+	}
+	var v any
+	if err := yaml.Unmarshal(out, &v); err != nil {
+		return true
+	}
+	got, ok := v.(string)
+	if !ok {
+		return true
+	}
+	return got != s
+}
+
+// needsForceQuoteAsYAMLKey reports whether a string used as a mapping key
+// would fail to round-trip when emitted bare by goccy/go-yaml. Some tokens
+// that are valid as values are special as keys — notably the merge key "<<",
+// which goccy emits bare but then refuses to re-parse against a null value.
+func needsForceQuoteAsYAMLKey(s string) bool {
+	if needsForceQuoteForYAML(s) {
+		return true
+	}
+	out, err := yaml.Marshal(yaml.MapSlice{yaml.MapItem{Key: s, Value: nil}})
+	if err != nil {
+		return true
+	}
+	var v any
+	if err := yaml.UnmarshalWithOptions(out, &v, yaml.UseOrderedMap()); err != nil {
+		return true
+	}
+	ms, ok := v.(yaml.MapSlice)
+	if !ok || len(ms) != 1 {
+		return true
+	}
+	got, ok := ms[0].Key.(string)
+	if !ok {
+		return true
+	}
+	return got != s
+}
+
 func nodeToYAMLValue(n *node) (any, error) {
 	switch n.kind {
 	case kindScalar:
+		if s, ok := n.scalar.(string); ok && needsForceQuoteForYAML(s) {
+			return yamlAmbiguousStringScalar(s), nil
+		}
 		return n.scalar, nil
 	case kindMap:
 		out := make(yaml.MapSlice, 0, len(n.keys))
+		needsCustom := false
 		for _, k := range n.keys {
 			child, err := nodeToYAMLValue(n.fields[k])
 			if err != nil {
 				return nil, err
 			}
+			if needsForceQuoteAsYAMLKey(k) {
+				needsCustom = true
+			}
 			out = append(out, yaml.MapItem{Key: k, Value: child})
+		}
+		if needsCustom {
+			// One or more keys would not round-trip when emitted bare by
+			// goccy/go-yaml (e.g., the merge key "<<"), so we hand off to a
+			// custom marshaler that force-quotes problematic keys.
+			items := make([]yamlForceQuotedItem, 0, len(out))
+			for _, it := range out {
+				items = append(items, yamlForceQuotedItem{key: it.Key.(string), value: it.Value})
+			}
+			return yamlForceQuotedMap{items: items}, nil
 		}
 		return out, nil
 	case kindSeq:

--- a/pkg/merge/yaml.go
+++ b/pkg/merge/yaml.go
@@ -1,0 +1,103 @@
+package merge
+
+import (
+	"fmt"
+
+	"github.com/goccy/go-yaml"
+)
+
+// loadYAML parses YAML bytes into an order-preserving *node tree.
+// Uses yaml.UseOrderedMap so map keys come back as yaml.MapSlice with
+// declared order intact.
+func loadYAML(data []byte) (*node, error) {
+	var raw any
+	if err := yaml.UnmarshalWithOptions(data, &raw, yaml.UseOrderedMap()); err != nil {
+		return nil, err
+	}
+	return yamlToNode(raw)
+}
+
+func yamlToNode(v any) (*node, error) {
+	switch x := v.(type) {
+	case nil:
+		return &node{kind: kindScalar, scalar: nil}, nil
+	case yaml.MapSlice:
+		n := &node{kind: kindMap, fields: map[string]*node{}}
+		for _, item := range x {
+			ks, ok := item.Key.(string)
+			if !ok {
+				ks = fmt.Sprintf("%v", item.Key)
+			}
+			child, err := yamlToNode(item.Value)
+			if err != nil {
+				return nil, err
+			}
+			n.keys = append(n.keys, ks)
+			n.fields[ks] = child
+		}
+		return n, nil
+	case []any:
+		n := &node{kind: kindSeq}
+		for _, item := range x {
+			child, err := yamlToNode(item)
+			if err != nil {
+				return nil, err
+			}
+			n.seq = append(n.seq, child)
+		}
+		return n, nil
+	case map[string]any:
+		// Fallback for unordered map (shouldn't happen with UseOrderedMap,
+		// but be defensive — keys appear in arbitrary order).
+		n := &node{kind: kindMap, fields: map[string]*node{}}
+		for k, vv := range x {
+			child, err := yamlToNode(vv)
+			if err != nil {
+				return nil, err
+			}
+			n.keys = append(n.keys, k)
+			n.fields[k] = child
+		}
+		return n, nil
+	default:
+		return &node{kind: kindScalar, scalar: x}, nil
+	}
+}
+
+// dumpYAML serializes a *node tree to YAML bytes via yaml.Marshal on a
+// reconstructed MapSlice/[]any tree (which preserves insertion order).
+func dumpYAML(n *node) ([]byte, error) {
+	v, err := nodeToYAMLValue(n)
+	if err != nil {
+		return nil, err
+	}
+	return yaml.MarshalWithOptions(v, yaml.Indent(2))
+}
+
+func nodeToYAMLValue(n *node) (any, error) {
+	switch n.kind {
+	case kindScalar:
+		return n.scalar, nil
+	case kindMap:
+		out := make(yaml.MapSlice, 0, len(n.keys))
+		for _, k := range n.keys {
+			child, err := nodeToYAMLValue(n.fields[k])
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, yaml.MapItem{Key: k, Value: child})
+		}
+		return out, nil
+	case kindSeq:
+		out := make([]any, 0, len(n.seq))
+		for _, item := range n.seq {
+			v, err := nodeToYAMLValue(item)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, v)
+		}
+		return out, nil
+	}
+	return nil, fmt.Errorf("unknown node kind %v", n.kind)
+}

--- a/pkg/merge/yaml.go
+++ b/pkg/merge/yaml.go
@@ -32,7 +32,9 @@ func yamlToNode(v any) (*node, error) {
 			if err != nil {
 				return nil, err
 			}
-			n.keys = append(n.keys, ks)
+			if _, exists := n.fields[ks]; !exists {
+				n.keys = append(n.keys, ks)
+			}
 			n.fields[ks] = child
 		}
 		return n, nil

--- a/pkg/merge/yaml_test.go
+++ b/pkg/merge/yaml_test.go
@@ -179,3 +179,118 @@ func TestDumpYAML_MergeKeyRoundTrips(t *testing.T) {
 		t.Errorf("<< key lost: out=%s n2.keys=%v", out, n2.keys)
 	}
 }
+
+// TestDumpYAML_NestedMergeKey verifies the C1 concern from the workaround
+// review: a force-quoted key (here, the YAML merge key "<<") embedded inside
+// an outer mapping must produce valid YAML that round-trips. The hand-rolled
+// emission in yamlForceQuotedMap.MarshalYAML writes bytes at column 0; this
+// test confirms goccy correctly indents them when the marshaler is invoked
+// at a nested position.
+func TestDumpYAML_NestedMergeKey(t *testing.T) {
+	n := &node{
+		kind: kindMap, keys: []string{"outer"},
+		fields: map[string]*node{
+			"outer": {
+				kind: kindMap, keys: []string{"<<"},
+				fields: map[string]*node{
+					"<<": {kind: kindScalar, scalar: nil},
+				},
+			},
+		},
+	}
+	out, err := dumpYAML(n)
+	if err != nil {
+		t.Fatalf("dump: %v", err)
+	}
+	got, err := loadYAML(out)
+	if err != nil {
+		t.Fatalf("re-load failed: %v\noutput:\n%s", err, out)
+	}
+	outer := got.fields["outer"]
+	if outer == nil {
+		t.Fatalf("outer map missing after round-trip\noutput:\n%s", out)
+	}
+	if _, ok := outer.fields["<<"]; !ok {
+		t.Errorf("<< key missing from nested map after round-trip\noutput:\n%s", out)
+	}
+}
+
+// TestDumpYAML_DoublyNestedMergeKey: yamlForceQuotedMap nested inside another
+// yamlForceQuotedMap.
+func TestDumpYAML_DoublyNestedMergeKey(t *testing.T) {
+	n := &node{
+		kind: kindMap, keys: []string{"<<"},
+		fields: map[string]*node{
+			"<<": {
+				kind: kindMap, keys: []string{"<<"},
+				fields: map[string]*node{
+					"<<": {kind: kindScalar, scalar: "value"},
+				},
+			},
+		},
+	}
+	out, err := dumpYAML(n)
+	if err != nil {
+		t.Fatalf("dump: %v", err)
+	}
+	got, err := loadYAML(out)
+	if err != nil {
+		t.Fatalf("re-load failed: %v\noutput:\n%s", err, out)
+	}
+	if !nodeEqual(n, got) {
+		t.Errorf("doubly-nested round-trip changed structure\nfirst:  %+v\nsecond: %+v\noutput:\n%s", n, got, out)
+	}
+}
+
+// TestDumpYAML_ForceQuotedScalarInSequence: a sequence containing strings
+// that need force-quoting (e.g., "---", "<<", "\n").
+func TestDumpYAML_ForceQuotedScalarInSequence(t *testing.T) {
+	cases := []string{"---", "<<", "\n", "...", "true", "null"}
+	for _, s := range cases {
+		t.Run(s, func(t *testing.T) {
+			n := &node{
+				kind: kindSeq,
+				seq:  []*node{{kind: kindScalar, scalar: s}},
+			}
+			out, err := dumpYAML(n)
+			if err != nil {
+				t.Fatalf("dump: %v", err)
+			}
+			got, err := loadYAML(out)
+			if err != nil {
+				t.Fatalf("re-load failed: %v\noutput:\n%s", err, out)
+			}
+			if got.kind != kindSeq || len(got.seq) != 1 {
+				t.Fatalf("expected single-elem seq, got %+v\noutput:\n%s", got, out)
+			}
+			gotS, ok := got.seq[0].scalar.(string)
+			if !ok {
+				t.Fatalf("seq[0] not string: %T %v", got.seq[0].scalar, got.seq[0].scalar)
+			}
+			if gotS != s {
+				t.Errorf("seq scalar lost identity: want %q, got %q\noutput:\n%s", s, gotS, out)
+			}
+		})
+	}
+}
+
+// TestDumpYAML_MultilineKey: a string with newlines used as a map key.
+// needsForceQuoteAsYAMLKey returns true; the custom emitter quotes it via %q
+// so embedded \n becomes a literal escape sequence.
+func TestDumpYAML_MultilineKey(t *testing.T) {
+	n := &node{
+		kind: kindMap, keys: []string{"a\nb"},
+		fields: map[string]*node{"a\nb": {kind: kindScalar, scalar: "value"}},
+	}
+	out, err := dumpYAML(n)
+	if err != nil {
+		t.Fatalf("dump: %v", err)
+	}
+	got, err := loadYAML(out)
+	if err != nil {
+		t.Fatalf("re-load failed: %v\noutput:\n%s", err, out)
+	}
+	if !nodeEqual(n, got) {
+		t.Errorf("multi-line key round-trip changed structure\noutput:\n%s", out)
+	}
+}

--- a/pkg/merge/yaml_test.go
+++ b/pkg/merge/yaml_test.go
@@ -3,6 +3,8 @@ package merge
 import (
 	"strings"
 	"testing"
+
+	"github.com/goccy/go-yaml"
 )
 
 func TestLoadYAML_PreservesOrder(t *testing.T) {
@@ -76,5 +78,37 @@ func TestYAMLMergeRoundTrip(t *testing.T) {
 	// Order: outline before replicated-docs.
 	if strings.Index(got, "outline") > strings.Index(got, "replicated-docs") {
 		t.Errorf("expected outline before replicated-docs in:\n%s", got)
+	}
+}
+
+func TestLoadYAML_RejectsNonStringKey(t *testing.T) {
+	// The goccy/go-yaml library normalizes scalar keys to strings during
+	// UseOrderedMap decoding, so we exercise yamlToNode directly with a
+	// constructed MapSlice carrying a non-string key. This guards the
+	// defensive check that prevents 123 and "123" from silently colliding
+	// on the same Go map key if a future decoder change preserves types.
+	ms := yaml.MapSlice{
+		{Key: 123, Value: "foo"},
+		{Key: true, Value: "bar"},
+	}
+	_, err := yamlToNode(ms)
+	if err == nil {
+		t.Fatal("expected error for non-string YAML keys, got nil")
+	}
+	if !strings.Contains(err.Error(), "non-string YAML key") {
+		t.Errorf("error message should mention non-string YAML key; got: %v", err)
+	}
+}
+
+func TestYamlToNode_RejectsUnorderedMap(t *testing.T) {
+	// Direct test on the helper, since UseOrderedMap should always produce
+	// MapSlice in the production path. We pass a Go map[string]any here to
+	// confirm the defensive branch errors instead of silently losing order.
+	_, err := yamlToNode(map[string]any{"a": 1, "b": 2})
+	if err == nil {
+		t.Fatal("expected error for unordered map, got nil")
+	}
+	if !strings.Contains(err.Error(), "UseOrderedMap") {
+		t.Errorf("error message should mention UseOrderedMap; got: %v", err)
 	}
 }

--- a/pkg/merge/yaml_test.go
+++ b/pkg/merge/yaml_test.go
@@ -133,3 +133,49 @@ func TestLoadYAML_DuplicateKeysLastWins(t *testing.T) {
 		t.Errorf("dump produced invalid YAML with duplicates: %v\nout: %s", err, out)
 	}
 }
+
+func TestDumpYAML_AmbiguousStringRoundTrips(t *testing.T) {
+	// goccy/go-yaml's default marshaler leaves several string scalars bare
+	// that should be quoted — document-separator tokens "---"/"...",
+	// whitespace-only strings, strings containing newlines — so re-parsing
+	// the dump yields a different value (usually nil or ""). dumpYAML
+	// detects these and force-quotes them so round-trip is stable.
+	for _, s := range []string{"---", "...", "\n", "\t", "\n\n", "a\n", "a\nb\n"} {
+		n := &node{kind: kindScalar, scalar: s}
+		out, err := dumpYAML(n)
+		if err != nil {
+			t.Fatalf("dumpYAML(%q): %v", s, err)
+		}
+		n2, err := loadYAML(out)
+		if err != nil {
+			t.Fatalf("loadYAML(%q dump): %v", s, err)
+		}
+		got, ok := n2.scalar.(string)
+		if !ok || got != s {
+			t.Errorf("round trip lost value: input=%q dump=%q parsed=%#v", s, out, n2.scalar)
+		}
+	}
+}
+
+func TestDumpYAML_MergeKeyRoundTrips(t *testing.T) {
+	// goccy/go-yaml emits the YAML merge key "<<" bare against a null value
+	// ("<<: null"), which then fails to re-parse. dumpYAML force-quotes such
+	// keys via a custom map marshaler so round-trip is stable. We construct
+	// the node directly because goccy/go-yaml refuses some "<<:" inputs.
+	n := &node{
+		kind:   kindMap,
+		keys:   []string{"<<"},
+		fields: map[string]*node{"<<": {kind: kindScalar, scalar: nil}},
+	}
+	out, err := dumpYAML(n)
+	if err != nil {
+		t.Fatalf("dumpYAML: %v", err)
+	}
+	n2, err := loadYAML(out)
+	if err != nil {
+		t.Fatalf("re-parse failed: %v\nout: %s", err, out)
+	}
+	if _, exists := n2.fields["<<"]; !exists {
+		t.Errorf("<< key lost: out=%s n2.keys=%v", out, n2.keys)
+	}
+}

--- a/pkg/merge/yaml_test.go
+++ b/pkg/merge/yaml_test.go
@@ -112,3 +112,24 @@ func TestYamlToNode_RejectsUnorderedMap(t *testing.T) {
 		t.Errorf("error message should mention UseOrderedMap; got: %v", err)
 	}
 }
+
+func TestLoadYAML_DuplicateKeysLastWins(t *testing.T) {
+	// YAML keys 0 and 00 both normalize to string "0" via goccy/go-yaml
+	// UseOrderedMap. Ensure the loader dedupes n.keys so dumpYAML produces
+	// valid output rather than two "0:" lines (invalid YAML).
+	in := []byte("0:\n00:\n")
+	n, err := loadYAML(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(n.keys) != 1 {
+		t.Fatalf("expected single key entry, got %d: %v", len(n.keys), n.keys)
+	}
+	out, err := dumpYAML(n)
+	if err != nil {
+		t.Fatalf("dumpYAML: %v", err)
+	}
+	if _, err := loadYAML(out); err != nil {
+		t.Errorf("dump produced invalid YAML with duplicates: %v\nout: %s", err, out)
+	}
+}

--- a/pkg/merge/yaml_test.go
+++ b/pkg/merge/yaml_test.go
@@ -1,0 +1,80 @@
+package merge
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLoadYAML_PreservesOrder(t *testing.T) {
+	in := []byte("b: 2\na: 1\nnested:\n  y: Y\n  x: X\n")
+	got, err := loadYAML(in)
+	if err != nil {
+		t.Fatalf("loadYAML: %v", err)
+	}
+	wantKeys := []string{"b", "a", "nested"}
+	if len(got.keys) != len(wantKeys) {
+		t.Fatalf("keys: want %v, got %v", wantKeys, got.keys)
+	}
+	for i, k := range wantKeys {
+		if got.keys[i] != k {
+			t.Errorf("key[%d]: want %q, got %q", i, k, got.keys[i])
+		}
+	}
+}
+
+func TestLoadYAML_Sequence(t *testing.T) {
+	in := []byte("items:\n  - a\n  - b\n  - c\n")
+	got, err := loadYAML(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	items := got.fields["items"]
+	if items == nil || items.kind != kindSeq {
+		t.Fatalf("items: want kindSeq, got %+v", items)
+	}
+	if len(items.seq) != 3 {
+		t.Fatalf("len: want 3, got %d", len(items.seq))
+	}
+}
+
+func TestDumpYAML_RoundTrip(t *testing.T) {
+	in := []byte("mcp:\n  outline:\n    url: https://outline\n")
+	n, err := loadYAML(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := dumpYAML(n)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "mcp:") || !strings.Contains(got, "outline:") {
+		t.Errorf("round-trip lost structure: %s", got)
+	}
+}
+
+func TestYAMLMergeRoundTrip(t *testing.T) {
+	base := []byte("mcp:\n  outline:\n    url: https://outline\n")
+	overlay := []byte("mcp:\n  replicated-docs:\n    url: https://docs\n")
+	bn, err := loadYAML(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	on, err := loadYAML(overlay)
+	if err != nil {
+		t.Fatal(err)
+	}
+	merged := mergeNodes(bn, on)
+	out, err := dumpYAML(merged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "outline") || !strings.Contains(got, "replicated-docs") {
+		t.Errorf("merged YAML missing entries: %s", got)
+	}
+	// Order: outline before replicated-docs.
+	if strings.Index(got, "outline") > strings.Index(got, "replicated-docs") {
+		t.Errorf("expected outline before replicated-docs in:\n%s", got)
+	}
+}

--- a/pkg/mold/mold.go
+++ b/pkg/mold/mold.go
@@ -56,12 +56,13 @@ type Dependency struct {
 // OutputTarget represents a single output directory or file mapping.
 // It supports three YAML forms:
 //   - Simple string: "dest/path" (process defaults to true)
-//   - Expanded map: {dest: "dest/path", process: false, set: {...}}
+//   - Expanded map: {dest: "dest/path", process: false, set: {...}, strategy: "merge"}
 //   - List of either form, expanded into multiple targets (multi-destination)
 type OutputTarget struct {
-	Dest    string         `yaml:"dest"`
-	Process *bool          `yaml:"process,omitempty"` // nil = true (default)
-	Set     map[string]any `yaml:"set,omitempty"`     // per-destination context overrides
+	Dest     string         `yaml:"dest"`
+	Process  *bool          `yaml:"process,omitempty"`  // nil = true (default)
+	Set      map[string]any `yaml:"set,omitempty"`      // per-destination context overrides
+	Strategy string         `yaml:"strategy,omitempty"` // "" or "replace" (default) | "merge"
 }
 
 // ShouldProcess returns whether files under this target should be template-processed.

--- a/pkg/mold/mold.go
+++ b/pkg/mold/mold.go
@@ -76,6 +76,7 @@ type ResolvedFile struct {
 	DestPath string         // output path (e.g., ".claude/commands/hello.md")
 	Process  bool           // whether to apply template processing
 	Set      map[string]any // context overrides applied to this render pass
+	Strategy string         // "" or "replace" (default) | "merge"
 }
 
 // Mold represents a mold.yaml manifest.

--- a/pkg/mold/output.go
+++ b/pkg/mold/output.go
@@ -359,6 +359,18 @@ func parseTargetMap(v map[string]any) (OutputTarget, error) {
 		}
 		t.Set = sm
 	}
+	if strategy, ok := v["strategy"]; ok {
+		s, ok := strategy.(string)
+		if !ok {
+			return t, fmt.Errorf("strategy must be a string")
+		}
+		switch s {
+		case "", "replace", "merge":
+			t.Strategy = s
+		default:
+			return t, fmt.Errorf("unknown strategy %q: must be \"replace\" or \"merge\"", s)
+		}
+	}
 	return t, nil
 }
 

--- a/pkg/mold/output.go
+++ b/pkg/mold/output.go
@@ -44,10 +44,11 @@ type dirMapping struct {
 
 // fileMapping represents a normalized single-file output mapping.
 type fileMapping struct {
-	src     string // source file path in the mold fs
-	dest    string // destination file path
-	process bool
-	set     map[string]any
+	src      string // source file path in the mold fs
+	dest     string // destination file path
+	process  bool
+	set      map[string]any
+	strategy string
 }
 
 // resolveConfig holds configuration for ResolveFiles.
@@ -258,10 +259,11 @@ func parseMapOutput(m map[string]any, moldFS fs.FS) ([]dirMapping, []fileMapping
 				dirs = append(dirs, dirMapping{src: src, target: target})
 			} else {
 				files = append(files, fileMapping{
-					src:     src,
-					dest:    target.Dest,
-					process: target.ShouldProcess(),
-					set:     target.Set,
+					src:      src,
+					dest:     target.Dest,
+					process:  target.ShouldProcess(),
+					set:      target.Set,
+					strategy: target.Strategy,
 				})
 			}
 		}
@@ -402,6 +404,7 @@ func resolveFromMappings(dirs []dirMapping, files []fileMapping, moldFS fs.FS) (
 						DestPath: fo.dest,
 						Process:  fo.process,
 						Set:      fo.set,
+						Strategy: fo.strategy,
 					})
 				}
 				delete(fileOverrides, p) // consumed
@@ -418,6 +421,7 @@ func resolveFromMappings(dirs []dirMapping, files []fileMapping, moldFS fs.FS) (
 				DestPath: destPath,
 				Process:  dm.target.ShouldProcess(),
 				Set:      dm.target.Set,
+				Strategy: dm.target.Strategy,
 			})
 			return nil
 		})
@@ -438,6 +442,7 @@ func resolveFromMappings(dirs []dirMapping, files []fileMapping, moldFS fs.FS) (
 				DestPath: f.dest,
 				Process:  f.process,
 				Set:      f.set,
+				Strategy: f.strategy,
 			})
 		}
 	}

--- a/pkg/mold/output.go
+++ b/pkg/mold/output.go
@@ -367,10 +367,10 @@ func parseTargetMap(v map[string]any) (OutputTarget, error) {
 			return t, fmt.Errorf("strategy must be a string")
 		}
 		switch s {
-		case "", "replace", "merge":
+		case "", "replace", "merge", "append":
 			t.Strategy = s
 		default:
-			return t, fmt.Errorf("unknown strategy %q: must be \"replace\" or \"merge\"", s)
+			return t, fmt.Errorf("unknown strategy %q: must be \"replace\", \"merge\", or \"append\"", s)
 		}
 	}
 	return t, nil

--- a/pkg/mold/output_test.go
+++ b/pkg/mold/output_test.go
@@ -704,3 +704,58 @@ func TestParseTargetMap_Strategy(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveFiles_StrategyPropagation(t *testing.T) {
+	moldFS := fstest.MapFS{
+		"config/opencode.json": &fstest.MapFile{Data: []byte("{}")},
+		"commands/hello.md":    &fstest.MapFile{Data: []byte("hello")},
+	}
+
+	output := map[string]any{
+		"config/opencode.json": map[string]any{
+			"dest":     "opencode.json",
+			"strategy": "merge",
+		},
+		"commands": ".claude/commands",
+	}
+
+	resolved, err := ResolveFiles(output, moldFS)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gotStrategy := map[string]string{}
+	for _, rf := range resolved {
+		gotStrategy[rf.SrcPath] = rf.Strategy
+	}
+	if got := gotStrategy["config/opencode.json"]; got != "merge" {
+		t.Errorf("opencode.json: want strategy=merge, got %q", got)
+	}
+	if got := gotStrategy["commands/hello.md"]; got != "" {
+		t.Errorf("hello.md: want strategy=\"\", got %q", got)
+	}
+}
+
+func TestResolveFiles_StrategyPropagation_DirOutput(t *testing.T) {
+	moldFS := fstest.MapFS{
+		"shared/opencode.json": &fstest.MapFile{Data: []byte("{}")},
+	}
+
+	output := map[string]any{
+		"shared": map[string]any{
+			"dest":     ".",
+			"strategy": "merge",
+		},
+	}
+
+	resolved, err := ResolveFiles(output, moldFS)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resolved) != 1 {
+		t.Fatalf("expected 1 resolved file, got %d", len(resolved))
+	}
+	if resolved[0].Strategy != "merge" {
+		t.Errorf("want strategy=merge, got %q", resolved[0].Strategy)
+	}
+}

--- a/pkg/mold/output_test.go
+++ b/pkg/mold/output_test.go
@@ -672,3 +672,35 @@ func TestResolveFiles_ExcludesReservedDirs(t *testing.T) {
 		t.Errorf("expected dest .claude/commands/hello.md, got %s", rf.DestPath)
 	}
 }
+
+func TestParseTargetMap_Strategy(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   map[string]any
+		want    string
+		wantErr bool
+	}{
+		{name: "absent", input: map[string]any{"dest": "x"}, want: ""},
+		{name: "replace", input: map[string]any{"dest": "x", "strategy": "replace"}, want: "replace"},
+		{name: "merge", input: map[string]any{"dest": "x", "strategy": "merge"}, want: "merge"},
+		{name: "unknown", input: map[string]any{"dest": "x", "strategy": "smush"}, wantErr: true},
+		{name: "non-string", input: map[string]any{"dest": "x", "strategy": 7}, wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseTargetMap(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (target=%+v)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Strategy != tc.want {
+				t.Fatalf("Strategy: want %q, got %q", tc.want, got.Strategy)
+			}
+		})
+	}
+}

--- a/pkg/mold/output_test.go
+++ b/pkg/mold/output_test.go
@@ -683,6 +683,7 @@ func TestParseTargetMap_Strategy(t *testing.T) {
 		{name: "absent", input: map[string]any{"dest": "x"}, want: ""},
 		{name: "replace", input: map[string]any{"dest": "x", "strategy": "replace"}, want: "replace"},
 		{name: "merge", input: map[string]any{"dest": "x", "strategy": "merge"}, want: "merge"},
+		{name: "append", input: map[string]any{"dest": "x", "strategy": "append"}, want: "append"},
 		{name: "unknown", input: map[string]any{"dest": "x", "strategy": "smush"}, wantErr: true},
 		{name: "non-string", input: map[string]any{"dest": "x", "strategy": 7}, wantErr: true},
 	}


### PR DESCRIPTION
Closes #171.

## Problem

When casting multiple molds into the same project, two molds (or two output entries within one mold) can target the same destination file. Today the second write wins — the first mold's content is overwritten wholesale. The motivating case is multiple molds each producing `opencode.json` with their own MCP server entries; the user expects them to combine, but the last cast clobbers the first.

## Solution

Add an opt-in `strategy` field on flux.yaml output entries:

```yaml
output:
  mcp:
    - dest: opencode.json
      strategy: merge       # "" or "replace" (default) | "merge"
      set:
        agent.current_target: opencode
```

When `strategy: merge` is set on a JSON or YAML destination, casting deep-merges the new content into the existing on-disk file instead of overwriting. Default behavior (no `strategy` field) is bit-identical to today.

## Merge semantics

- Detected by extension (`.json`, `.yaml`, `.yml`); other extensions silently fall back to replace.
- **Maps**: deep-merge. Existing keys keep their position; overlay-only keys are appended in declared order.
- **Arrays**: concat with deep-equality dedupe (base entries first, then overlay-only).
- **Type mismatch** (e.g., scalar replaced by a map): overlay wins.
- **Non-existent destination**: write the new content verbatim.
- **JSON output**: 2-space indented, key insertion order preserved, integers preserved as integers (no float coercion), HTML escape disabled so URLs with `&` don't become `&`.
- **YAML output**: 2-space indented, key insertion order preserved via goccy/go-yaml's `UseOrderedMap`. Comments and anchors are *not guaranteed* to survive round-tripping (documented).

## Malformed existing files

If the destination is hand-edited and no longer parses, `cast` errors out by default to avoid clobbering the user's work, with an actionable error suggesting `--force-replace-on-parse-error` to opt into clobbering. The flag is also exposed via `CastOptions.ForceReplaceOnParseError` so the foundries TUI core (`CastMold`) and `forge --output` can plumb it through their own UIs.

## Implementation

A new `pkg/merge/` package with public surface `MergeFile(destPath, newContent, opts)` / `Options{ForceReplaceOnParseError}` / `*ParseError`. Internally split into:

- `merge.go` — read → parse → merge → serialize → write dispatcher.
- `deep.go` — format-agnostic ordered `node` tree + `mergeNodes` (preserves base map order, appends overlay-only keys, concats sequences with deep-equality dedupe) + `nodeEqual`.
- `json.go` — order-preserving load/dump using `json.Decoder.Token` + `UseNumber`.
- `yaml.go` — order-preserving load/dump using goccy/go-yaml's `UseOrderedMap` + `MapSlice`.

Wired into `internal/commands/cast.go` via a `switch rf.Strategy` block in `copyResolvedFiles` (replacing the single `os.WriteFile` call site). The mirror change lands in `internal/commands/forge.go`'s `writeForgeFiles` so `forge --output` previews behave the same way as `cast`.

## Test plan

- [x] `pkg/merge` unit tests: format-agnostic merge logic (scalar overwrite, type mismatch, map order preservation, nested map merge, sequence concat-dedupe, deep-equality dedupe, json.Number string identity), JSON load/dump (order, integer fidelity, MCP fixture, HTML-escape regression, trailing-garbage rejection), YAML load/dump (order, sequences, MCP fixture, non-string-key error, unordered-map error), and file-level dispatcher (nonexistent dest, unknown ext, JSON merge, YAML merge, malformed dest with and without force flag, read errors, malformed new content).
- [x] `pkg/mold` unit tests: `parseTargetMap` strategy parsing/validation, `ResolvedFile` strategy propagation through both file-form and dir-form output mappings.
- [x] Cast integration tests: single-mold merge against pre-seeded `opencode.json`; two-mold foundry-like merge (the literal acceptance criterion from #171); force-replace-on-parse-error plumbing through `copyResolvedFiles`'s new parameter.
- [x] Forge integration test: `writeForgeFiles` deep-merges into pre-existing destination under `--output`.
- [x] `go build ./...`, `go test ./... -count=1`, `go vet ./...` — all green.
- [x] Manually verified `ailloy cast --help` and `ailloy forge --help` both surface `--force-replace-on-parse-error`.

## Backwards compatibility

Backwards compatible. Omitting `strategy` is bit-identical to today's behavior — the existing `os.MkdirAll` + `os.WriteFile` write path is preserved unchanged inside the new switch's `case "", "replace":` branch. No flag day, no migration. Existing molds keep working.

## Docs

- `docs/flux.md` — new `strategy` reference subsection inside Output Mapping with the value table, motivating MCP example, merge semantics, formatting guarantees, malformed-file handling, and the `forge --output` parity note.
- `docs/blanks.md` — new "fan-in: many sources, one destination" subsection mirroring the existing fan-out section, cross-referencing the flux strategy docs so authors discover the feature when they hit the multi-mold-shared-config case.

## Out of scope (future tickets)

- Other strategies (`append`, line-merge for `.gitignore`, etc.).
- Cross-mold conflict reporting or dry-run preview of merged output.
- Explicit `format: json|yaml` field to override extension detection.
- YAML comment / anchor preservation guarantees.
- File locking for concurrent casts.