### PR TITLE
fix: surface inaccessible sub-foundry warnings on search and install

### DIFF
--- a/internal/commands/foundries.go
+++ b/internal/commands/foundries.go
@@ -68,7 +68,7 @@ func runFoundries(_ *cobra.Command, _ []string) error {
 			return out, err
 		},
 		InstallFoundry: func(ctx context.Context, cfg *index.Config, nameOrURL string, opts foundries.InstallFoundryOptions) ([]foundries.InstallFoundryReport, error) {
-			rs, err := InstallFoundryCore(ctx, cfg, nameOrURL, InstallFoundryOptions{
+			rs, _, err := InstallFoundryCore(ctx, cfg, nameOrURL, InstallFoundryOptions{
 				Global:        opts.Global,
 				WithWorkflows: opts.WithWorkflows,
 				DryRun:        opts.DryRun,

--- a/internal/commands/foundry.go
+++ b/internal/commands/foundry.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -137,10 +138,12 @@ func runFoundrySearch(_ *cobra.Command, args []string) error {
 		GitHubOnly: searchGitHubOnly,
 	}
 
-	results, err := index.Search(cfg, query, opts)
+	results, warnings, err := index.Search(cfg, query, opts)
 	if err != nil {
 		return err
 	}
+
+	renderResolutionWarnings(warnings)
 
 	if len(results) == 0 {
 		fmt.Println(styles.InfoBoxStyle.Render(
@@ -330,8 +333,15 @@ func runFoundryUpdate(_ *cobra.Command, _ []string) error {
 		fmt.Println(" " + styles.SuccessStyle.Render("ok") +
 			styles.SubtleStyle.Render(fmt.Sprintf(" (%d molds)", r.MoldCount)))
 		for _, w := range r.Warnings {
+			hint := ""
+			switch {
+			case errors.Is(w.Err, index.ErrForbidden):
+				hint = " (private repo? check your git credentials)"
+			case errors.Is(w.Err, index.ErrNotFound):
+				hint = " (not found — may be private or moved)"
+			}
 			fmt.Println(styles.SubtleStyle.Render(
-				fmt.Sprintf("    warning: nested foundry %q failed: %v", w.Source, w.Err)))
+				fmt.Sprintf("    warning: nested foundry %q failed: %v%s", w.Source, w.Err, hint)))
 		}
 	}
 
@@ -395,7 +405,7 @@ func runFoundryInstall(_ *cobra.Command, args []string) error {
 	fmt.Println(styles.WorkingBanner("Casting every mold from " + nameOrURL + "..."))
 	fmt.Println()
 
-	reports, err := InstallFoundryCore(context.Background(), cfg, nameOrURL, InstallFoundryOptions{
+	reports, warnings, err := InstallFoundryCore(context.Background(), cfg, nameOrURL, InstallFoundryOptions{
 		Global:        foundryInstallGlobal,
 		WithWorkflows: foundryInstallWithWorkflows,
 		DryRun:        foundryInstallDryRun,
@@ -406,6 +416,8 @@ func runFoundryInstall(_ *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	renderResolutionWarnings(warnings)
 
 	var (
 		installed int
@@ -464,4 +476,26 @@ func runFoundryInstall(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("%d mold(s) failed to install", failed)
 	}
 	return nil
+}
+
+// renderResolutionWarnings prints non-fatal foundry resolution warnings —
+// typically a sub-foundry the caller couldn't access (private repo without
+// credentials). Prints nothing when there are no warnings.
+func renderResolutionWarnings(warnings []index.ResolutionWarning) {
+	if len(warnings) == 0 {
+		return
+	}
+	fmt.Println(styles.SubtleStyle.Render("Some foundries were skipped:"))
+	for _, w := range warnings {
+		hint := ""
+		switch {
+		case errors.Is(w.Err, index.ErrForbidden):
+			hint = "  (private repo? ensure your git credentials grant access)"
+		case errors.Is(w.Err, index.ErrNotFound):
+			hint = "  (repository not found — may be private or moved)"
+		}
+		fmt.Println(styles.SubtleStyle.Render(
+			fmt.Sprintf("  warning: foundry %q failed: %v%s", w.Source, w.Err, hint)))
+	}
+	fmt.Println()
 }

--- a/internal/commands/foundry_core.go
+++ b/internal/commands/foundry_core.go
@@ -173,10 +173,15 @@ var ErrFoundryNotFound = errors.New("foundry not found")
 // Molds already present in the target lockfile are skipped unless
 // opts.Force. The first git fetch may take a while; subsequent calls reuse
 // the cache.
-func InstallFoundryCore(ctx context.Context, cfg *index.Config, nameOrURL string, opts InstallFoundryOptions) ([]InstallFoundryReport, error) {
+//
+// The returned warnings carry non-fatal sub-foundry resolution failures
+// (e.g. private nested foundries the caller cannot access). Molds from those
+// inaccessible sub-foundries are silently absent from the report; warnings
+// give the CLI a chance to explain why.
+func InstallFoundryCore(ctx context.Context, cfg *index.Config, nameOrURL string, opts InstallFoundryOptions) ([]InstallFoundryReport, []index.ResolutionWarning, error) {
 	cacheDir, err := index.IndexCacheDir()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var match *index.FoundryEntry
@@ -188,20 +193,21 @@ func InstallFoundryCore(ctx context.Context, cfg *index.Config, nameOrURL string
 		}
 	}
 	if match == nil {
-		return nil, fmt.Errorf("%w: %q", ErrFoundryNotFound, nameOrURL)
+		return nil, nil, fmt.Errorf("%w: %q", ErrFoundryNotFound, nameOrURL)
 	}
 
 	fetcher, ferr := index.NewFetcher(defaultGitRunner())
 	if ferr != nil {
-		return nil, ferr
+		return nil, nil, ferr
 	}
 	lookup := index.CacheFirstLookup(cacheDir, fetcher)
 
 	r := index.NewResolver(lookup)
 	root, allMolds, err := r.Resolve(match.URL)
 	if err != nil {
-		return nil, fmt.Errorf("resolving foundry %s: %w", match.Name, err)
+		return nil, nil, fmt.Errorf("resolving foundry %s: %w", match.Name, err)
 	}
+	warnings := r.Warnings()
 
 	// Build the working set of molds to install.
 	var molds []index.ResolvedMold
@@ -263,5 +269,5 @@ func InstallFoundryCore(ctx context.Context, cfg *index.Config, nameOrURL string
 		out = append(out, report)
 	}
 
-	return out, nil
+	return out, warnings, nil
 }

--- a/internal/commands/foundry_core_test.go
+++ b/internal/commands/foundry_core_test.go
@@ -42,7 +42,7 @@ foundries:
 		Foundries: []index.FoundryEntry{{Name: "parent", URL: parentURL, Type: "git", Status: "ok"}},
 	}
 
-	reports, err := InstallFoundryCore(context.Background(), cfg, "parent", InstallFoundryOptions{
+	reports, warnings, err := InstallFoundryCore(context.Background(), cfg, "parent", InstallFoundryOptions{
 		DryRun:  true,
 		Shallow: true,
 	})
@@ -60,5 +60,13 @@ foundries:
 	}
 	if len(reports[0].Chain) != 0 {
 		t.Errorf("reports[0].Chain = %v, want empty (root-owned)", reports[0].Chain)
+	}
+	// The unreachable child foundry should surface as a warning so the CLI
+	// can explain why nested molds are missing.
+	if len(warnings) != 1 {
+		t.Fatalf("got %d warnings, want 1", len(warnings))
+	}
+	if warnings[0].Source != "github.com/example/missing" {
+		t.Errorf("warnings[0].Source = %q, want github.com/example/missing", warnings[0].Source)
 	}
 }

--- a/pkg/foundry/index/errors.go
+++ b/pkg/foundry/index/errors.go
@@ -1,0 +1,62 @@
+package index
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrForbidden indicates a foundry source could not be reached because the
+// remote required authentication that the local environment did not satisfy
+// (private repo, missing credentials, expired token, 403/401, etc.).
+//
+// Callers should wrap this with a meaningful message and let the CLI render
+// guidance about checking git credentials for the failing URL.
+var ErrForbidden = errors.New("foundry forbidden")
+
+// ErrNotFound indicates a remote returned 404 / "repository not found".
+// Note that GitHub returns 404 for both missing repos and private repos that
+// the caller cannot see, so callers should treat this as auth-adjacent.
+var ErrNotFound = errors.New("foundry not found")
+
+// classifyGitError inspects combined git stderr/stdout and the underlying
+// error and returns a typed sentinel (ErrForbidden / ErrNotFound) when the
+// output matches a known auth/visibility failure. Returns the original error
+// unchanged when no pattern matches.
+func classifyGitError(err error, gitOutput []byte) error {
+	if err == nil {
+		return nil
+	}
+	out := strings.ToLower(string(gitOutput))
+
+	authPatterns := []string{
+		"authentication failed",
+		"could not read username",
+		"could not read password",
+		"permission denied",
+		"403 forbidden",
+		"the requested url returned error: 403",
+		"the requested url returned error: 401",
+		"access denied",
+		"invalid username or password",
+	}
+	for _, p := range authPatterns {
+		if strings.Contains(out, p) {
+			return fmt.Errorf("%w: %v\n%s", ErrForbidden, err, gitOutput)
+		}
+	}
+
+	notFoundPatterns := []string{
+		"repository not found",
+		"not found",
+		"the requested url returned error: 404",
+		"does not exist",
+	}
+	for _, p := range notFoundPatterns {
+		if strings.Contains(out, p) {
+			return fmt.Errorf("%w: %v\n%s", ErrNotFound, err, gitOutput)
+		}
+	}
+
+	return fmt.Errorf("%v\n%s", err, gitOutput)
+}

--- a/pkg/foundry/index/errors_test.go
+++ b/pkg/foundry/index/errors_test.go
@@ -1,0 +1,62 @@
+package index
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestClassifyGitError_Auth(t *testing.T) {
+	cases := []struct {
+		name string
+		out  string
+	}{
+		{"https authentication failed", "fatal: Authentication failed for 'https://github.com/owner/private'"},
+		{"http 403", "fatal: unable to access 'https://github.com/owner/private/': The requested URL returned error: 403"},
+		{"missing username", "fatal: could not read Username for 'https://github.com': terminal prompts disabled"},
+		{"ssh permission denied", "git@github.com: Permission denied (publickey)."},
+		{"http 401", "fatal: unable to access 'https://example.com/x': The requested URL returned error: 401"},
+	}
+	base := fmt.Errorf("exit status 128")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyGitError(base, []byte(tc.out))
+			if !errors.Is(got, ErrForbidden) {
+				t.Fatalf("errors.Is(_, ErrForbidden) = false; err = %v", got)
+			}
+		})
+	}
+}
+
+func TestClassifyGitError_NotFound(t *testing.T) {
+	cases := []string{
+		"remote: Repository not found.",
+		"fatal: repository 'https://github.com/x/y' not found",
+		"fatal: unable to access 'https://github.com/x/y': The requested URL returned error: 404",
+	}
+	base := fmt.Errorf("exit status 128")
+	for _, out := range cases {
+		t.Run(out, func(t *testing.T) {
+			got := classifyGitError(base, []byte(out))
+			if !errors.Is(got, ErrNotFound) {
+				t.Fatalf("errors.Is(_, ErrNotFound) = false; err = %v", got)
+			}
+		})
+	}
+}
+
+func TestClassifyGitError_Unknown(t *testing.T) {
+	got := classifyGitError(fmt.Errorf("exit status 1"), []byte("some unrelated git failure"))
+	if errors.Is(got, ErrForbidden) || errors.Is(got, ErrNotFound) {
+		t.Fatalf("classifyGitError should not classify generic errors; got %v", got)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil error")
+	}
+}
+
+func TestClassifyGitError_NilPasses(t *testing.T) {
+	if err := classifyGitError(nil, []byte("anything")); err != nil {
+		t.Fatalf("nil input should pass through, got %v", err)
+	}
+}

--- a/pkg/foundry/index/fetcher.go
+++ b/pkg/foundry/index/fetcher.go
@@ -65,7 +65,7 @@ func (f *Fetcher) fetchGitIndex(entry *FoundryEntry) (*Index, error) {
 		// Bare clone exists — fetch updates.
 		out, err := f.git("-C", bareDir, "fetch", "--all")
 		if err != nil {
-			return nil, fmt.Errorf("git fetch: %w\n%s", err, out)
+			return nil, fmt.Errorf("git fetch %s: %w", entry.URL, classifyGitError(err, out))
 		}
 	} else {
 		// Create bare clone.
@@ -74,7 +74,7 @@ func (f *Fetcher) fetchGitIndex(entry *FoundryEntry) (*Index, error) {
 		}
 		out, err := f.git("clone", "--bare", entry.URL, bareDir)
 		if err != nil {
-			return nil, fmt.Errorf("git clone: %w\n%s", err, out)
+			return nil, fmt.Errorf("git clone %s: %w", entry.URL, classifyGitError(err, out))
 		}
 	}
 
@@ -121,7 +121,14 @@ func (f *Fetcher) fetchURLIndex(entry *FoundryEntry) (*Index, error) {
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("fetching index: HTTP %d", resp.StatusCode)
+		switch resp.StatusCode {
+		case http.StatusUnauthorized, http.StatusForbidden:
+			return nil, fmt.Errorf("fetching %s: %w (HTTP %d)", entry.URL, ErrForbidden, resp.StatusCode)
+		case http.StatusNotFound:
+			return nil, fmt.Errorf("fetching %s: %w (HTTP %d)", entry.URL, ErrNotFound, resp.StatusCode)
+		default:
+			return nil, fmt.Errorf("fetching %s: HTTP %d", entry.URL, resp.StatusCode)
+		}
 	}
 
 	data, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20)) // 10 MB limit

--- a/pkg/foundry/index/search.go
+++ b/pkg/foundry/index/search.go
@@ -45,13 +45,18 @@ type ghSearchResponse struct {
 // Search queries all registered foundry indexes and optionally GitHub Topics.
 // Results from indexes appear first, followed by GitHub Topics results.
 // Duplicates (same source) are collapsed, preferring the index entry.
-func Search(cfg *Config, query string, opts SearchOptions) ([]SearchResult, error) {
+//
+// Warnings carries non-fatal sub-foundry resolution failures (e.g. a private
+// nested foundry the caller cannot access). The CLI is expected to render
+// these so users understand why some molds may be missing.
+func Search(cfg *Config, query string, opts SearchOptions) ([]SearchResult, []ResolutionWarning, error) {
 	var indexResults []SearchResult
 	var ghResults []SearchResult
+	var warnings []ResolutionWarning
 	var indexErr, ghErr error
 
 	if !opts.GitHubOnly {
-		indexResults, indexErr = searchIndexes(cfg, query)
+		indexResults, warnings, indexErr = searchIndexes(cfg, query)
 	}
 
 	if !opts.IndexOnly {
@@ -60,22 +65,22 @@ func Search(cfg *Config, query string, opts SearchOptions) ([]SearchResult, erro
 
 	// If both failed, return the first error.
 	if indexErr != nil && ghErr != nil {
-		return nil, fmt.Errorf("searching indexes: %w", indexErr)
+		return nil, warnings, fmt.Errorf("searching indexes: %w", indexErr)
 	}
 
 	// Merge and deduplicate.
 	results := mergeResults(indexResults, ghResults)
-	return results, nil
+	return results, warnings, nil
 }
 
 // searchIndexes searches all cached foundry indexes for matching molds,
 // transitively resolving any nested foundries declared in their `foundries:`
 // fields. Lookups are cache-first; child foundries not yet cached fall back
 // to the network so a freshly-added parent works without an explicit update.
-func searchIndexes(cfg *Config, query string) ([]SearchResult, error) {
+func searchIndexes(cfg *Config, query string) ([]SearchResult, []ResolutionWarning, error) {
 	cacheDir, err := IndexCacheDir()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	git := defaultGitRunnerForSearch()
 	fetcher := NewFetcherWithCacheDir(git, cacheDir)
@@ -85,9 +90,11 @@ func searchIndexes(cfg *Config, query string) ([]SearchResult, error) {
 
 // searchWithLookup is the testable core: given an explicit IndexLookup, walk
 // every registered root via a fresh Resolver and return matching molds with
-// their resolution chain.
-func searchWithLookup(cfg *Config, query string, lookup IndexLookup) ([]SearchResult, error) {
+// their resolution chain. Sub-foundry resolution failures are returned as
+// warnings rather than swallowed.
+func searchWithLookup(cfg *Config, query string, lookup IndexLookup) ([]SearchResult, []ResolutionWarning, error) {
 	var results []SearchResult
+	var warnings []ResolutionWarning
 	q := strings.ToLower(query)
 
 	for _, entry := range cfg.EffectiveFoundries() {
@@ -97,8 +104,11 @@ func searchWithLookup(cfg *Config, query string, lookup IndexLookup) ([]SearchRe
 		if err != nil {
 			// Root failed (e.g., not cached and offline). Skip — preserves
 			// the existing "skip indexes that aren't cached yet" behavior.
+			// Sub-foundry failures of an otherwise-resolvable root are still
+			// surfaced as warnings below.
 			continue
 		}
+		warnings = append(warnings, r.Warnings()...)
 		for _, m := range molds {
 			if !matchesMold(m.Entry, q) {
 				continue
@@ -114,7 +124,7 @@ func searchWithLookup(cfg *Config, query string, lookup IndexLookup) ([]SearchRe
 			})
 		}
 	}
-	return results, nil
+	return results, warnings, nil
 }
 
 // formatOrigin renders the resolution chain. Root molds get "index:<root>";

--- a/pkg/foundry/index/search_test.go
+++ b/pkg/foundry/index/search_test.go
@@ -1,6 +1,7 @@
 package index
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -276,9 +277,12 @@ func TestSearchTraversesNestedFoundries(t *testing.T) {
 	}
 
 	cfg := &Config{Foundries: []FoundryEntry{{Name: "parent", URL: "github.com/x/parent", Type: "git"}}}
-	results, err := searchWithLookup(cfg, "alpha", lookup)
+	results, warnings, err := searchWithLookup(cfg, "alpha", lookup)
 	if err != nil {
 		t.Fatalf("searchWithLookup: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("warnings = %+v, want none", warnings)
 	}
 	if len(results) != 2 {
 		t.Fatalf("got %d results, want 2", len(results))
@@ -299,5 +303,47 @@ func TestSearchTraversesNestedFoundries(t *testing.T) {
 	}
 	if !strings.Contains(childResult.Origin, "via parent") {
 		t.Errorf("child Origin = %q, want it to contain 'via parent'", childResult.Origin)
+	}
+}
+
+// TestSearchSurfacesNestedFoundryWarnings verifies that when a sub-foundry
+// fails to resolve (e.g. private repo the caller can't access), the parent
+// search still returns root molds AND surfaces the failure as a warning so
+// the CLI can explain why nested results are missing.
+func TestSearchSurfacesNestedFoundryWarnings(t *testing.T) {
+	parent := &Index{
+		APIVersion: "v1", Kind: "foundry-index", Name: "parent",
+		Molds: []MoldEntry{{Name: "alpha-mold", Source: "github.com/x/alpha", Description: "alpha"}},
+		Foundries: []FoundryRef{
+			{Name: "private", Source: "github.com/x/private"},
+		},
+	}
+	authErr := fmt.Errorf("git clone github.com/x/private: %w: exit status 128", ErrForbidden)
+	lookup := func(source string) (*Index, error) {
+		switch canonicalizeSource(source) {
+		case "github.com/x/parent":
+			return parent, nil
+		case "github.com/x/private":
+			return nil, authErr
+		}
+		return nil, fmt.Errorf("unexpected lookup: %s", source)
+	}
+
+	cfg := &Config{Foundries: []FoundryEntry{{Name: "parent", URL: "github.com/x/parent", Type: "git"}}}
+	results, warnings, err := searchWithLookup(cfg, "alpha", lookup)
+	if err != nil {
+		t.Fatalf("searchWithLookup: %v", err)
+	}
+	if len(results) != 1 || results[0].Name != "parent/alpha-mold" {
+		t.Fatalf("results = %+v, want [parent/alpha-mold]", results)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %+v, want exactly 1", warnings)
+	}
+	if warnings[0].Source != "github.com/x/private" {
+		t.Errorf("warnings[0].Source = %q, want github.com/x/private", warnings[0].Source)
+	}
+	if !errors.Is(warnings[0].Err, ErrForbidden) {
+		t.Errorf("warnings[0].Err should wrap ErrForbidden; got %v", warnings[0].Err)
 	}
 }


### PR DESCRIPTION
## Description

Sub-foundry resolution failures were already non-fatal in `Resolver.resolveNode`, but `foundry search` and `foundry install` silently dropped the collected warnings — so a teammate without access to a private nested foundry (e.g. `nimble-giant/foundry` referencing a private `kriscoleman/replicated-foundry`) got fewer molds with no indication why. This PR propagates `[]ResolutionWarning` through `Search`, `searchWithLookup`, and `InstallFoundryCore`, adds a `renderResolutionWarnings` helper in the CLI, and classifies common git stderr patterns into typed `ErrForbidden` / `ErrNotFound` sentinels (plus matching HTTP 401/403/404 mapping) so the output can include hints like `(private repo? ensure your git credentials grant access)`.

## Related Issue

N/A

## Testing

- New `errors_test.go` covers auth, not-found, and unknown classifier branches.
- New `TestSearchSurfacesNestedFoundryWarnings` asserts search returns root molds and propagates a sub-foundry failure wrapping `ErrForbidden`.
- Extended `TestInstallFoundryCoreShallow` to assert the install path now returns the missing nested foundry as a warning.
- `go test -race ./...`, `go vet ./...`, `gofmt -l .`, `golangci-lint run` — all clean.

## UAT

Add a parent foundry that references a private repo you cannot access, then run `ailloy foundry search <query>` and `ailloy foundry install <parent>` — you should see results from the accessible foundries plus a styled warning naming the private foundry with a credentials hint, instead of the previous silent omission.

## Checklist

- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [ ] I have updated documentation (if applicable)
- [x] My commits have DCO sign-off (`git commit -s`)