### PR TITLE
fix: reflect cast state on Discover and detect updates

### DIFF
--- a/internal/commands/docs.go
+++ b/internal/commands/docs.go
@@ -111,6 +111,13 @@ func runDocs(cmd *cobra.Command, args []string) error {
 		return renderTopicTo(out, args[0])
 	}
 
+	// Non-interactive contexts (tests, pipes, CI) skip the extension — its
+	// output bypasses cmd.OutOrStdout() and goes straight to the real fd,
+	// which breaks captured-stdout tests and pipe consumers.
+	if !isInteractive() {
+		return printTopicList(out)
+	}
+
 	// Bare `ailloy docs`. Prefer the extension when allowed.
 	if !docsNoExtension {
 		if code, ran, err := tryExecDocsExtension(args); ran {
@@ -124,10 +131,6 @@ func runDocs(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Fallback: in-binary glamour render to stdout (table when piped).
-	if !isInteractive() {
-		return printTopicList(out)
-	}
 	return printTopicList(out)
 }
 

--- a/internal/tui/foundries/data/identity.go
+++ b/internal/tui/foundries/data/identity.go
@@ -1,0 +1,28 @@
+package data
+
+import "strings"
+
+// MoldIdentity returns the canonical join key used to match a Discover catalog
+// entry against an installed-manifest entry.
+//
+// Catalog rows store the mold's full source (which may embed a //subpath, e.g.
+// "github.com/owner/repo//molds/launch"), while installed rows store the bare
+// repo source plus a separate Subpath field. Without normalisation the two
+// strings never match for any subpath-bearing mold and the "installed" badge
+// silently drops off Discover after a TUI restart.
+//
+// Pass either form: an embedded "//subpath" in source is preferred, otherwise
+// the explicit subpath argument is appended.
+func MoldIdentity(source, subpath string) string {
+	base := source
+	if i := strings.Index(source, "//"); i != -1 {
+		if subpath == "" {
+			subpath = source[i+2:]
+		}
+		base = source[:i]
+	}
+	if subpath == "" {
+		return base
+	}
+	return base + "//" + subpath
+}

--- a/internal/tui/foundries/data/identity_test.go
+++ b/internal/tui/foundries/data/identity_test.go
@@ -1,0 +1,54 @@
+package data
+
+import "testing"
+
+func TestMoldIdentity(t *testing.T) {
+	tests := []struct {
+		name    string
+		source  string
+		subpath string
+		want    string
+	}{
+		{
+			name:    "bare repo, no subpath",
+			source:  "github.com/nimble-giant/nimble-mold",
+			subpath: "",
+			want:    "github.com/nimble-giant/nimble-mold",
+		},
+		{
+			name:    "catalog form: embedded subpath",
+			source:  "github.com/kriscoleman/replicated-foundry//molds/launch",
+			subpath: "",
+			want:    "github.com/kriscoleman/replicated-foundry//molds/launch",
+		},
+		{
+			name:    "installed form: separate subpath",
+			source:  "github.com/kriscoleman/replicated-foundry",
+			subpath: "molds/launch",
+			want:    "github.com/kriscoleman/replicated-foundry//molds/launch",
+		},
+		{
+			name:    "agreement: catalog and installed produce the same key",
+			source:  "github.com/x/y//z",
+			subpath: "z",
+			want:    "github.com/x/y//z",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := MoldIdentity(tc.source, tc.subpath); got != tc.want {
+				t.Fatalf("MoldIdentity(%q, %q) = %q, want %q", tc.source, tc.subpath, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMoldIdentity_BothFormsMatch is the load-bearing invariant: a catalog row
+// and its installed-manifest counterpart must produce the same key.
+func TestMoldIdentity_BothFormsMatch(t *testing.T) {
+	catalog := MoldIdentity("github.com/kriscoleman/replicated-foundry//molds/launch", "")
+	installed := MoldIdentity("github.com/kriscoleman/replicated-foundry", "molds/launch")
+	if catalog != installed {
+		t.Fatalf("identity mismatch: catalog=%q installed=%q", catalog, installed)
+	}
+}

--- a/internal/tui/foundries/discover/model.go
+++ b/internal/tui/foundries/discover/model.go
@@ -22,6 +22,8 @@ var (
 	moldNameStyle   = lipgloss.NewStyle().Foreground(styles.Accent1).Bold(true)
 	verifiedStyle   = lipgloss.NewStyle().Foreground(styles.Success).Bold(true)
 	installedStyle  = lipgloss.NewStyle().Foreground(styles.Info).Bold(true)
+	upToDateStyle   = lipgloss.NewStyle().Foreground(styles.Success).Bold(true)
+	updateStyle     = lipgloss.NewStyle().Foreground(styles.Warning).Bold(true)
 	descStyle       = lipgloss.NewStyle().Foreground(styles.LightGray)
 	metaStyle       = lipgloss.NewStyle().Foreground(styles.Gray)
 	statusOKStyle   = lipgloss.NewStyle().Foreground(styles.Success)
@@ -50,22 +52,36 @@ type CastFn func(ctx context.Context, source string, opts CastOptions) error
 // the verified default has never been fetched).
 type UpdateFn func(cfg *index.Config) error
 
+// installedInfo is what we know about a mold present in the installed manifest.
+// Source/Subpath are kept so we can build a foundry.Reference for resolving the
+// latest upstream version.
+type installedInfo struct {
+	Version string
+	Commit  string
+	Source  string
+	Subpath string
+}
+
 // Model is the Discover tab.
 type Model struct {
-	cfg         *index.Config
-	cast        CastFn
-	update      UpdateFn
-	catalog     []data.CatalogEntry
-	filtered    []data.CatalogEntry
-	installed   map[string]string // source -> installed version (for the "installed" badge)
-	selected    map[string]bool
-	cursor      int
-	filter      textinput.Model
-	loading     bool
-	loadErr     error
-	castStat    map[string]string
-	autoFetched bool                // guard so we only auto-fetch once per session
-	pending     map[string][]string // moldRef → encoded "--set" overrides
+	cfg            *index.Config
+	cast           CastFn
+	update         UpdateFn
+	git            foundry.GitRunner // injected for tests; nil falls back to DefaultGitRunner
+	catalog        []data.CatalogEntry
+	filtered       []data.CatalogEntry
+	installed      map[string]installedInfo           // canonical join key → installed info
+	latest         map[string]foundry.ResolvedVersion // canonical join key → latest upstream
+	resolving      map[string]bool                    // canonical join key → "checking…" in flight
+	selected       map[string]bool
+	cursor         int
+	filter         textinput.Model
+	loading        bool
+	loadErr        error
+	castStat       map[string]string
+	autoFetched    bool                // guard so we only auto-fetch once per session
+	pending        map[string][]string // moldRef → encoded "--set" overrides
+	wantLatestScan bool                // user pressed `r`; resolve latest after inventory reloads
 }
 
 type catalogLoadedMsg struct {
@@ -74,7 +90,7 @@ type catalogLoadedMsg struct {
 }
 
 type inventoryLoadedMsg struct {
-	installed map[string]string // source -> version
+	installed map[string]installedInfo // canonical join key → info
 }
 
 type catalogFetchedMsg struct{ err error }
@@ -82,6 +98,15 @@ type catalogFetchedMsg struct{ err error }
 type castDoneMsg struct {
 	source string
 	err    error
+}
+
+// latestResolvedMsg reports the result of one upstream version resolve. One
+// message fires per installed mold so the UI can update incrementally rather
+// than blocking on the slowest network call.
+type latestResolvedMsg struct {
+	key      string
+	resolved *foundry.ResolvedVersion
+	err      error
 }
 
 // New initializes the Discover model and kicks off catalog loading. cast is
@@ -95,7 +120,9 @@ func New(cfg *index.Config, cast CastFn, update UpdateFn) Model {
 		cfg:       cfg,
 		cast:      cast,
 		update:    update,
-		installed: map[string]string{},
+		installed: map[string]installedInfo{},
+		latest:    map[string]foundry.ResolvedVersion{},
+		resolving: map[string]bool{},
 		selected:  map[string]bool{},
 		filter:    ti,
 		loading:   true,
@@ -117,12 +144,20 @@ func loadCatalogCmd(cfg *index.Config) tea.Cmd {
 func loadInventoryCmd(cfg *index.Config) tea.Cmd {
 	return func() tea.Msg {
 		items, _ := data.LoadInventory(cfg)
-		out := make(map[string]string, len(items))
+		out := make(map[string]installedInfo, len(items))
 		for _, it := range items {
-			// First scope wins (project before global). Both are useful info,
-			// but the badge just signals "you have this".
-			if _, exists := out[it.Entry.Source]; !exists {
-				out[it.Entry.Source] = it.Entry.Version
+			// Key by the canonical "source[//subpath]" form so subpath-bearing
+			// catalog entries (e.g. "github.com/x/y//molds/foo") match installed
+			// entries (which store subpath separately). First scope wins —
+			// project entries take precedence over global ones.
+			key := data.MoldIdentity(it.Entry.Source, it.Entry.Subpath)
+			if _, exists := out[key]; !exists {
+				out[key] = installedInfo{
+					Version: it.Entry.Version,
+					Commit:  it.Entry.Commit,
+					Source:  it.Entry.Source,
+					Subpath: it.Entry.Subpath,
+				}
 			}
 		}
 		return inventoryLoadedMsg{installed: out}
@@ -150,6 +185,23 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		return m, loadCatalogCmd(m.cfg)
 	case inventoryLoadedMsg:
 		m.installed = msg.installed
+		// Drop any stale "latest" entries for molds that are no longer installed
+		// so the next render doesn't claim "up to date" for things we don't have.
+		for k := range m.latest {
+			if _, ok := m.installed[k]; !ok {
+				delete(m.latest, k)
+			}
+		}
+		if m.wantLatestScan {
+			m.wantLatestScan = false
+			return m, m.scanLatestCmd()
+		}
+		return m, nil
+	case latestResolvedMsg:
+		delete(m.resolving, msg.key)
+		if msg.err == nil && msg.resolved != nil {
+			m.latest[msg.key] = *msg.resolved
+		}
 		return m, nil
 	case castDoneMsg:
 		if msg.err != nil {
@@ -158,7 +210,9 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			m.castStat[msg.source] = "ok"
 			delete(m.pending, msg.source)
 		}
-		// Refresh inventory so the "installed" badge updates immediately.
+		// Refresh inventory so the "installed" badge updates immediately, and
+		// re-scan latest so an updated mold's "update available" tag clears.
+		m.wantLatestScan = true
 		return m, loadInventoryCmd(m.cfg)
 	case tea.KeyMsg:
 		if m.filter.Focused() {
@@ -204,6 +258,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			return m, tea.Batch(cmds...)
 		case "r":
 			m.loading = true
+			m.wantLatestScan = true
 			return m, tea.Batch(loadCatalogCmd(m.cfg), loadInventoryCmd(m.cfg))
 		}
 	}
@@ -219,6 +274,57 @@ func (m Model) fetchCmd() tea.Cmd {
 		}
 		return catalogFetchedMsg{err: update(cfg)}
 	}
+}
+
+// scanLatestCmd kicks off one async resolve per installed mold, in parallel.
+// Each resolve emits its own latestResolvedMsg so the UI fills in incrementally
+// rather than blocking on the slowest network call.
+func (m *Model) scanLatestCmd() tea.Cmd {
+	if len(m.installed) == 0 {
+		return nil
+	}
+	git := m.git
+	if git == nil {
+		git = foundry.DefaultGitRunner()
+	}
+	cmds := make([]tea.Cmd, 0, len(m.installed))
+	for key, info := range m.installed {
+		if m.resolving[key] {
+			continue
+		}
+		m.resolving[key] = true
+		key, info := key, info
+		cmds = append(cmds, func() tea.Msg {
+			ref, err := referenceFromInstalled(info)
+			if err != nil {
+				return latestResolvedMsg{key: key, err: err}
+			}
+			rv, err := foundry.ResolveVersion(ref, git)
+			return latestResolvedMsg{key: key, resolved: rv, err: err}
+		})
+	}
+	if len(cmds) == 0 {
+		return nil
+	}
+	return tea.Batch(cmds...)
+}
+
+// referenceFromInstalled builds the foundry.Reference needed for a "latest"
+// resolve from the source/subpath stored in the installed manifest. Mirrors
+// internal/commands.referenceFromInstalledEntry without taking a dependency on
+// the commands package.
+func referenceFromInstalled(info installedInfo) (*foundry.Reference, error) {
+	parts := strings.SplitN(info.Source, "/", 3)
+	if len(parts) < 3 {
+		return nil, fmt.Errorf("invalid source %q: expected host/owner/repo", info.Source)
+	}
+	return &foundry.Reference{
+		Host:    parts[0],
+		Owner:   parts[1],
+		Repo:    parts[2],
+		Subpath: info.Subpath,
+		Type:    foundry.Latest,
+	}, nil
 }
 
 func (m Model) castCmd(source string) tea.Cmd {
@@ -321,6 +427,37 @@ func formatSetValue(v any) string {
 	}
 }
 
+// renderCastBadge produces the status pill rendered next to a catalog row's
+// name. Returns "" when the mold has never been cast (no badge at all);
+// otherwise one of:
+//
+//   - "● up to date {version}"        — installed and matches latest upstream
+//   - "● update available {old} → {new}" — installed but upstream has moved on
+//   - "● installed {version} (checking…)" — installed, latest still resolving
+//   - "● installed {version}"          — installed, latest unknown (resolve failed)
+func renderCastBadge(m Model, e data.CatalogEntry) string {
+	key := data.MoldIdentity(e.Source, "")
+	info, ok := m.installed[key]
+	if !ok {
+		return ""
+	}
+	version := info.Version
+	if version == "" {
+		version = "?"
+	}
+	if latest, have := m.latest[key]; have {
+		if latest.Tag == info.Version && latest.Commit == info.Commit {
+			return upToDateStyle.Render("● up to date " + version)
+		}
+		return updateStyle.Render("● update available " + version + " → " + latest.Tag)
+	}
+	label := "● installed " + version
+	if m.resolving[key] {
+		label += " (checking…)"
+	}
+	return installedStyle.Render(label)
+}
+
 func (m Model) View() string {
 	if m.loading {
 		return metaStyle.Render("Loading catalog…")
@@ -362,12 +499,8 @@ func (m Model) View() string {
 			verified = " " + verifiedStyle.Render("✓")
 		}
 		installedTag := ""
-		if v, ok := m.installed[e.Source]; ok {
-			label := "● installed"
-			if v != "" {
-				label = "● installed " + v
-			}
-			installedTag = " " + installedStyle.Render(label)
+		if badge := renderCastBadge(m, e); badge != "" {
+			installedTag = " " + badge
 		}
 		status := ""
 		if s, ok := m.castStat[e.Source]; ok {
@@ -396,6 +529,6 @@ func (m Model) View() string {
 
 	fmt.Fprintf(&b, "\n%s\n", metaStyle.Render(fmt.Sprintf("%d selected · %d shown · %d total",
 		len(m.selected), len(visible), len(m.catalog))))
-	b.WriteString(metaStyle.Render("space toggle · enter cast all · / search · c clear · r refresh · f flux · j/k move") + "\n")
+	b.WriteString(metaStyle.Render("space toggle · enter cast all · / search · c clear · r refresh + check updates · f flux · j/k move") + "\n")
 	return b.String()
 }

--- a/internal/tui/foundries/discover/model_test.go
+++ b/internal/tui/foundries/discover/model_test.go
@@ -1,9 +1,11 @@
 package discover
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/nimble-giant/ailloy/internal/tui/foundries/data"
+	"github.com/nimble-giant/ailloy/pkg/foundry"
 )
 
 func TestCurrentMold_NoSelection(t *testing.T) {
@@ -29,6 +31,130 @@ func TestCurrentMold_HighlightedEntry(t *testing.T) {
 	}
 	if scope != data.ScopeProject {
 		t.Fatalf("scope = %v want ScopeProject (default)", scope)
+	}
+}
+
+// TestRenderCastBadge_NotInstalled — molds the user has never cast get no badge,
+// so the row stays clean.
+func TestRenderCastBadge_NotInstalled(t *testing.T) {
+	m := Model{
+		installed: map[string]installedInfo{},
+		latest:    map[string]foundry.ResolvedVersion{},
+		resolving: map[string]bool{},
+	}
+	e := data.CatalogEntry{Source: "github.com/x/y"}
+	if got := renderCastBadge(m, e); got != "" {
+		t.Fatalf("expected empty badge for uninstalled mold, got %q", got)
+	}
+}
+
+// TestRenderCastBadge_InstalledNoLatest — the user cast it but we haven't
+// resolved upstream yet (e.g. they haven't pressed `r`). Show "● installed".
+func TestRenderCastBadge_InstalledNoLatest(t *testing.T) {
+	key := data.MoldIdentity("github.com/x/y", "")
+	m := Model{
+		installed: map[string]installedInfo{
+			key: {Version: "v0.1.0", Source: "github.com/x/y"},
+		},
+		latest:    map[string]foundry.ResolvedVersion{},
+		resolving: map[string]bool{},
+	}
+	e := data.CatalogEntry{Source: "github.com/x/y"}
+	got := renderCastBadge(m, e)
+	if !strings.Contains(got, "● installed") || !strings.Contains(got, "v0.1.0") {
+		t.Fatalf("expected '● installed v0.1.0', got %q", got)
+	}
+	if strings.Contains(got, "checking") {
+		t.Fatalf("did not expect 'checking' marker when resolve not in flight, got %q", got)
+	}
+}
+
+// TestRenderCastBadge_InstalledChecking — we're actively resolving the latest
+// version; show the in-flight indicator.
+func TestRenderCastBadge_InstalledChecking(t *testing.T) {
+	key := data.MoldIdentity("github.com/x/y", "")
+	m := Model{
+		installed: map[string]installedInfo{
+			key: {Version: "v0.1.0", Source: "github.com/x/y"},
+		},
+		latest:    map[string]foundry.ResolvedVersion{},
+		resolving: map[string]bool{key: true},
+	}
+	e := data.CatalogEntry{Source: "github.com/x/y"}
+	got := renderCastBadge(m, e)
+	if !strings.Contains(got, "checking") {
+		t.Fatalf("expected 'checking' marker, got %q", got)
+	}
+}
+
+// TestRenderCastBadge_UpToDate — upstream resolves to the same tag+commit as
+// what's in the manifest; show the green "up to date" pill.
+func TestRenderCastBadge_UpToDate(t *testing.T) {
+	key := data.MoldIdentity("github.com/x/y", "")
+	m := Model{
+		installed: map[string]installedInfo{
+			key: {Version: "v0.1.0", Commit: "abc123", Source: "github.com/x/y"},
+		},
+		latest: map[string]foundry.ResolvedVersion{
+			key: {Tag: "v0.1.0", Commit: "abc123"},
+		},
+		resolving: map[string]bool{},
+	}
+	e := data.CatalogEntry{Source: "github.com/x/y"}
+	got := renderCastBadge(m, e)
+	if !strings.Contains(got, "up to date") {
+		t.Fatalf("expected 'up to date', got %q", got)
+	}
+}
+
+// TestRenderCastBadge_UpdateAvailable — upstream tag/commit differs; show the
+// amber "update available v_old → v_new" pill.
+func TestRenderCastBadge_UpdateAvailable(t *testing.T) {
+	key := data.MoldIdentity("github.com/x/y", "")
+	m := Model{
+		installed: map[string]installedInfo{
+			key: {Version: "v0.1.0", Commit: "abc123", Source: "github.com/x/y"},
+		},
+		latest: map[string]foundry.ResolvedVersion{
+			key: {Tag: "v0.2.0", Commit: "def456"},
+		},
+		resolving: map[string]bool{},
+	}
+	e := data.CatalogEntry{Source: "github.com/x/y"}
+	got := renderCastBadge(m, e)
+	if !strings.Contains(got, "update available") {
+		t.Fatalf("expected 'update available', got %q", got)
+	}
+	if !strings.Contains(got, "v0.1.0") || !strings.Contains(got, "v0.2.0") {
+		t.Fatalf("expected old and new versions in badge, got %q", got)
+	}
+}
+
+// TestRenderCastBadge_SubpathMoldMatches is the regression test for the bug
+// behind this change. Catalog Source for subpath molds has the form
+// "github.com/owner/repo//subpath" while installed manifests store the same
+// mold as Source="github.com/owner/repo" + Subpath="subpath". Before the
+// MoldIdentity fix, the badge silently dropped off after a TUI restart because
+// the lookup keys didn't match.
+func TestRenderCastBadge_SubpathMoldMatches(t *testing.T) {
+	catalogSource := "github.com/kriscoleman/replicated-foundry//molds/launch"
+	key := data.MoldIdentity("github.com/kriscoleman/replicated-foundry", "molds/launch")
+
+	m := Model{
+		installed: map[string]installedInfo{
+			key: {
+				Version: "v0.2.0",
+				Source:  "github.com/kriscoleman/replicated-foundry",
+				Subpath: "molds/launch",
+			},
+		},
+		latest:    map[string]foundry.ResolvedVersion{},
+		resolving: map[string]bool{},
+	}
+	e := data.CatalogEntry{Source: catalogSource}
+	got := renderCastBadge(m, e)
+	if !strings.Contains(got, "● installed") {
+		t.Fatalf("expected subpath mold to render as installed, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Description

Fixes a bug in the foundries TUI where casting molds and reopening the app left the **Discover** tab showing those molds as uncast — only the Installed tab knew about them. Root cause: catalog rows store mold sources with embedded subpaths (`host/owner/repo//subpath`) while installed manifests store the bare source plus a separate `Subpath` field, so the discover lookup keyed by `Source` alone never matched for any subpath-bearing mold.

The fix introduces `data.MoldIdentity` to produce a canonical join key from either form, and uses it on both ends so the "● installed" badge survives a TUI restart. While there, the Discover tab also gains an "out of date" affordance: pressing `r` (or finishing a cast) kicks off async upstream version resolution via `foundry.ResolveVersion` (the same path `recast` uses), and each row renders one of three states — `● installed` / `● up to date {version}` / `● update available {old} → {new}`. Re-selecting a cast mold and pressing Enter triggers a re-cast (the existing update path).

Also drive-by fixes a pre-existing `internal/commands` test failure: `runDocs` now skips the docs extension in non-interactive contexts (tests, pipes), since the extension writes to the real stdout fd and bypasses `cmd.OutOrStdout()`.

## Related Issue

N/A — reported via in-app feedback.

## Testing

- `go test -race ./...` passes (the previously red `TestRunDocs_NonInteractiveFallsBackToList` now passes).
- New unit tests cover all five badge states plus a regression test for the subpath lookup, and `MoldIdentity` invariants live in `internal/tui/foundries/data/identity_test.go`.
- `golangci-lint run` is clean.

## UAT

1. Cast a subpath-bearing mold (e.g. `github.com/kriscoleman/replicated-foundry//molds/launch`) via the foundries TUI Discover tab.
2. Quit and reopen the TUI → the row now reads `● installed v0.2.0` (previously: nothing).
3. Press `r` → the badge upgrades to `● up to date v0.2.0` (or `● update available v0.2.0 → v0.3.0` if a newer tag exists upstream).
4. Re-select the row with Space, press Enter → cast re-runs and the badge flips back to `● up to date`.

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [ ] I have updated documentation (if applicable)
- [x] My commits have DCO sign-off (`git commit -s`)