### PR TITLE
fix: apply .ailloy/flux/ overrides for subpath molds during cast

### DIFF
--- a/internal/commands/cast.go
+++ b/internal/commands/cast.go
@@ -121,7 +121,7 @@ func resolveMoldReader(args []string) (*blanks.MoldReader, string, error) {
 				return nil, "", fmt.Errorf("resolving remote mold: %w", err)
 			}
 			resolvedRemote = result
-			return blanks.NewMoldReaderFromFS(fsys, result.Root), result.Ref.CacheKey(), nil
+			return blanks.NewMoldReaderFromFS(fsys, result.Root), result.Ref.OverrideKey(), nil
 		}
 		reader, err := blanks.NewMoldReaderFromPath(args[0])
 		return reader, "", err

--- a/internal/commands/cast_core.go
+++ b/internal/commands/cast_core.go
@@ -69,7 +69,7 @@ func CastMold(_ context.Context, ref string, opts CastOptions) (CastResult, erro
 	}
 	source := ""
 	if remoteResult != nil {
-		source = remoteResult.Ref.CacheKey()
+		source = remoteResult.Ref.OverrideKey()
 	}
 	res.Source = source
 

--- a/internal/commands/cast_core_test.go
+++ b/internal/commands/cast_core_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/nimble-giant/ailloy/pkg/blanks"
+	"github.com/nimble-giant/ailloy/pkg/foundry"
 	"github.com/nimble-giant/ailloy/pkg/mold"
 )
 
@@ -85,5 +86,73 @@ flux:
 	}
 	if got := flux["target"]; got != "claude" {
 		t.Fatalf("expected default when source empty; got %v", got)
+	}
+}
+
+// TestLayerFluxForCore_SubpathOverridesAreFound is the regression test for
+// issue #196: when a foundry hosts multiple molds at distinct subpaths, the
+// saved override file must be picked up during the cast. Previously the load
+// side keyed lookups on Reference.CacheKey() (host/owner/repo only) while the
+// fluxpicker saved keyed on the full mold source (with subpath), so the two
+// disagreed and per-mold customization silently no-op'd.
+func TestLayerFluxForCore_SubpathOverridesAreFound(t *testing.T) {
+	homeDir := t.TempDir()
+	projectDir := t.TempDir()
+	t.Chdir(projectDir)
+	t.Setenv("HOME", homeDir)
+
+	moldDir := filepath.Join(projectDir, "mold")
+	if err := os.MkdirAll(moldDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	manifest := []byte(`name: launch
+flux:
+  - name: target
+    type: string
+    default: claude
+`)
+	if err := os.WriteFile(filepath.Join(moldDir, "mold.yaml"), manifest, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	reader, err := blanks.NewMoldReaderFromPath(moldDir)
+	if err != nil {
+		t.Fatalf("MoldReaderFromPath: %v", err)
+	}
+
+	// Mirror the foundries TUI's save path: the picker slugs the raw mold
+	// source string (no Reference parsing) and writes to .ailloy/flux/.
+	rawSource := "github.com/replicated-collab/foundry//molds/launch"
+	saveSlug := mold.FluxFileSlug(rawSource)
+	projectFlux := filepath.Join(".ailloy", "flux", saveSlug+".yaml")
+	if err := os.MkdirAll(filepath.Dir(projectFlux), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(projectFlux, []byte("target: opencode\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Mirror the cast pipeline: parse the same ref and pass OverrideKey() in
+	// as `source`. The lookup must find the file that was saved above.
+	ref, err := foundry.ParseReference(rawSource)
+	if err != nil {
+		t.Fatalf("ParseReference: %v", err)
+	}
+	flux, err := layerFluxForCore(reader, ref.OverrideKey(), nil, nil)
+	if err != nil {
+		t.Fatalf("layerFluxForCore: %v", err)
+	}
+	if got := flux["target"]; got != "opencode" {
+		t.Fatalf("expected subpath override target=opencode; got %v (slug saved=%q lookup-key=%q)",
+			got, saveSlug, ref.OverrideKey())
+	}
+
+	// CacheKey() — the old, buggy lookup — must NOT find the override.
+	// Pinning this prevents a future refactor from silently regressing.
+	flux, err = layerFluxForCore(reader, ref.CacheKey(), nil, nil)
+	if err != nil {
+		t.Fatalf("layerFluxForCore (cache key): %v", err)
+	}
+	if got := flux["target"]; got != "claude" {
+		t.Fatalf("CacheKey() lookup unexpectedly matched; subpath molds in the same repo would collide. got=%v", got)
 	}
 }

--- a/pkg/foundry/reference.go
+++ b/pkg/foundry/reference.go
@@ -160,6 +160,20 @@ func (r *Reference) CacheKey() string {
 	return fmt.Sprintf("%s/%s/%s", r.Host, r.Owner, r.Repo)
 }
 
+// OverrideKey returns the per-mold key used to look up persisted flux
+// overrides written by the foundries TUI. It is CacheKey with the subpath
+// appended so monorepo molds (where one repo hosts several molds at distinct
+// subpaths) get their own override file rather than colliding on the repo
+// key. Version is intentionally excluded — saves are keyed on the raw mold
+// source (which carries no version), so loads must match.
+func (r *Reference) OverrideKey() string {
+	key := r.CacheKey()
+	if sp := strings.Trim(r.Subpath, "/"); sp != "" {
+		key = key + "/" + sp
+	}
+	return key
+}
+
 // ReleasePrefix returns the last segment of Subpath, used to match monorepo-
 // style per-mold tags like `<prefix>-v1.2.3` (e.g. `wiki-v0.4.0`). Returns ""
 // when there is no subpath.

--- a/pkg/foundry/reference_test.go
+++ b/pkg/foundry/reference_test.go
@@ -236,6 +236,43 @@ func TestReference_CacheKey(t *testing.T) {
 	}
 }
 
+func TestReference_OverrideKey(t *testing.T) {
+	tests := []struct {
+		name string
+		ref  Reference
+		want string
+	}{
+		{
+			name: "no subpath matches CacheKey",
+			ref:  Reference{Host: "github.com", Owner: "owner", Repo: "repo"},
+			want: "github.com/owner/repo",
+		},
+		{
+			name: "subpath appended",
+			ref:  Reference{Host: "github.com", Owner: "owner", Repo: "repo", Subpath: "molds/launch"},
+			want: "github.com/owner/repo/molds/launch",
+		},
+		{
+			name: "subpath with leading and trailing slashes is trimmed",
+			ref:  Reference{Host: "github.com", Owner: "owner", Repo: "repo", Subpath: "/molds/launch/"},
+			want: "github.com/owner/repo/molds/launch",
+		},
+		{
+			name: "version is intentionally omitted",
+			ref:  Reference{Host: "github.com", Owner: "owner", Repo: "repo", Version: "v1.2.3", Subpath: "molds/launch"},
+			want: "github.com/owner/repo/molds/launch",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.ref.OverrideKey(); got != tt.want {
+				t.Errorf("OverrideKey() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestReference_String(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Description

The fluxpicker saved overrides keyed on the full mold source (with subpath), but the cast pipeline looked them up via `Reference.CacheKey()` which only returns `host/owner/repo`. For monorepo molds the keys disagreed, so per-mold customization made via the foundries TUI silently no-op'd. This PR adds `Reference.OverrideKey()` (CacheKey + subpath, version intentionally omitted to match the save side) and routes both `cast.go` and `cast_core.go` through it.

## Related Issue

Fixes #196

## Testing

\`go test ./pkg/foundry/... ./internal/commands/...\` passes (incl. new \`TestReference_OverrideKey\` and \`TestLayerFluxForCore_SubpathOverridesAreFound\`); pre-push lefthook (build, golangci-lint, full test suite with -race) green.

## UAT

Register a foundry whose index contains a subpath mold (e.g. \`github.com/owner/repo//molds/launch\`), run \`ailloy foundries\`, customize a flux value (e.g. \`agent.targets: [opencode]\`) and save to project; rerun the install and confirm the cast output reflects the override instead of the mold's default.

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [ ] I have updated documentation (if applicable)
- [x] My commits have DCO sign-off (\`git commit -s\`)