### PR TITLE
fix: foundries flux picker save/load and footer hints

### DIFF
--- a/docs/foundry.md
+++ b/docs/foundry.md
@@ -277,10 +277,10 @@ mold.
 | `↑` / `↓` | move cursor through results |
 | `tab` | commit top match into the type-aware editor |
 | `enter` | commit highlighted match (filter) / save value (editor) |
-| `d` | clear the override on the highlighted key |
-| `R` | reset every override in this session |
-| `s` | open the save-target prompt |
-| `esc` | cancel editor, or close picker (prompts to save when there are unsaved overrides) |
+| `d` | clear the override on the highlighted key (when filter blurred) |
+| `R` | reset every override in this session (when filter blurred) |
+| `ctrl+s` | open the save-target prompt (works regardless of filter focus) |
+| `esc` | cancel editor; close picker; or open the save prompt when there are unsaved overrides. From the save prompt, `esc` discards & closes. |
 
 Each row shows a badge: `●` set in this session, `○` value comes from
 `flux.yaml` defaults, blank for unset/required. The editor shape is
@@ -295,6 +295,12 @@ The save prompt routes the overrides three ways:
 - `[o]` this cast only — keeps the values in TUI memory and threads them as
   `--set` overrides into the next cast of that mold (cleared on success,
   retained on failure for retry).
+
+Project- and global-saved files are **auto-loaded by every cast of that
+mold** (CLI or TUI). They layer between the mold's built-in defaults and any
+user-supplied `-f` files, with project winning over global on conflict. So
+saving `target: opencode` to project once is enough — subsequent
+`ailloy cast <ref>` invocations pick it up without `-f`.
 
 The `<slug>` is derived from the full mold ref (e.g., `github.com/nimble-giant/agents` → `github.com_nimble-giant_agents`) so molds with the same final segment under different foundries — including nested foundries that re-export shared molds — don't clobber each other on disk.
 

--- a/internal/commands/cast.go
+++ b/internal/commands/cast.go
@@ -74,7 +74,7 @@ func runCast(_ *cobra.Command, args []string) error {
 		return err
 	}
 	if castClaudePluginFlag {
-		return castClaudePlugin(reader)
+		return castClaudePlugin(reader, source)
 	}
 	return castProject(reader, source)
 }
@@ -129,8 +129,12 @@ func resolveMoldReader(args []string) (*blanks.MoldReader, string, error) {
 }
 
 // loadCastFlux loads layered flux values using Helm-style precedence:
-// mold flux.yaml < mold.yaml schema defaults < -f files (left to right) < --set flags
-func loadCastFlux(reader *blanks.MoldReader) (map[string]any, error) {
+// mold flux.yaml < mold.yaml schema defaults < persisted ~/.ailloy/flux/<slug>.yaml
+// < persisted ./.ailloy/flux/<slug>.yaml < -f files (left to right) < --set flags.
+//
+// `source` is the mold ref used to derive the persisted-file slug (typically the
+// foundry cache key for remote refs). Empty source skips persisted-file lookup.
+func loadCastFlux(reader *blanks.MoldReader, source string) (map[string]any, error) {
 	// Layer 1: Load mold flux.yaml as base
 	fluxDefaults, err := reader.LoadFluxDefaults()
 	if err != nil {
@@ -148,7 +152,21 @@ func loadCastFlux(reader *blanks.MoldReader) (map[string]any, error) {
 		flux[k] = v
 	}
 
-	// Layer 3: Layer -f files left-to-right (each overrides previous)
+	// Layer 3: persisted flux files written by the foundries TUI (global, then
+	// project — project wins on conflict). Layered before user-supplied -f so
+	// explicit -f still overrides saved values.
+	persisted := mold.PersistedFluxPaths(source)
+	if len(persisted) > 0 {
+		overlay, err := mold.LayerFluxFiles(persisted)
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range overlay {
+			flux[k] = v
+		}
+	}
+
+	// Layer 4: Layer -f files left-to-right (each overrides previous)
 	if len(castValFiles) > 0 {
 		overlay, err := mold.LayerFluxFiles(castValFiles)
 		if err != nil {
@@ -159,7 +177,7 @@ func loadCastFlux(reader *blanks.MoldReader) (map[string]any, error) {
 		}
 	}
 
-	// Layer 4: Apply --set overrides (highest precedence)
+	// Layer 5: Apply --set overrides (highest precedence)
 	if err := mold.ApplySetOverrides(flux, castSetFlags); err != nil {
 		return nil, err
 	}
@@ -212,7 +230,7 @@ func castProject(reader *blanks.MoldReader, source string) error {
 	}
 
 	// Load flux values and extract output mapping.
-	flux, err := loadCastFlux(reader)
+	flux, err := loadCastFlux(reader, source)
 	if err != nil {
 		flux = make(map[string]any)
 	}

--- a/internal/commands/cast_core.go
+++ b/internal/commands/cast_core.go
@@ -76,7 +76,7 @@ func CastMold(_ context.Context, ref string, opts CastOptions) (CastResult, erro
 		res.MoldName = manifest.Name
 	}
 
-	flux, err := layerFluxForCore(reader, opts.ValueFiles, opts.SetOverrides)
+	flux, err := layerFluxForCore(reader, source, opts.ValueFiles, opts.SetOverrides)
 	if err != nil {
 		return res, err
 	}
@@ -216,8 +216,10 @@ func openMoldReaderForCore(ref string, global bool) (*blanks.MoldReader, *foundr
 }
 
 // layerFluxForCore mirrors loadCastFlux but is parameterized so CastMold
-// doesn't depend on package-level cast flag vars.
-func layerFluxForCore(reader *blanks.MoldReader, valueFiles, setOverrides []string) (map[string]any, error) {
+// doesn't depend on package-level cast flag vars. `source` is the resolved
+// mold ref used to pick up persisted flux files (~/.ailloy/flux/<slug>.yaml
+// then ./.ailloy/flux/<slug>.yaml). Empty source skips persisted-file lookup.
+func layerFluxForCore(reader *blanks.MoldReader, source string, valueFiles, setOverrides []string) (map[string]any, error) {
 	defaults, err := reader.LoadFluxDefaults()
 	if err != nil {
 		defaults = make(map[string]any)
@@ -229,6 +231,15 @@ func layerFluxForCore(reader *blanks.MoldReader, valueFiles, setOverrides []stri
 	flux := make(map[string]any, len(defaults))
 	for k, v := range defaults {
 		flux[k] = v
+	}
+	if persisted := mold.PersistedFluxPaths(source); len(persisted) > 0 {
+		overlay, err := mold.LayerFluxFiles(persisted)
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range overlay {
+			flux[k] = v
+		}
 	}
 	if len(valueFiles) > 0 {
 		overlay, err := mold.LayerFluxFiles(valueFiles)

--- a/internal/commands/cast_core_test.go
+++ b/internal/commands/cast_core_test.go
@@ -1,0 +1,89 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nimble-giant/ailloy/pkg/blanks"
+	"github.com/nimble-giant/ailloy/pkg/mold"
+)
+
+// TestLayerFluxForCore_AutoLoadsPersistedFluxFiles asserts that
+// ./.ailloy/flux/<slug>.yaml and ~/.ailloy/flux/<slug>.yaml are layered into
+// the cast pipeline between mold defaults and explicit -f files. This is the
+// fix for the bug where the foundries TUI's project/global save wrote files
+// that nothing read.
+func TestLayerFluxForCore_AutoLoadsPersistedFluxFiles(t *testing.T) {
+	homeDir := t.TempDir()
+	projectDir := t.TempDir()
+	t.Chdir(projectDir)
+	t.Setenv("HOME", homeDir)
+
+	// Build a minimal mold dir on disk so MoldReader can load it.
+	moldDir := filepath.Join(projectDir, "mold")
+	if err := os.MkdirAll(moldDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	manifest := []byte(`name: launch
+flux:
+  - name: target
+    type: string
+    default: claude
+`)
+	if err := os.WriteFile(filepath.Join(moldDir, "mold.yaml"), manifest, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	reader, err := blanks.NewMoldReaderFromPath(moldDir)
+	if err != nil {
+		t.Fatalf("MoldReaderFromPath: %v", err)
+	}
+
+	source := "github.com/kris/replicated-foundry/molds/launch"
+	slug := mold.FluxFileSlug(source)
+
+	// Without any persisted file: target == default.
+	flux, err := layerFluxForCore(reader, source, nil, nil)
+	if err != nil {
+		t.Fatalf("layerFluxForCore: %v", err)
+	}
+	if got := flux["target"]; got != "claude" {
+		t.Fatalf("expected default target=claude; got %v", got)
+	}
+
+	// Write project-scoped persisted file with target: opencode.
+	projectFlux := filepath.Join(".ailloy", "flux", slug+".yaml")
+	if err := os.MkdirAll(filepath.Dir(projectFlux), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(projectFlux, []byte("target: opencode\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	flux, err = layerFluxForCore(reader, source, nil, nil)
+	if err != nil {
+		t.Fatalf("layerFluxForCore: %v", err)
+	}
+	if got := flux["target"]; got != "opencode" {
+		t.Fatalf("expected project-saved target=opencode; got %v", got)
+	}
+
+	// Explicit --set still wins over persisted file (Helm-style precedence).
+	flux, err = layerFluxForCore(reader, source, nil, []string{"target=zed"})
+	if err != nil {
+		t.Fatalf("layerFluxForCore: %v", err)
+	}
+	if got := flux["target"]; got != "zed" {
+		t.Fatalf("expected --set to win over persisted; got %v", got)
+	}
+
+	// Empty source skips persisted-file lookup (local mold dirs).
+	flux, err = layerFluxForCore(reader, "", nil, nil)
+	if err != nil {
+		t.Fatalf("layerFluxForCore: %v", err)
+	}
+	if got := flux["target"]; got != "claude" {
+		t.Fatalf("expected default when source empty; got %v", got)
+	}
+}

--- a/internal/commands/cast_plugin.go
+++ b/internal/commands/cast_plugin.go
@@ -36,13 +36,16 @@ type pluginPackageResult struct {
 // castClaudePlugin is the CLI entrypoint for `ailloy cast --claude-plugin`.
 // It prints the banner and success message; the underlying pipeline lives in
 // packageMoldAsClaudePlugin so foundry install / CastMold can share it.
-func castClaudePlugin(reader *blanks.MoldReader) error {
+//
+// `source` is the resolved mold ref used to pick up persisted flux files; it
+// is "" for local mold dirs and embedded molds.
+func castClaudePlugin(reader *blanks.MoldReader, source string) error {
 	if !castSilent.Load() {
 		fmt.Println(styles.WorkingBanner("Casting Ailloy mold as Claude Code plugin..."))
 		fmt.Println()
 	}
 
-	flux, err := loadCastFlux(reader)
+	flux, err := loadCastFlux(reader, source)
 	if err != nil {
 		flux = make(map[string]any)
 	}

--- a/internal/commands/cast_plugin_test.go
+++ b/internal/commands/cast_plugin_test.go
@@ -106,7 +106,7 @@ func TestCastClaudePlugin_FullPipeline(t *testing.T) {
 	chdir(t, tmp)
 
 	reader := fixtureMoldReader()
-	if err := castClaudePlugin(reader); err != nil {
+	if err := castClaudePlugin(reader, ""); err != nil {
 		t.Fatalf("castClaudePlugin: %v", err)
 	}
 
@@ -151,7 +151,7 @@ func TestCastClaudePlugin_FluxOverride(t *testing.T) {
 	chdir(t, tmp)
 
 	reader := fixtureMoldReader()
-	if err := castClaudePlugin(reader); err != nil {
+	if err := castClaudePlugin(reader, ""); err != nil {
 		t.Fatalf("castClaudePlugin: %v", err)
 	}
 
@@ -172,7 +172,7 @@ func TestCastClaudePlugin_WithWorkflowsWarnsAndSkips(t *testing.T) {
 	chdir(t, tmp)
 
 	reader := fixtureMoldReader()
-	if err := castClaudePlugin(reader); err != nil {
+	if err := castClaudePlugin(reader, ""); err != nil {
 		t.Fatalf("castClaudePlugin: %v", err)
 	}
 
@@ -210,7 +210,7 @@ func TestCastClaudePlugin_RecastReplacesContents(t *testing.T) {
 	}
 
 	reader := fixtureMoldReader()
-	if err := castClaudePlugin(reader); err != nil {
+	if err := castClaudePlugin(reader, ""); err != nil {
 		t.Fatalf("castClaudePlugin: %v", err)
 	}
 
@@ -231,7 +231,7 @@ func TestCastClaudePlugin_GlobalRoutesToHome(t *testing.T) {
 	t.Setenv("HOME", tmp)
 
 	reader := fixtureMoldReader()
-	if err := castClaudePlugin(reader); err != nil {
+	if err := castClaudePlugin(reader, ""); err != nil {
 		t.Fatalf("castClaudePlugin: %v", err)
 	}
 
@@ -250,7 +250,7 @@ func TestCastClaudePlugin_PluginNameOverride(t *testing.T) {
 	chdir(t, tmp)
 
 	reader := fixtureMoldReader()
-	if err := castClaudePlugin(reader); err != nil {
+	if err := castClaudePlugin(reader, ""); err != nil {
 		t.Fatalf("castClaudePlugin: %v", err)
 	}
 

--- a/internal/tui/foundries/discover/model.go
+++ b/internal/tui/foundries/discover/model.go
@@ -396,6 +396,6 @@ func (m Model) View() string {
 
 	fmt.Fprintf(&b, "\n%s\n", metaStyle.Render(fmt.Sprintf("%d selected · %d shown · %d total",
 		len(m.selected), len(visible), len(m.catalog))))
-	b.WriteString(metaStyle.Render("space toggle · enter cast all · / search · c clear · r refresh · j/k move") + "\n")
+	b.WriteString(metaStyle.Render("space toggle · enter cast all · / search · c clear · r refresh · f flux · j/k move") + "\n")
 	return b.String()
 }

--- a/internal/tui/foundries/fluxpicker/integration_test.go
+++ b/internal/tui/foundries/fluxpicker/integration_test.go
@@ -44,12 +44,8 @@ func TestEndToEnd_SaveToProject(t *testing.T) {
 		t.Fatalf("override not applied: %+v", m.Overrides())
 	}
 
-	// Blur the filter so that the 's' shortcut key is recognized (not typed
-	// into the filter text input).
-	m.filter.Blur()
-
-	// Open save prompt and save to project.
-	m, _ = m.Update(keyMsg("s"))
+	// Open save prompt via Ctrl+S; works regardless of filter focus.
+	m, _ = m.Update(keyMsg("ctrl+s"))
 	if m.focus != focusSavePrompt {
 		t.Fatalf("expected save prompt, got focus=%v", m.focus)
 	}
@@ -90,11 +86,7 @@ func TestEndToEnd_SessionTargetSkipsDisk(t *testing.T) {
 	m := New().OpenFor("ref", data.ScopeProject, schema, nil)
 	m = m.SetOverride("k", "v")
 
-	// Blur the filter so that the 's' shortcut key is recognized (not typed
-	// into the filter text input).
-	m.filter.Blur()
-
-	m, _ = m.Update(keyMsg("s"))
+	m, _ = m.Update(keyMsg("ctrl+s"))
 	if m.focus != focusSavePrompt {
 		t.Fatalf("expected save prompt focus, got %v", m.focus)
 	}

--- a/internal/tui/foundries/fluxpicker/persist.go
+++ b/internal/tui/foundries/fluxpicker/persist.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+
+	"github.com/nimble-giant/ailloy/pkg/mold"
 )
 
 // writeFluxFile writes overrides into a YAML file at path, merging with any
@@ -93,6 +95,10 @@ func resolveGlobalPath(moldName string) (string, error) {
 	return filepath.Join(home, ".ailloy", "flux", moldName+".yaml"), nil
 }
 
+// fluxFileSlug delegates to the shared slug helper. Kept as a package-local
+// alias so existing call sites stay readable.
+var fluxFileSlug = mold.FluxFileSlug
+
 // persistOverrides routes overrides to the chosen save target. Returns the
 // path written (empty string for SaveTargetSession).
 func persistOverrides(moldName string, target SaveTarget, overrides map[string]any) (string, error) {
@@ -110,46 +116,6 @@ func persistOverrides(moldName string, target SaveTarget, overrides map[string]a
 		return path, writeFluxFile(path, overrides)
 	}
 	return "", fmt.Errorf("unknown save target %v", target)
-}
-
-// fluxFileSlug derives a deterministic, filesystem-safe filename stem from a
-// mold ref. The full source is preserved (with separators replaced) so molds
-// with the same final segment under different foundries — including nested
-// foundries that can re-export molds — don't collide on disk.
-//
-//	"github.com/nimble-giant/agents@v1"  → "github.com_nimble-giant_agents_v1"
-//	"nimble-giant/agents"                → "nimble-giant_agents"
-//	"agents"                             → "agents"
-//
-// Anything that isn't [A-Za-z0-9._-] is collapsed to '_'.
-func fluxFileSlug(ref string) string {
-	ref = strings.TrimSuffix(strings.TrimSpace(ref), ".git")
-	if ref == "" {
-		return "mold"
-	}
-	out := make([]byte, 0, len(ref))
-	for i := 0; i < len(ref); i++ {
-		c := ref[i]
-		switch {
-		case c >= 'a' && c <= 'z',
-			c >= 'A' && c <= 'Z',
-			c >= '0' && c <= '9',
-			c == '.', c == '-':
-			out = append(out, c)
-		default:
-			if len(out) > 0 && out[len(out)-1] != '_' {
-				out = append(out, '_')
-			}
-		}
-	}
-	// Trim trailing underscore from collapsed runs at the tail.
-	for len(out) > 0 && out[len(out)-1] == '_' {
-		out = out[:len(out)-1]
-	}
-	if len(out) == 0 {
-		return "mold"
-	}
-	return string(out)
 }
 
 // mergeOverrides returns a new map combining defaults and overrides

--- a/internal/tui/foundries/fluxpicker/update.go
+++ b/internal/tui/foundries/fluxpicker/update.go
@@ -31,6 +31,19 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 }
 
 func (m Model) handleKey(k tea.KeyMsg) (Model, tea.Cmd) {
+	// Ctrl+S opens the save prompt from any focus mode. Filter input
+	// otherwise swallows letter shortcuts, so a non-letter binding is the
+	// only one that reliably reaches the picker while typing.
+	if k.Type == tea.KeyCtrlS && m.focus != focusSavePrompt {
+		if len(m.overrides) == 0 {
+			return m, nil
+		}
+		m.saving = saveState{active: true}
+		m.focus = focusSavePrompt
+		m.editor = editorState{}
+		m.filter.Blur()
+		return m, nil
+	}
 	switch m.focus {
 	case focusEditor:
 		return m.handleEditorKey(k)
@@ -88,8 +101,9 @@ func (m Model) handleFilterKey(k tea.KeyMsg) (Model, tea.Cmd) {
 		return m, nil
 	case tea.KeyRunes:
 		// Single-character shortcuts only fire when the filter is blurred —
-		// otherwise typing 'd'/'R'/'s' into the filter would clear overrides
-		// or open the save prompt instead of editing the query.
+		// otherwise typing 'd'/'R' into the filter would clear overrides.
+		// Save is bound to Ctrl+S in handleKey so it works regardless of
+		// filter focus.
 		if len(k.Runes) == 1 && !m.filter.Focused() {
 			switch k.Runes[0] {
 			case 'd':
@@ -100,10 +114,6 @@ func (m Model) handleFilterKey(k tea.KeyMsg) (Model, tea.Cmd) {
 				return m, nil
 			case 'R':
 				return m.ResetOverrides(), nil
-			case 's':
-				m.saving = saveState{active: true}
-				m.focus = focusSavePrompt
-				return m, nil
 			}
 		}
 	}
@@ -161,10 +171,11 @@ func (m Model) handleEditorKey(k tea.KeyMsg) (Model, tea.Cmd) {
 // handleSaveKey handles key events when the save-target prompt is focused.
 func (m Model) handleSaveKey(k tea.KeyMsg) (Model, tea.Cmd) {
 	if k.Type == tea.KeyEsc {
-		m.saving = saveState{}
-		m.focus = focusFilter
-		m.filter.Focus()
-		return m, nil
+		// Discard pending overrides and close. The picker reached this prompt
+		// because the user opted to save (ctrl+s) or pressed esc with pending
+		// overrides; an esc from here is the explicit "throw it away" action.
+		m = m.ResetOverrides()
+		return m.Close(), nil
 	}
 	if k.Type == tea.KeyRunes && len(k.Runes) == 1 {
 		var target SaveTarget

--- a/internal/tui/foundries/fluxpicker/update_test.go
+++ b/internal/tui/foundries/fluxpicker/update_test.go
@@ -21,6 +21,8 @@ func keyMsg(s string) tea.KeyMsg {
 		return tea.KeyMsg{Type: tea.KeyDown}
 	case "up":
 		return tea.KeyMsg{Type: tea.KeyUp}
+	case "ctrl+s":
+		return tea.KeyMsg{Type: tea.KeyCtrlS}
 	default:
 		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
 	}
@@ -87,16 +89,28 @@ func TestUpdate_RResetsAllOverrides(t *testing.T) {
 	}
 }
 
-func TestUpdate_SOpensSavePrompt(t *testing.T) {
+func TestUpdate_CtrlSOpensSavePrompt(t *testing.T) {
+	// Ctrl+S works regardless of filter focus; we deliberately leave the
+	// filter focused (its default state in OpenFor) to prove the binding
+	// reaches the picker even while the user is typing.
 	m := New().OpenFor("a", data.ScopeProject,
-		[]mold.FluxVar{{Name: "k"}}, nil)
-	m.filter.Blur()
-	m, _ = m.Update(keyMsg("s"))
+		[]mold.FluxVar{{Name: "k"}}, nil).
+		SetOverride("k", "v")
+	m, _ = m.Update(keyMsg("ctrl+s"))
 	if m.focus != focusSavePrompt {
 		t.Fatalf("expected save prompt focus, got %v", m.focus)
 	}
 	if !m.saving.active {
 		t.Fatal("expected saving.active=true")
+	}
+}
+
+func TestUpdate_CtrlSWithNoOverridesIsNoop(t *testing.T) {
+	m := New().OpenFor("a", data.ScopeProject,
+		[]mold.FluxVar{{Name: "k"}}, nil)
+	m, _ = m.Update(keyMsg("ctrl+s"))
+	if m.focus == focusSavePrompt {
+		t.Fatal("expected save prompt to remain closed when no overrides exist")
 	}
 }
 
@@ -162,16 +176,21 @@ func TestHandleSaveKey_SessionEmitsMsg(t *testing.T) {
 	}
 }
 
-func TestHandleSaveKey_EscReturnsToFilter(t *testing.T) {
-	m := New().OpenFor("ref", data.ScopeProject, nil, nil)
+func TestHandleSaveKey_EscDiscardsAndCloses(t *testing.T) {
+	// Esc from the save prompt is the explicit "throw it away" action: the
+	// user already opted to save (ctrl+s, or esc-with-overrides) and is
+	// declining; closing the picker matches the dialog's [esc] discard label.
+	m := New().OpenFor("ref", data.ScopeProject,
+		[]mold.FluxVar{{Name: "k", Type: "string"}}, nil).
+		SetOverride("k", "v")
 	m.saving = saveState{active: true}
 	m.focus = focusSavePrompt
 	m, _ = m.Update(keyMsg("esc"))
-	if m.focus != focusFilter {
-		t.Fatalf("expected focus to return to filter, got %v", m.focus)
+	if m.IsOpen() {
+		t.Fatal("expected picker to close on esc-from-save-prompt")
 	}
-	if m.saving.active {
-		t.Fatal("expected saving cleared")
+	if len(m.Overrides()) != 0 {
+		t.Fatalf("expected overrides discarded, got %+v", m.Overrides())
 	}
 }
 

--- a/internal/tui/foundries/fluxpicker/view.go
+++ b/internal/tui/foundries/fluxpicker/view.go
@@ -7,7 +7,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-const footerHint = "tab: commit filter   enter: save key   d: clear   R: reset all   s: save & close   esc: cancel"
+const footerHint = "tab: commit filter   enter: edit key   ctrl+s: save & close   esc: discard / close"
 
 var (
 	pickerBox = lipgloss.NewStyle().
@@ -76,7 +76,9 @@ func (m Model) View() string {
 	}
 
 	if m.saving.active {
-		b.WriteString("\nsave: [p] project  [g] global  [o] this cast only  [esc] cancel\n")
+		fmt.Fprintf(&b,
+			"\nSave %d override(s)?  [p] project (.ailloy/flux/)  [g] global (~/.ailloy/flux/)  [o] this cast only  [esc] discard & close\n",
+			len(m.overrides))
 	}
 
 	if m.err != nil {

--- a/internal/tui/foundries/installed/model.go
+++ b/internal/tui/foundries/installed/model.go
@@ -246,6 +246,6 @@ func (m Model) View() string {
 			metaStyle.Render(it.Entry.Source),
 			legacy)
 	}
-	b.WriteString("\n" + metaStyle.Render("u update · x uninstall · r refresh · j/k move") + "\n")
+	b.WriteString("\n" + metaStyle.Render("u update · x uninstall · r refresh · f flux · j/k move") + "\n")
 	return b.String()
 }

--- a/pkg/mold/flux_persist.go
+++ b/pkg/mold/flux_persist.go
@@ -1,0 +1,80 @@
+package mold
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// FluxFileSlug derives a deterministic, filesystem-safe filename stem from a
+// mold ref. The full source is preserved (with separators replaced) so molds
+// with the same final segment under different foundries — including nested
+// foundries that re-export shared molds — don't collide on disk.
+//
+//	"github.com/nimble-giant/agents@v1"  → "github.com_nimble-giant_agents_v1"
+//	"nimble-giant/agents"                → "nimble-giant_agents"
+//	"agents"                             → "agents"
+//
+// Anything that isn't [A-Za-z0-9._-] is collapsed to '_'.
+func FluxFileSlug(ref string) string {
+	ref = strings.TrimSuffix(strings.TrimSpace(ref), ".git")
+	if ref == "" {
+		return "mold"
+	}
+	out := make([]byte, 0, len(ref))
+	for i := 0; i < len(ref); i++ {
+		c := ref[i]
+		switch {
+		case c >= 'a' && c <= 'z',
+			c >= 'A' && c <= 'Z',
+			c >= '0' && c <= '9',
+			c == '.', c == '-':
+			out = append(out, c)
+		default:
+			if len(out) > 0 && out[len(out)-1] != '_' {
+				out = append(out, '_')
+			}
+		}
+	}
+	for len(out) > 0 && out[len(out)-1] == '_' {
+		out = out[:len(out)-1]
+	}
+	if len(out) == 0 {
+		return "mold"
+	}
+	return string(out)
+}
+
+// PersistedFluxPaths returns the existing persisted flux files for the given
+// mold ref, in load order (global, then project). Files that don't exist are
+// omitted. Empty ref returns nil.
+//
+// Layering order matches Helm conventions: more specific (project) wins over
+// less specific (global). Both sit between the mold's built-in defaults and
+// any user-supplied -f files.
+func PersistedFluxPaths(ref string) []string {
+	if strings.TrimSpace(ref) == "" {
+		return nil
+	}
+	slug := FluxFileSlug(ref)
+	var paths []string
+	if home, err := os.UserHomeDir(); err == nil {
+		p := filepath.Join(home, ".ailloy", "flux", slug+".yaml")
+		if persistedFluxFileExists(p) {
+			paths = append(paths, p)
+		}
+	}
+	p := filepath.Join(".ailloy", "flux", slug+".yaml")
+	if persistedFluxFileExists(p) {
+		paths = append(paths, p)
+	}
+	return paths
+}
+
+func persistedFluxFileExists(path string) bool {
+	info, err := os.Stat(path) // #nosec G304 -- path built from sanitized slug under known prefixes
+	if err != nil {
+		return false
+	}
+	return !info.IsDir()
+}

--- a/pkg/mold/flux_persist_test.go
+++ b/pkg/mold/flux_persist_test.go
@@ -1,0 +1,77 @@
+package mold
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFluxFileSlug(t *testing.T) {
+	cases := map[string]string{
+		"":                                  "mold",
+		"agents":                            "agents",
+		"nimble-giant/agents":               "nimble-giant_agents",
+		"github.com/nimble-giant/agents":    "github.com_nimble-giant_agents",
+		"github.com/nimble-giant/agents@v1": "github.com_nimble-giant_agents_v1",
+		"github.com/kris/replicated-foundry/molds/launch":     "github.com_kris_replicated-foundry_molds_launch",
+		"github.com/kris/replicated-foundry/molds/launch.git": "github.com_kris_replicated-foundry_molds_launch",
+		"  github.com/kris/replicated-foundry/molds/launch  ": "github.com_kris_replicated-foundry_molds_launch",
+	}
+	for in, want := range cases {
+		if got := FluxFileSlug(in); got != want {
+			t.Errorf("FluxFileSlug(%q) = %q want %q", in, got, want)
+		}
+	}
+}
+
+func TestPersistedFluxPaths_EmptyRefReturnsNil(t *testing.T) {
+	if got := PersistedFluxPaths(""); got != nil {
+		t.Fatalf("expected nil for empty ref; got %v", got)
+	}
+	if got := PersistedFluxPaths("   "); got != nil {
+		t.Fatalf("expected nil for whitespace ref; got %v", got)
+	}
+}
+
+func TestPersistedFluxPaths_OrderingAndExistence(t *testing.T) {
+	// Use a distinct project dir and HOME so project's relative path can't
+	// accidentally resolve onto the global file.
+	homeDir := t.TempDir()
+	projectDir := t.TempDir()
+	t.Chdir(projectDir)
+	t.Setenv("HOME", homeDir)
+
+	ref := "github.com/x/y"
+	slug := FluxFileSlug(ref)
+
+	if got := PersistedFluxPaths(ref); len(got) != 0 {
+		t.Fatalf("expected no paths before files exist; got %v", got)
+	}
+
+	globalPath := filepath.Join(homeDir, ".ailloy", "flux", slug+".yaml")
+	if err := os.MkdirAll(filepath.Dir(globalPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(globalPath, []byte("k: g\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got := PersistedFluxPaths(ref)
+	if len(got) != 1 || got[0] != globalPath {
+		t.Fatalf("expected [%s]; got %v", globalPath, got)
+	}
+
+	projectPath := filepath.Join(".ailloy", "flux", slug+".yaml")
+	if err := os.MkdirAll(filepath.Dir(projectPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(projectPath, []byte("k: p\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Both exist — global first, then project (project wins on merge).
+	got = PersistedFluxPaths(ref)
+	if len(got) != 2 || got[0] != globalPath || got[1] != projectPath {
+		t.Fatalf("expected [global project]; got %v", got)
+	}
+}


### PR DESCRIPTION
## Description

Three bugs in the foundries TUI flux picker:

1. **`f` key not advertised** in Discover/Installed footers — added `· f flux` to both.
2. **`s` save shortcut never fired** because the filter is always focused in filter-mode and the shortcut was gated on `!filter.Focused()`. Bound save to `ctrl+s` in `handleKey` so it works regardless of filter state. Updated footer hint, reworded the save dialog, and made `esc` from the save prompt actually discard & close (matches the new `[esc] discard & close` label).
3. **Project/global saves were write-only** — the picker wrote `.ailloy/flux/<slug>.yaml` and `~/.ailloy/flux/<slug>.yaml` but nothing in the cast pipeline ever read them. Added `mold.FluxFileSlug` + `mold.PersistedFluxPaths`, and threaded the source ref through `loadCastFlux`, `layerFluxForCore`, and `castClaudePlugin` so persisted files are auto-layered between defaults and `-f` (project wins over global; explicit `-f`/`--set` still win over both). Picker delegates to the shared slug helper so write/read paths can't drift.

## Related Issue

N/A

## Testing

- `go test -race ./...` — full suite passes.
- New unit tests: `pkg/mold/flux_persist_test.go` (slug + path ordering), `internal/commands/cast_core_test.go` (auto-load layering with `--set` precedence and empty-source skip).
- Updated existing fluxpicker tests for `ctrl+s` and the new esc-from-save-prompt semantics.

## UAT

1. `ailloy foundries`, navigate to Discover or Installed — `f flux` should appear in the footer.
2. Highlight a mold and press `f`. Type to filter, `tab` a key, edit value, `enter`. Filter is focused — press `ctrl+s`; save prompt should appear.
3. Pick `[p] project`. Picker closes; check `./.ailloy/flux/<slug>.yaml` was written.
4. Trigger another cast of that mold (TUI Discover `enter`, or `ailloy cast <ref>` from the shell). The saved overrides should be applied — no `-f` needed. `--set` and explicit `-f` still override.
5. From the save prompt, `esc` should discard pending overrides and close the picker.

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [x] I have updated documentation (if applicable)
- [x] My commits have DCO sign-off (`git commit -s`)