### PR TITLE
fix: clean up empty multi-dest dirs in CastMold path (#195)

### DIFF
--- a/internal/commands/cast_core.go
+++ b/internal/commands/cast_core.go
@@ -159,6 +159,10 @@ func CastMold(_ context.Context, ref string, opts CastOptions) (CastResult, erro
 		return res, fmt.Errorf("copying files: %w", err)
 	}
 
+	// Drop directories that ended up empty after skipped renders (#145, #195).
+	dirs = cleanupEmptyDirs(dirs, destPrefix)
+	res.Dirs = dirs
+
 	// Mirror what cast.go does: record install dirs in .ailloy/state.yaml so
 	// `mold list` can find blanks installed via the foundries TUI.
 	if destPrefix == "" {

--- a/internal/commands/cast_core_test.go
+++ b/internal/commands/cast_core_test.go
@@ -9,6 +9,67 @@ import (
 	"github.com/nimble-giant/ailloy/pkg/mold"
 )
 
+// TestCastMold_CleansEmptyMultiDestDirs reproduces issue #195: when a
+// multi-destination output mapping has per-dest `set` context and the
+// template renders to empty for one destination, the foundry-TUI install
+// path (CastMold) eagerly created the destination dir but never cleaned
+// it up after the empty render was skipped. The CLI cast path already
+// cleans up via cleanupEmptyDirs (#145); CastMold needs the same.
+func TestCastMold_CleansEmptyMultiDestDirs(t *testing.T) {
+	projectDir := t.TempDir()
+	t.Chdir(projectDir)
+	t.Setenv("HOME", t.TempDir())
+
+	moldDir := filepath.Join(projectDir, "mold")
+	if err := os.MkdirAll(filepath.Join(moldDir, "agents"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(moldDir, "mold.yaml"),
+		[]byte("apiVersion: v1\nkind: Mold\nname: launch\nversion: 0.1.0\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(moldDir, "flux.yaml"), []byte(`agent:
+  targets:
+    - opencode
+
+output:
+  agents:
+    - dest: .claude/agents
+      set:
+        agent.current_target: claude
+    - dest: .opencode/agents
+      set:
+        agent.current_target: opencode
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	template := `{{- if and (eq .agent.current_target "claude") (has "claude" .agent.targets) -}}
+---
+name: coding-agent
+---
+claude body
+{{- else if and (eq .agent.current_target "opencode") (has "opencode" .agent.targets) -}}
+---
+description: opencode
+---
+opencode body
+{{- end -}}`
+	if err := os.WriteFile(filepath.Join(moldDir, "agents", "coding-agent.md"), []byte(template), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := CastMold(t.Context(), moldDir, CastOptions{}); err != nil {
+		t.Fatalf("CastMold: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(projectDir, ".opencode", "agents", "coding-agent.md")); err != nil {
+		t.Fatalf("expected .opencode/agents/coding-agent.md to exist: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(projectDir, ".claude", "agents")); err == nil {
+		t.Errorf("regression #195: .claude/agents/ leftover after CastMold (template rendered empty for inactive target)")
+	}
+}
+
 // TestLayerFluxForCore_AutoLoadsPersistedFluxFiles asserts that
 // ./.ailloy/flux/<slug>.yaml and ~/.ailloy/flux/<slug>.yaml are layered into
 // the cast pipeline between mold defaults and explicit -f files. This is the

--- a/internal/commands/cast_foundry_shape_test.go
+++ b/internal/commands/cast_foundry_shape_test.go
@@ -330,6 +330,73 @@ func TestIntegration_ReplicatedFoundryShape_SingleTargetOnly(t *testing.T) {
 	}
 }
 
+// TestIntegration_MultiDest_DifferentDirs_SkipsEmptyRender: literal
+// reproduction of issue #195. A single source file fans out to two
+// different destination directories via per-dest `set` overrides; the
+// template uses conditionals so only one destination's render produces
+// content. The inactive destination's render is empty and must NOT be
+// written as a zero-byte file.
+func TestIntegration_MultiDest_DifferentDirs_SkipsEmptyRender(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	flux := `agent:
+  targets:
+    - opencode
+
+output:
+  agents:
+    - dest: .claude/agents
+      set:
+        agent.current_target: claude
+    - dest: .opencode/agents
+      set:
+        agent.current_target: opencode
+`
+
+	template := `{{- if and (eq .agent.current_target "claude") (has "claude" .agent.targets) -}}
+---
+name: coding-agent
+model: opus
+---
+claude body
+{{- else if and (eq .agent.current_target "opencode") (has "opencode" .agent.targets) -}}
+---
+description: coding agent
+mode: primary
+---
+opencode body
+{{- end -}}`
+
+	moldFS := fstest.MapFS{
+		"mold.yaml":              &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: Mold\nname: agents\nversion: 0.1.0\n")},
+		"flux.yaml":              &fstest.MapFile{Data: []byte(flux)},
+		"agents/coding-agent.md": &fstest.MapFile{Data: []byte(template)},
+	}
+
+	castFoundryMold(t, moldFS)
+
+	// Active destination must exist with content.
+	openPath := filepath.Join(".opencode", "agents", "coding-agent.md")
+	openBytes, err := os.ReadFile(openPath)
+	if err != nil {
+		t.Fatalf("expected %s to be created, got: %v", openPath, err)
+	}
+	if !strings.Contains(string(openBytes), "opencode body") {
+		t.Errorf("expected opencode content, got:\n%s", openBytes)
+	}
+
+	// Inactive destination must NOT be written as a zero-byte file.
+	claudePath := filepath.Join(".claude", "agents", "coding-agent.md")
+	if info, err := os.Stat(claudePath); err == nil {
+		t.Errorf("regression #195: %s should not exist (template renders empty for inactive target), but it does (size=%d)", claudePath, info.Size())
+	}
+}
+
 // TestIntegration_ReplicatedFoundryShape_ThreeMolds: a more demanding scenario
 // — three molds all writing to the same destination files. Verifies merge
 // behaves transitively (mold C reads the result of mold A + mold B).


### PR DESCRIPTION
## Description

The CLI cast path already calls `cleanupEmptyDirs` after `copyResolvedFiles` so multi-destination output mappings whose templates render to empty for inactive targets don't leave behind empty directories (#145). `CastMold` in `cast_core.go` — the path used by the foundries TUI install — eagerly created destination dirs but never invoked the same cleanup, so casting `replicated-collab/foundry//molds/launch` left `.claude/agents/` (or `.opencode/agents/`) behind depending on `agent.targets`. This change mirrors the CLI path: invoke `cleanupEmptyDirs` after the file write loop and update `CastResult.Dirs` so `writeInstallState` records only surviving directories.

## Related Issue

Fixes #195

## Testing

Added `TestCastMold_CleansEmptyMultiDestDirs` reproducing the launch-mold shape (single source `agents/coding-agent.md` fanned out to `.claude/agents` and `.opencode/agents` with per-dest `agent.current_target` overrides). Verified RED before the fix, GREEN after. Also added `TestIntegration_MultiDest_DifferentDirs_SkipsEmptyRender` to lock in the CLI-path behavior. Full `go test ./...` passes.

## UAT

```
ailloy cast github.com/replicated-collab/foundry//molds/launch --set 'agent.targets=[opencode]'
```
After cast, only `.opencode/agents/` should exist with both agent files; `.claude/agents/` should not exist (previously left as empty dir). Re-run with `[claude]` for the opposite assertion.

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [ ] I have updated documentation (if applicable)
- [x] My commits have DCO sign-off (`git commit -s`)