### PR TITLE
fix: resolve monorepo-prefixed semver tags for subpath references

### DIFF
--- a/pkg/foundry/reference.go
+++ b/pkg/foundry/reference.go
@@ -160,6 +160,20 @@ func (r *Reference) CacheKey() string {
 	return fmt.Sprintf("%s/%s/%s", r.Host, r.Owner, r.Repo)
 }
 
+// ReleasePrefix returns the last segment of Subpath, used to match monorepo-
+// style per-mold tags like `<prefix>-v1.2.3` (e.g. `wiki-v0.4.0`). Returns ""
+// when there is no subpath.
+func (r *Reference) ReleasePrefix() string {
+	s := strings.Trim(r.Subpath, "/")
+	if s == "" {
+		return ""
+	}
+	if idx := strings.LastIndex(s, "/"); idx != -1 {
+		return s[idx+1:]
+	}
+	return s
+}
+
 // String returns a human-readable representation of the reference.
 func (r *Reference) String() string {
 	s := r.CacheKey()

--- a/pkg/foundry/resolver.go
+++ b/pkg/foundry/resolver.go
@@ -34,6 +34,27 @@ type ResolvedVersion struct {
 // abc123\trefs/tags/v1.0.0^{}
 var tagRef = regexp.MustCompile(`^([0-9a-f]+)\trefs/tags/(.+)$`)
 
+// prefixedTagRe matches monorepo-style per-component tags like `wiki-v0.4.0`
+// or `my-mold-1.2.3-rc1`. Group 1 is the prefix (component name); group 2 is
+// the semver remainder (with or without leading `v`).
+var prefixedTagRe = regexp.MustCompile(`^([A-Za-z][A-Za-z0-9_-]*)-v?(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.+-]+)?)$`)
+
+// parseSemverTag classifies a tag as plain semver (`v1.2.3`, `1.2.3`) or
+// prefixed semver (`wiki-v0.4.0`). Returns the prefix ("" for plain), the
+// normalised semver string (no leading v), and ok=true on success.
+func parseSemverTag(tag string) (prefix, normalized string, ok bool) {
+	plain := strings.TrimPrefix(tag, "v")
+	if _, err := semver.NewVersion(plain); err == nil {
+		return "", plain, true
+	}
+	if m := prefixedTagRe.FindStringSubmatch(tag); m != nil {
+		if _, err := semver.NewVersion(m[2]); err == nil {
+			return m[1], m[2], true
+		}
+	}
+	return "", "", false
+}
+
 // ResolveVersion resolves a Reference to a concrete tag + commit SHA using
 // git ls-remote. It does not require a local clone.
 func ResolveVersion(ref *Reference, git GitRunner) (*ResolvedVersion, error) {
@@ -63,8 +84,9 @@ func remoteTags(url string, git GitRunner) (map[string]string, error) {
 	return parseLsRemoteTags(string(out))
 }
 
-// parseLsRemoteTags parses the output of git ls-remote --tags into a map
-// of normalised version string → commit SHA.
+// parseLsRemoteTags parses the output of git ls-remote --tags into a map of
+// raw tag name → commit SHA. Includes both plain (`v1.2.3`) and monorepo-
+// prefixed (`wiki-v0.4.0`) semver tags. Non-semver tags are excluded.
 func parseLsRemoteTags(output string) (map[string]string, error) {
 	tags := make(map[string]string)
 
@@ -86,9 +108,8 @@ func parseLsRemoteTags(output string) (map[string]string, error) {
 			tagName = strings.TrimSuffix(tagName, "^{}")
 		}
 
-		// Only keep tags that look like semver.
-		normalized := strings.TrimPrefix(tagName, "v")
-		if _, err := semver.NewVersion(normalized); err != nil {
+		// Only keep tags that look like semver (plain or prefixed).
+		if _, _, ok := parseSemverTag(tagName); !ok {
 			continue
 		}
 
@@ -100,12 +121,46 @@ func parseLsRemoteTags(output string) (map[string]string, error) {
 	return tags, nil
 }
 
-// resolveLatest picks the highest semver tag.
+// selectTagsForPrefix narrows a tag map down to those eligible for ranking
+// against a particular release prefix.
+//
+//   - prefix == "":       only plain (un-prefixed) semver tags.
+//   - prefix == "wiki":   only `wiki-v*` tags. If none exist, falls back to
+//     plain tags so single-mold repos using plain tags still work.
+func selectTagsForPrefix(all map[string]string, prefix string) map[string]string {
+	plain := map[string]string{}
+	prefixed := map[string]string{}
+
+	for tag, sha := range all {
+		p, _, ok := parseSemverTag(tag)
+		if !ok {
+			continue
+		}
+		switch {
+		case p == "":
+			plain[tag] = sha
+		case prefix != "" && p == prefix:
+			prefixed[tag] = sha
+		}
+	}
+
+	if prefix == "" {
+		return plain
+	}
+	if len(prefixed) > 0 {
+		return prefixed
+	}
+	return plain
+}
+
+// resolveLatest picks the highest semver tag, preferring monorepo-prefixed
+// tags (`<subpath>-v*`) when the reference has a Subpath.
 func resolveLatest(ref *Reference, git GitRunner) (*ResolvedVersion, error) {
-	tags, err := remoteTags(ref.CloneURL(), git)
+	all, err := remoteTags(ref.CloneURL(), git)
 	if err != nil {
 		return nil, err
 	}
+	tags := selectTagsForPrefix(all, ref.ReleasePrefix())
 	tag, sha, err := highestVersion(tags, nil)
 	if err != nil {
 		return nil, fmt.Errorf("no semver tags found for %s", ref.CacheKey())
@@ -113,16 +168,26 @@ func resolveLatest(ref *Reference, git GitRunner) (*ResolvedVersion, error) {
 	return &ResolvedVersion{Tag: tag, Commit: sha}, nil
 }
 
-// resolveExact finds the exact tag matching the specified version.
+// resolveExact finds the exact tag matching the specified version. When the
+// reference has a Subpath, prefixed candidates (`<prefix>-v1.2.3`) are tried
+// before plain ones.
 func resolveExact(ref *Reference, git GitRunner) (*ResolvedVersion, error) {
 	tags, err := remoteTags(ref.CloneURL(), git)
 	if err != nil {
 		return nil, err
 	}
 
-	// Try both with and without v prefix.
 	version := ref.Version
-	candidates := []string{version, "v" + version, strings.TrimPrefix(version, "v")}
+	bare := strings.TrimPrefix(version, "v")
+	candidates := []string{version, "v" + bare, bare}
+	if prefix := ref.ReleasePrefix(); prefix != "" {
+		prefixed := []string{
+			prefix + "-" + version,
+			prefix + "-v" + bare,
+			prefix + "-" + bare,
+		}
+		candidates = append(prefixed, candidates...)
+	}
 
 	for _, tag := range candidates {
 		if sha, ok := tags[tag]; ok {
@@ -132,17 +197,20 @@ func resolveExact(ref *Reference, git GitRunner) (*ResolvedVersion, error) {
 	return nil, fmt.Errorf("tag %q not found in %s", ref.Version, ref.CacheKey())
 }
 
-// resolveConstraint matches a semver constraint against available tags.
+// resolveConstraint matches a semver constraint against available tags. When
+// the reference has a Subpath, the constraint is evaluated against the
+// monorepo-prefixed tags for that subpath when any exist.
 func resolveConstraint(ref *Reference, git GitRunner) (*ResolvedVersion, error) {
 	c, err := semver.NewConstraint(ref.Version)
 	if err != nil {
 		return nil, fmt.Errorf("invalid semver constraint %q: %w", ref.Version, err)
 	}
 
-	tags, err := remoteTags(ref.CloneURL(), git)
+	all, err := remoteTags(ref.CloneURL(), git)
 	if err != nil {
 		return nil, err
 	}
+	tags := selectTagsForPrefix(all, ref.ReleasePrefix())
 
 	tag, sha, err := highestVersion(tags, c)
 	if err != nil {
@@ -184,7 +252,10 @@ func highestVersion(tags map[string]string, c *semver.Constraints) (string, stri
 
 	var entries []entry
 	for tag, sha := range tags {
-		normalized := strings.TrimPrefix(tag, "v")
+		_, normalized, ok := parseSemverTag(tag)
+		if !ok {
+			continue
+		}
 		v, err := semver.NewVersion(normalized)
 		if err != nil {
 			continue

--- a/pkg/foundry/resolver_test.go
+++ b/pkg/foundry/resolver_test.go
@@ -225,3 +225,150 @@ func TestHighestVersion_Empty(t *testing.T) {
 		t.Fatal("expected error for empty tags")
 	}
 }
+
+// monorepoTagsOutput models a foundry repo (e.g. kriscoleman/replicated-foundry)
+// that uses per-mold prefixed tags (`<mold>-v<semver>`) for current releases
+// while still carrying older plain `v*` tags from before the split.
+const monorepoTagsOutput = `1111111111111111111111111111111111111111	refs/tags/v0.1.0
+2222222222222222222222222222222222222222	refs/tags/v0.2.0
+3333333333333333333333333333333333333333	refs/tags/v0.3.0
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa	refs/tags/wiki-v0.4.0
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb	refs/tags/docs-v0.4.0
+cccccccccccccccccccccccccccccccccccccccc	refs/tags/launch-v0.4.0
+dddddddddddddddddddddddddddddddddddddddd	refs/tags/wiki-v0.5.0
+`
+
+func TestResolveVersion_Latest_PrefixedMonorepoTag(t *testing.T) {
+	git := mockGitRunner(map[string]string{
+		"[ls-remote --tags https://github.com/kriscoleman/replicated-foundry.git]": monorepoTagsOutput,
+	})
+
+	ref := &Reference{
+		Host:    "github.com",
+		Owner:   "kriscoleman",
+		Repo:    "replicated-foundry",
+		Subpath: "molds/wiki",
+		Type:    Latest,
+	}
+	resolved, err := ResolveVersion(ref, git)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resolved.Tag != "wiki-v0.5.0" {
+		t.Errorf("Tag = %q, want wiki-v0.5.0 (highest prefixed match for subpath)", resolved.Tag)
+	}
+	if resolved.Commit != "dddddddddddddddddddddddddddddddddddddddd" {
+		t.Errorf("Commit = %q, want dddd... (wiki-v0.5.0 SHA)", resolved.Commit)
+	}
+}
+
+func TestResolveVersion_Latest_PrefixedFallsBackToPlain(t *testing.T) {
+	git := mockGitRunner(map[string]string{
+		"[ls-remote --tags https://github.com/kriscoleman/replicated-foundry.git]": monorepoTagsOutput,
+	})
+
+	// Subpath has no matching prefixed tags → fall back to plain v*.
+	ref := &Reference{
+		Host:    "github.com",
+		Owner:   "kriscoleman",
+		Repo:    "replicated-foundry",
+		Subpath: "molds/nonexistent",
+		Type:    Latest,
+	}
+	resolved, err := ResolveVersion(ref, git)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resolved.Tag != "v0.3.0" {
+		t.Errorf("Tag = %q, want v0.3.0 (fallback to plain semver)", resolved.Tag)
+	}
+}
+
+func TestResolveVersion_Latest_NoSubpathIgnoresPrefixed(t *testing.T) {
+	git := mockGitRunner(map[string]string{
+		"[ls-remote --tags https://github.com/kriscoleman/replicated-foundry.git]": monorepoTagsOutput,
+	})
+
+	// No subpath → only plain v* tags are eligible (today's behaviour).
+	ref := &Reference{
+		Host:  "github.com",
+		Owner: "kriscoleman",
+		Repo:  "replicated-foundry",
+		Type:  Latest,
+	}
+	resolved, err := ResolveVersion(ref, git)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resolved.Tag != "v0.3.0" {
+		t.Errorf("Tag = %q, want v0.3.0 (no subpath → plain only)", resolved.Tag)
+	}
+}
+
+func TestResolveVersion_Exact_PrefixedMonorepoTag(t *testing.T) {
+	git := mockGitRunner(map[string]string{
+		"[ls-remote --tags https://github.com/kriscoleman/replicated-foundry.git]": monorepoTagsOutput,
+	})
+
+	// User says @v0.4.0 with a wiki subpath → resolve to wiki-v0.4.0.
+	ref := &Reference{
+		Host:    "github.com",
+		Owner:   "kriscoleman",
+		Repo:    "replicated-foundry",
+		Subpath: "molds/wiki",
+		Version: "v0.4.0",
+		Type:    Exact,
+	}
+	resolved, err := ResolveVersion(ref, git)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resolved.Tag != "wiki-v0.4.0" {
+		t.Errorf("Tag = %q, want wiki-v0.4.0", resolved.Tag)
+	}
+	if resolved.Commit != "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {
+		t.Errorf("Commit = %q, want aaaa... (wiki-v0.4.0 SHA)", resolved.Commit)
+	}
+}
+
+func TestResolveVersion_Constraint_PrefixedMonorepoTag(t *testing.T) {
+	git := mockGitRunner(map[string]string{
+		"[ls-remote --tags https://github.com/kriscoleman/replicated-foundry.git]": monorepoTagsOutput,
+	})
+
+	ref := &Reference{
+		Host:    "github.com",
+		Owner:   "kriscoleman",
+		Repo:    "replicated-foundry",
+		Subpath: "molds/wiki",
+		Version: ">=0.4.0",
+		Type:    Constraint,
+	}
+	resolved, err := ResolveVersion(ref, git)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// >=0.4.0 against wiki-prefixed semvers (0.4.0, 0.5.0) → 0.5.0.
+	if resolved.Tag != "wiki-v0.5.0" {
+		t.Errorf("Tag = %q, want wiki-v0.5.0", resolved.Tag)
+	}
+}
+
+func TestReference_ReleasePrefix(t *testing.T) {
+	cases := []struct {
+		subpath string
+		want    string
+	}{
+		{"", ""},
+		{"molds/wiki", "wiki"},
+		{"molds/launch/", "launch"},
+		{"wiki", "wiki"},
+		{"a/b/c", "c"},
+	}
+	for _, tc := range cases {
+		ref := &Reference{Subpath: tc.subpath}
+		if got := ref.ReleasePrefix(); got != tc.want {
+			t.Errorf("ReleasePrefix(subpath=%q) = %q, want %q", tc.subpath, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Description

The version resolver in `pkg/foundry/resolver.go` only recognized plain `v<semver>` tags, so when a foundry repo (e.g. `kriscoleman/replicated-foundry`) publishes per-mold tags like `wiki-v0.4.0`, `docs-v0.4.0`, `launch-v0.4.0`, those were silently filtered out and every install resolved to a stale plain tag (`v0.3.0`) — which masked downstream merge/destination fixes already shipped in the v0.4.0 mold contents.

This change adds `Reference.ReleasePrefix()` (last segment of `Subpath`) and teaches the resolver to prefer `<prefix>-v*` tags when any exist for that subpath, falling back to plain `v*` tags so single-mold repos still work. `resolveLatest`, `resolveExact`, and `resolveConstraint` are all subpath-aware.

## Related Issue

N/A — surfaced while debugging multi-mold cast bugs (mcp.json clobber, AGENTS.md root clobber, target propagation) that turned out to be already fixed in the v0.4.0 mold tags ailloy could not see.

## Testing

- New unit tests in `resolver_test.go`: prefixed latest, prefix fallback to plain, no-subpath ignores prefixed, prefixed exact, prefixed constraint, plus `ReleasePrefix` cases.
- Full `go test ./...` is green.
- Manual repro: `ailloy cast 'github.com/kriscoleman/replicated-foundry//molds/{launch,docs,wiki}' --set agents.targets=opencode` now installs `*-v0.4.0` for each, with `.mcp.json` correctly merging both `replicated-docs` and `outline` servers and `AGENTS.md` placed in per-mold subdirs.

## UAT

In a fresh tmp folder, `ailloy cast 'github.com/kriscoleman/replicated-foundry//molds/wiki'` should install `wiki-v0.4.0` (visible in `.ailloy/installed.yaml`), not `v0.3.0`.

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [ ] I have updated documentation (if applicable)
- [x] My commits have DCO sign-off (`git commit -s`)