### PR TITLE
fix: stop concurrent CastMolds racing on global silencing state

### DIFF
--- a/internal/commands/anneal.go
+++ b/internal/commands/anneal.go
@@ -93,7 +93,7 @@ func runAnneal(_ *cobra.Command, args []string) error {
 			}
 		}
 		allowLocalDeps := !foundry.IsRemoteReference(moldDir)
-		if err := installDeclaredDeps(manifest, moldKey, false, allowLocalDeps, false); err != nil {
+		if err := installDeclaredDeps(manifest, moldKey, false, allowLocalDeps, false, false, nil); err != nil {
 			log.Printf("warning: installing declared deps for %s: %v", moldDir, err)
 		}
 	}

--- a/internal/commands/cast.go
+++ b/internal/commands/cast.go
@@ -12,7 +12,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/charmbracelet/huh"
@@ -54,12 +53,31 @@ var (
 	// at cast time. Missing deps surface as errors instead of being fetched
 	// silently. Intended for CI; see --frozen flag.
 	castFrozen bool
-	// castSilent suppresses interactive output from copyResolvedFiles and
-	// related helpers. Set by CastMold (the programmatic core used by the
-	// foundries TUI) so per-file "✅ Created" lines don't corrupt the
-	// Bubble Tea alt-screen.
-	castSilent atomic.Bool
 )
+
+// copyOpts configures copyResolvedFiles. Centralising these as a struct lets
+// callers like CastMold (used by the foundries TUI) request a fully silent
+// run — no per-file stdout writes, all warnings to a discarding logger — so
+// concurrent casts can't race on global silencing flags.
+type copyOpts struct {
+	ForceReplaceOnParseError bool
+	// Silent suppresses the per-file "✅ Created" stdout lines. The Bubble
+	// Tea alt-screen is corrupted by any stray Println, so the TUI path sets
+	// this true.
+	Silent bool
+	// Logger receives non-fatal warnings (template validation, skipped empty
+	// renders). Nil falls back to log.Default(); the TUI path passes a
+	// discarding logger so concurrent casts can't race on log.SetOutput.
+	Logger *log.Logger
+}
+
+// logger returns opts.Logger or log.Default() when unset.
+func (o copyOpts) logger() *log.Logger {
+	if o.Logger != nil {
+		return o.Logger
+	}
+	return log.Default()
+}
 
 func init() {
 	rootCmd.AddCommand(castCmd)
@@ -273,7 +291,7 @@ func castProject(reader *blanks.MoldReader, source string) error {
 	// otherwise a malicious foundry could declare e.g. `- ore: /etc` and
 	// have it copied into the project tree.
 	allowLocalDeps := resolvedRemote == nil
-	if err := installDeclaredDeps(manifest, moldKey, castGlobal, allowLocalDeps, castFrozen); err != nil {
+	if err := installDeclaredDeps(manifest, moldKey, castGlobal, allowLocalDeps, castFrozen, false, nil); err != nil {
 		return fmt.Errorf("installing declared dependencies: %w", err)
 	}
 
@@ -334,7 +352,9 @@ func castProject(reader *blanks.MoldReader, source string) error {
 	fmt.Println()
 
 	// Copy resolved files from mold (using the ore-merged schema for validation).
-	if err := copyResolvedFilesWithSchema(reader, manifest, mergedSchema, flux, filesToCast, castForceReplaceOnParseError); err != nil {
+	if err := copyResolvedFilesWithSchema(reader, manifest, mergedSchema, flux, filesToCast, copyOpts{
+		ForceReplaceOnParseError: castForceReplaceOnParseError,
+	}); err != nil {
 		return fmt.Errorf("failed to copy files: %w", err)
 	}
 
@@ -343,7 +363,7 @@ func castProject(reader *blanks.MoldReader, source string) error {
 
 	// Record the cast in the installed manifest (provenance for `recast` / `quench`).
 	if resolvedRemote != nil {
-		if err := recordInstalled(resolvedRemote, castGlobal); err != nil {
+		if err := recordInstalled(resolvedRemote, castGlobal, nil); err != nil {
 			log.Printf("warning: failed to update installed manifest: %v", err)
 		}
 	}
@@ -654,20 +674,22 @@ func offerAgentsImport(claudePath string) {
 // inferred from the reader / mold manifest. Cast-time callers should prefer
 // copyResolvedFilesWithSchema so ore-merged schema entries participate in
 // ValidateFlux.
-func copyResolvedFiles(reader *blanks.MoldReader, manifest *mold.Mold, flux map[string]any, resolved []mold.ResolvedFile, forceReplaceOnParseError bool) error {
+func copyResolvedFiles(reader *blanks.MoldReader, manifest *mold.Mold, flux map[string]any, resolved []mold.ResolvedFile, opts copyOpts) error {
 	var schema []mold.FluxVar
 	if s, err := reader.LoadFluxSchema(); err == nil && s != nil {
 		schema = s
 	} else if manifest != nil && len(manifest.Flux) > 0 {
 		schema = manifest.Flux
 	}
-	return copyResolvedFilesWithSchema(reader, manifest, schema, flux, resolved, forceReplaceOnParseError)
+	return copyResolvedFilesWithSchema(reader, manifest, schema, flux, resolved, opts)
 }
 
 // copyResolvedFilesWithSchema is copyResolvedFiles with an explicit schema
 // parameter. Callers that have already merged ore overlays (cast/recast)
 // pass the merged schema so ValidateFlux sees the full ore.<name>.* surface.
-func copyResolvedFilesWithSchema(reader *blanks.MoldReader, manifest *mold.Mold, schema []mold.FluxVar, flux map[string]any, resolved []mold.ResolvedFile, forceReplaceOnParseError bool) error {
+func copyResolvedFilesWithSchema(reader *blanks.MoldReader, manifest *mold.Mold, schema []mold.FluxVar, flux map[string]any, resolved []mold.ResolvedFile, opts copyOpts) error {
+	logger := opts.logger()
+
 	// Validate: ore-merged schema preferred; fall back to flux.schema.yaml /
 	// mold.yaml's flux: block when caller didn't supply one.
 	if len(schema) == 0 {
@@ -678,12 +700,15 @@ func copyResolvedFilesWithSchema(reader *blanks.MoldReader, manifest *mold.Mold,
 		}
 	}
 	if err := mold.ValidateFlux(schema, flux); err != nil {
-		log.Printf("warning: %v", err)
+		logger.Printf("warning: %v", err)
 	}
 
 	// Build ingot resolver
 	resolver := buildIngotResolver(flux, reader.Root())
-	opts := []mold.TemplateOption{mold.WithIngotResolver(resolver)}
+	tplOpts := []mold.TemplateOption{
+		mold.WithIngotResolver(resolver),
+		mold.WithLogger(logger),
+	}
 
 	for _, rf := range resolved {
 		content, err := fs.ReadFile(reader.FS(), rf.SrcPath)
@@ -697,7 +722,7 @@ func copyResolvedFilesWithSchema(reader *blanks.MoldReader, manifest *mold.Mold,
 			if len(rf.Set) > 0 {
 				fluxForFile = mold.MergeSet(flux, rf.Set)
 			}
-			processed, err := mold.ProcessTemplate(string(content), fluxForFile, opts...)
+			processed, err := mold.ProcessTemplate(string(content), fluxForFile, tplOpts...)
 			if err != nil {
 				return fmt.Errorf("failed to process %s: %w", rf.SrcPath, err)
 			}
@@ -708,14 +733,14 @@ func copyResolvedFilesWithSchema(reader *blanks.MoldReader, manifest *mold.Mold,
 
 		// Skip files that render to empty or whitespace-only content (#130)
 		if rf.Process && strings.TrimSpace(string(outputContent)) == "" {
-			log.Printf("skipping %s: rendered to empty content", rf.SrcPath)
+			logger.Printf("skipping %s: rendered to empty content", rf.SrcPath)
 			continue
 		}
 
 		switch rf.Strategy {
 		case "merge":
 			err := merge.MergeFile(rf.DestPath, outputContent, merge.Options{
-				ForceReplaceOnParseError: forceReplaceOnParseError,
+				ForceReplaceOnParseError: opts.ForceReplaceOnParseError,
 			})
 			if err != nil {
 				var pe *merge.ParseError
@@ -749,7 +774,7 @@ func copyResolvedFilesWithSchema(reader *blanks.MoldReader, manifest *mold.Mold,
 			return fmt.Errorf("unknown strategy %q on output for %s", rf.Strategy, rf.DestPath)
 		}
 
-		if !castSilent.Load() {
+		if !opts.Silent {
 			fmt.Println(styles.SuccessStyle.Render("✅ Created: ") + styles.CodeStyle.Render(rf.DestPath))
 		}
 	}
@@ -758,14 +783,19 @@ func copyResolvedFilesWithSchema(reader *blanks.MoldReader, manifest *mold.Mold,
 }
 
 // recordInstalled upserts the just-cast mold into the installed manifest.
-func recordInstalled(result *foundry.ResolveResult, global bool) error {
+// logger receives the "corrupt manifest, resetting" warning; pass a discarding
+// logger from TUI callers to keep the alt-screen clean.
+func recordInstalled(result *foundry.ResolveResult, global bool, logger *log.Logger) error {
+	if logger == nil {
+		logger = log.Default()
+	}
 	path := manifestPathFor(global)
 	if path == "" {
 		return nil // global path unresolvable — silently skip rather than write to cwd
 	}
 	manifest, err := foundry.ReadInstalledManifest(path)
 	if err != nil {
-		log.Printf("warning: corrupt installed manifest at %s, resetting: %v", path, err)
+		logger.Printf("warning: corrupt installed manifest at %s, resetting: %v", path, err)
 		manifest = nil
 	}
 	if manifest == nil {

--- a/internal/commands/cast_core.go
+++ b/internal/commands/cast_core.go
@@ -54,21 +54,18 @@ type CastResult struct {
 // no terminal output. Returns structured results suitable for the TUI to
 // render. The cobra `runCast` keeps its richer CLI presentation.
 //
+// All silencing is plumbed through per-call options (silent flags, discarding
+// loggers). No process-global state — concurrent CastMold calls (as happens
+// when the foundries TUI dispatches multi-mold casts via tea.Batch) cannot
+// race each other into leaking output to the alt-screen.
+//
 // ctx is currently unused but reserved for future cancellation.
 func CastMold(_ context.Context, ref string, opts CastOptions) (CastResult, error) {
 	var res CastResult
 
-	// Silence per-file "✅ Created" lines from copyResolvedFiles so the
-	// Bubble Tea alt-screen doesn't get clobbered. Also redirect stderr
-	// so log.Printf warnings (e.g. install-state, lock-file write) don't
-	// bleed through.
-	castSilent.Store(true)
-	defer castSilent.Store(false)
-	prevLog := log.Writer()
-	log.SetOutput(io.Discard)
-	defer log.SetOutput(prevLog)
+	silentLogger := log.New(io.Discard, "", 0)
 
-	reader, remoteResult, err := openMoldReaderForCore(ref, opts.Global)
+	reader, remoteResult, err := openMoldReaderForCore(ref, opts.Global, silentLogger)
 	if err != nil {
 		return res, err
 	}
@@ -99,7 +96,7 @@ func CastMold(_ context.Context, ref string, opts CastOptions) (CastResult, erro
 	// otherwise a malicious foundry could declare e.g. `- ore: /etc` and
 	// have it copied into the project tree.
 	allowLocalDeps := remoteResult == nil
-	if err := installDeclaredDeps(manifest, moldKey, opts.Global, allowLocalDeps, opts.Frozen); err != nil {
+	if err := installDeclaredDeps(manifest, moldKey, opts.Global, allowLocalDeps, opts.Frozen, true, silentLogger); err != nil {
 		return res, fmt.Errorf("installing declared dependencies: %w", err)
 	}
 
@@ -114,6 +111,7 @@ func CastMold(_ context.Context, ref string, opts CastOptions) (CastResult, erro
 			WithWorkflows:   opts.WithWorkflows,
 			NameOverride:    opts.PluginName,
 			VersionOverride: opts.PluginVersion,
+			Logger:          silentLogger,
 		})
 		if perr != nil {
 			return res, perr
@@ -177,7 +175,11 @@ func CastMold(_ context.Context, ref string, opts CastOptions) (CastResult, erro
 		}
 	}
 
-	if err := copyResolvedFilesWithSchema(reader, manifest, mergedSchema, flux, filesToCast, opts.ForceReplaceOnParseError); err != nil {
+	if err := copyResolvedFilesWithSchema(reader, manifest, mergedSchema, flux, filesToCast, copyOpts{
+		ForceReplaceOnParseError: opts.ForceReplaceOnParseError,
+		Silent:                   true,
+		Logger:                   silentLogger,
+	}); err != nil {
 		return res, fmt.Errorf("copying files: %w", err)
 	}
 
@@ -189,7 +191,7 @@ func CastMold(_ context.Context, ref string, opts CastOptions) (CastResult, erro
 	// `mold list` can find blanks installed via the foundries TUI.
 	if destPrefix == "" {
 		if err := writeInstallState(dirs); err != nil {
-			log.Printf("warning: failed to write install state: %v", err)
+			silentLogger.Printf("warning: failed to write install state: %v", err)
 		}
 	}
 
@@ -199,8 +201,8 @@ func CastMold(_ context.Context, ref string, opts CastOptions) (CastResult, erro
 			// Upsert the manifest entry with provenance, then backfill Files
 			// + FileHashes. Mirrors what cast.go does via recordInstalled +
 			// RecordInstalledFiles.
-			if err := recordInstalled(remoteResult, opts.Global); err != nil {
-				log.Printf("warning: failed to update installed manifest: %v", err)
+			if err := recordInstalled(remoteResult, opts.Global, silentLogger); err != nil {
+				silentLogger.Printf("warning: failed to update installed manifest: %v", err)
 			} else {
 				installed := make([]foundry.InstalledFile, 0, len(filesToCast))
 				for _, f := range filesToCast {
@@ -227,12 +229,15 @@ func CastMold(_ context.Context, ref string, opts CastOptions) (CastResult, erro
 // The returned *foundry.ResolveResult is populated for remote refs (so the
 // caller can record provenance in the installed manifest) and nil for local
 // refs.
-func openMoldReaderForCore(ref string, global bool) (*blanks.MoldReader, *foundry.ResolveResult, error) {
+func openMoldReaderForCore(ref string, global bool, logger *log.Logger) (*blanks.MoldReader, *foundry.ResolveResult, error) {
 	if ref == "" {
 		return nil, nil, fmt.Errorf("ref required")
 	}
 	if foundry.IsRemoteReference(ref) {
-		var resolveOpts []foundry.ResolveOption
+		resolveOpts := []foundry.ResolveOption{}
+		if logger != nil {
+			resolveOpts = append(resolveOpts, foundry.WithLogger(logger))
+		}
 		if global {
 			resolveOpts = append(resolveOpts, foundry.WithLockPath(globalLockPath()))
 		}

--- a/internal/commands/cast_core_test.go
+++ b/internal/commands/cast_core_test.go
@@ -1,8 +1,10 @@
 package commands
 
 import (
+	"io"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/nimble-giant/ailloy/pkg/blanks"
@@ -68,6 +70,93 @@ opencode body
 	}
 	if _, err := os.Stat(filepath.Join(projectDir, ".claude", "agents")); err == nil {
 		t.Errorf("regression #195: .claude/agents/ leftover after CastMold (template rendered empty for inactive target)")
+	}
+}
+
+// TestCastMold_ConcurrentRunsStaySilent guards against the regression where
+// CastMold used a process-global `castSilent` toggle plus a global
+// log.SetOutput() to suppress per-file "✅ Created" lines. When the foundries
+// TUI dispatched multiple casts via tea.Batch, the first goroutine to finish
+// flipped the toggle back on while the others were still inside
+// copyResolvedFiles — leaking `fmt.Println` output into the Bubble Tea
+// alt-screen and producing the "jumbled output" symptom.
+//
+// The fix plumbs silencing through per-call opts (no globals). This test
+// captures stdout while running many CastMolds concurrently and asserts no
+// bytes are written.
+func TestCastMold_ConcurrentRunsStaySilent(t *testing.T) {
+	projectDir := t.TempDir()
+	t.Chdir(projectDir)
+	t.Setenv("HOME", t.TempDir())
+
+	// Build several local mold dirs, each with several files, so
+	// copyResolvedFiles iterates many times per cast — maximising the
+	// chance of catching any concurrent stdout write.
+	const moldCount = 4
+	const filesPerMold = 6
+	moldDirs := make([]string, 0, moldCount)
+	for i := 0; i < moldCount; i++ {
+		dir := filepath.Join(projectDir, "molds", "m"+string(rune('a'+i)))
+		if err := os.MkdirAll(filepath.Join(dir, "blanks"), 0o750); err != nil {
+			t.Fatal(err)
+		}
+		manifest := []byte("apiVersion: v1\nkind: Mold\nname: m" + string(rune('a'+i)) + "\nversion: 0.1.0\n")
+		if err := os.WriteFile(filepath.Join(dir, "mold.yaml"), manifest, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		flux := []byte("output:\n  blanks:\n    - dest: out/m" + string(rune('a'+i)) + "\n")
+		if err := os.WriteFile(filepath.Join(dir, "flux.yaml"), flux, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		for j := 0; j < filesPerMold; j++ {
+			fname := filepath.Join(dir, "blanks", "f"+string(rune('0'+j))+".md")
+			if err := os.WriteFile(fname, []byte("hello\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}
+		moldDirs = append(moldDirs, dir)
+	}
+
+	// Redirect stdout into a pipe so we can observe anything the cast path
+	// leaks. The race-prone scenario this guards against is multiple
+	// CastMolds racing on global silencing state.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	origStdout := os.Stdout
+	os.Stdout = w
+
+	var captured []byte
+	captureDone := make(chan struct{})
+	go func() {
+		captured, _ = io.ReadAll(r)
+		close(captureDone)
+	}()
+
+	var wg sync.WaitGroup
+	errs := make(chan error, moldCount)
+	for _, dir := range moldDirs {
+		wg.Add(1)
+		go func(d string) {
+			defer wg.Done()
+			if _, err := CastMold(t.Context(), d, CastOptions{}); err != nil {
+				errs <- err
+			}
+		}(dir)
+	}
+	wg.Wait()
+	close(errs)
+
+	os.Stdout = origStdout
+	_ = w.Close()
+	<-captureDone
+
+	for err := range errs {
+		t.Errorf("CastMold: %v", err)
+	}
+	if len(captured) > 0 {
+		t.Fatalf("CastMold leaked %d bytes to stdout: %q", len(captured), string(captured))
 	}
 }
 

--- a/internal/commands/cast_foundry_shape_test.go
+++ b/internal/commands/cast_foundry_shape_test.go
@@ -140,7 +140,7 @@ func castFoundryMold(t *testing.T, fs fstest.MapFS) {
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
-	if err := copyResolvedFiles(reader, manifest, flux, resolved, false); err != nil {
+	if err := copyResolvedFiles(reader, manifest, flux, resolved, copyOpts{}); err != nil {
 		t.Fatalf("copy: %v", err)
 	}
 }

--- a/internal/commands/cast_integration_test.go
+++ b/internal/commands/cast_integration_test.go
@@ -61,7 +61,7 @@ func TestIntegration_CopyResolvedFiles(t *testing.T) {
 		t.Fatal("expected resolved files, got none")
 	}
 
-	err = copyResolvedFiles(reader, manifest, flux, resolved, false)
+	err = copyResolvedFiles(reader, manifest, flux, resolved, copyOpts{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -124,7 +124,7 @@ func TestIntegration_CopyResolvedFiles_WithVariableSubstitution(t *testing.T) {
 		}
 	}
 
-	err = copyResolvedFiles(reader, manifest, flux, processable, false)
+	err = copyResolvedFiles(reader, manifest, flux, processable, copyOpts{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -163,7 +163,7 @@ func TestIntegration_ResolvedFilesMatchMold(t *testing.T) {
 		t.Fatalf("failed to resolve files: %v", err)
 	}
 
-	err = copyResolvedFiles(reader, manifest, flux, resolved, false)
+	err = copyResolvedFiles(reader, manifest, flux, resolved, copyOpts{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -228,7 +228,7 @@ func TestCopyResolvedFiles_SkipsEmptyRenderedFiles(t *testing.T) {
 		{SrcPath: "commands/nonempty.md", DestPath: filepath.Join(tmpDir, ".claude/commands/nonempty.md"), Process: true},
 	}
 
-	err := copyResolvedFiles(reader, nil, map[string]any{}, resolved, false)
+	err := copyResolvedFiles(reader, nil, map[string]any{}, resolved, copyOpts{})
 	if err != nil {
 		t.Fatalf("copyResolvedFiles failed: %v", err)
 	}
@@ -346,7 +346,7 @@ func TestCopyResolvedFiles_RemovesEmptyMultiDestDirs(t *testing.T) {
 		}
 	}
 
-	if err := copyResolvedFiles(reader, nil, map[string]any{}, resolved, false); err != nil {
+	if err := copyResolvedFiles(reader, nil, map[string]any{}, resolved, copyOpts{}); err != nil {
 		t.Fatalf("copyResolvedFiles failed: %v", err)
 	}
 
@@ -423,7 +423,7 @@ func TestIntegration_FilePermissions(t *testing.T) {
 		t.Fatalf("failed to resolve files: %v", err)
 	}
 
-	err = copyResolvedFiles(reader, manifest, flux, resolved, false)
+	err = copyResolvedFiles(reader, manifest, flux, resolved, copyOpts{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -534,7 +534,7 @@ func TestIntegration_WorkflowsNotProcessed(t *testing.T) {
 		t.Fatalf("failed to resolve files: %v", err)
 	}
 
-	err = copyResolvedFiles(reader, manifest, flux, resolved, false)
+	err = copyResolvedFiles(reader, manifest, flux, resolved, copyOpts{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -602,7 +602,7 @@ func TestIntegration_MergeStrategy_JSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
-	if err := copyResolvedFiles(reader, manifest, flux, resolved, false); err != nil {
+	if err := copyResolvedFiles(reader, manifest, flux, resolved, copyOpts{}); err != nil {
 		t.Fatalf("copy: %v", err)
 	}
 
@@ -664,7 +664,7 @@ func TestIntegration_MergeStrategy_TwoMolds(t *testing.T) {
 		if err != nil {
 			t.Fatalf("resolve: %v", err)
 		}
-		if err := copyResolvedFiles(reader, manifest, flux, resolved, false); err != nil {
+		if err := copyResolvedFiles(reader, manifest, flux, resolved, copyOpts{}); err != nil {
 			t.Fatalf("copy: %v", err)
 		}
 	}
@@ -719,7 +719,7 @@ func TestIntegration_MergeStrategy_ForceReplaceOnParseError(t *testing.T) {
 	}
 
 	// Without force-replace: should fail with ParseError-derived message.
-	err = copyResolvedFiles(reader, manifest, flux, resolved, false)
+	err = copyResolvedFiles(reader, manifest, flux, resolved, copyOpts{})
 	if err == nil {
 		t.Fatal("expected error without force-replace, got nil")
 	}
@@ -728,7 +728,7 @@ func TestIntegration_MergeStrategy_ForceReplaceOnParseError(t *testing.T) {
 	}
 
 	// With force-replace: should clobber the unparseable file.
-	if err := copyResolvedFiles(reader, manifest, flux, resolved, true); err != nil {
+	if err := copyResolvedFiles(reader, manifest, flux, resolved, copyOpts{ForceReplaceOnParseError: true}); err != nil {
 		t.Fatalf("force-replace should succeed; got: %v", err)
 	}
 	got, _ := os.ReadFile("opencode.json")
@@ -815,7 +815,7 @@ func TestIntegration_MergeStrategy_MultiDestList(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := copyResolvedFiles(reader, manifest, flux, resolved, false); err != nil {
+	if err := copyResolvedFiles(reader, manifest, flux, resolved, copyOpts{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -869,7 +869,7 @@ func TestIntegration_MergeStrategy_NonMergeableExt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := copyResolvedFiles(reader, manifest, flux, resolved, false); err != nil {
+	if err := copyResolvedFiles(reader, manifest, flux, resolved, copyOpts{}); err != nil {
 		t.Fatalf("non-mergeable ext should silently replace, not error: %v", err)
 	}
 
@@ -912,7 +912,7 @@ func TestIntegration_MergeStrategy_CrossFormatMisconfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = copyResolvedFiles(reader, manifest, flux, resolved, false)
+	err = copyResolvedFiles(reader, manifest, flux, resolved, copyOpts{})
 	if err == nil {
 		t.Fatal("expected error for YAML content into .json dest, got nil")
 	}
@@ -951,7 +951,7 @@ func TestIntegration_MergeStrategy_ErrorMessageActionable(t *testing.T) {
 	flux, _ := reader.LoadFluxDefaults()
 	resolved, _ := mold.ResolveFiles(flux["output"], reader.FS())
 
-	err := copyResolvedFiles(reader, manifest, flux, resolved, false)
+	err := copyResolvedFiles(reader, manifest, flux, resolved, copyOpts{})
 	if err == nil {
 		t.Fatal("expected error for unparseable existing file, got nil")
 	}
@@ -987,7 +987,7 @@ func TestIntegration_MergeStrategy_NestedDestPath(t *testing.T) {
 	flux, _ := reader.LoadFluxDefaults()
 	resolved, _ := mold.ResolveFiles(flux["output"], reader.FS())
 
-	if err := copyResolvedFiles(reader, manifest, flux, resolved, false); err != nil {
+	if err := copyResolvedFiles(reader, manifest, flux, resolved, copyOpts{}); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat("nested/sub/dir/config.json"); err != nil {
@@ -1043,7 +1043,7 @@ func TestIntegration_AppendStrategy_TwoMoldsContributeToAGENTS(t *testing.T) {
 		if err != nil {
 			t.Fatalf("resolve: %v", err)
 		}
-		if err := copyResolvedFiles(reader, manifest, flux, resolved, false); err != nil {
+		if err := copyResolvedFiles(reader, manifest, flux, resolved, copyOpts{}); err != nil {
 			t.Fatalf("copy: %v", err)
 		}
 	}
@@ -1093,7 +1093,7 @@ func TestIntegration_AppendStrategy_RecastIsIdempotent(t *testing.T) {
 		manifest, _ := reader.LoadManifest()
 		flux, _ := reader.LoadFluxDefaults()
 		resolved, _ := mold.ResolveFiles(flux["output"], reader.FS())
-		if err := copyResolvedFiles(reader, manifest, flux, resolved, false); err != nil {
+		if err := copyResolvedFiles(reader, manifest, flux, resolved, copyOpts{}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -1131,7 +1131,7 @@ func TestIntegration_AppendStrategy_NonMarkdownErrors(t *testing.T) {
 	manifest, _ := reader.LoadManifest()
 	flux, _ := reader.LoadFluxDefaults()
 	resolved, _ := mold.ResolveFiles(flux["output"], reader.FS())
-	err := copyResolvedFiles(reader, manifest, flux, resolved, false)
+	err := copyResolvedFiles(reader, manifest, flux, resolved, copyOpts{})
 	if err == nil {
 		t.Fatal("expected error for append on non-markdown file, got nil")
 	}

--- a/internal/commands/cast_ore_test.go
+++ b/internal/commands/cast_ore_test.go
@@ -58,7 +58,7 @@ func TestInstallDeclaredDeps_InstallsMissingOre(t *testing.T) {
 		},
 	}
 
-	if err := installDeclaredDeps(manifest, "g/test-mold", false, true, false); err != nil {
+	if err := installDeclaredDeps(manifest, "g/test-mold", false, true, false, false, nil); err != nil {
 		t.Fatalf("installDeclaredDeps: %v", err)
 	}
 
@@ -108,10 +108,10 @@ func TestInstallDeclaredDeps_AppendsDependent(t *testing.T) {
 			{Ore: remoteOre, Version: "1.0.0"},
 		},
 	}
-	if err := installDeclaredDeps(manifest, "g/first", false, true, false); err != nil {
+	if err := installDeclaredDeps(manifest, "g/first", false, true, false, false, nil); err != nil {
 		t.Fatalf("first install: %v", err)
 	}
-	if err := installDeclaredDeps(manifest, "g/second", false, true, false); err != nil {
+	if err := installDeclaredDeps(manifest, "g/second", false, true, false, false, nil); err != nil {
 		t.Fatalf("second install: %v", err)
 	}
 
@@ -157,7 +157,7 @@ func TestInstallDeclaredDeps_AliasCollisionPreCheck(t *testing.T) {
 			{Ore: oreB, Version: "1.0.0", As: "shared"},
 		},
 	}
-	err := installDeclaredDeps(manifest, "g/m", false, true, false)
+	err := installDeclaredDeps(manifest, "g/m", false, true, false, false, nil)
 	if err == nil {
 		t.Fatal("expected alias collision error, got nil")
 	}
@@ -197,7 +197,7 @@ func TestCast_AutoInstallsOreFromMoldYAML(t *testing.T) {
 		},
 	}
 
-	if err := installDeclaredDeps(manifest, "g/m", false, true, false); err != nil {
+	if err := installDeclaredDeps(manifest, "g/m", false, true, false, false, nil); err != nil {
 		t.Fatalf("installDeclaredDeps: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(".ailloy", "ores", "status", "ore.yaml")); err != nil {
@@ -271,7 +271,7 @@ func TestInstallDeclaredDeps_DistinctSubpathsCoexist(t *testing.T) {
 		},
 	}
 
-	if err := installDeclaredDeps(manifest, "g/test-mold", false, true, false); err != nil {
+	if err := installDeclaredDeps(manifest, "g/test-mold", false, true, false, false, nil); err != nil {
 		t.Fatalf("installDeclaredDeps: %v", err)
 	}
 
@@ -313,7 +313,7 @@ func TestInstallDeclaredDeps_RejectsLocalDepFromRemoteMold(t *testing.T) {
 	}
 
 	// Simulate a remote-resolved mold by passing allowLocalDeps=false.
-	err := installDeclaredDeps(manifest, "g/remote-mold", false, false, false)
+	err := installDeclaredDeps(manifest, "g/remote-mold", false, false, false, false, nil)
 	if err == nil {
 		t.Fatal("expected error for local-path dep in remote mold")
 	}
@@ -349,7 +349,7 @@ func TestInstallDeclaredDeps_FrozenErrorsOnMissing(t *testing.T) {
 		},
 	}
 
-	err := installDeclaredDeps(manifest, "g/test-mold", false, true, true)
+	err := installDeclaredDeps(manifest, "g/test-mold", false, true, true, false, nil)
 	if err == nil {
 		t.Fatal("expected error from --frozen on missing dep, got nil")
 	}
@@ -391,12 +391,12 @@ func TestInstallDeclaredDeps_FrozenNoOpWhenAlreadyInstalled(t *testing.T) {
 	}
 
 	// First, install normally.
-	if err := installDeclaredDeps(manifest, "g/test-mold", false, true, false); err != nil {
+	if err := installDeclaredDeps(manifest, "g/test-mold", false, true, false, false, nil); err != nil {
 		t.Fatalf("seed install: %v", err)
 	}
 
 	// Now run again with --frozen — should succeed without re-fetching.
-	if err := installDeclaredDeps(manifest, "g/test-mold", false, true, true); err != nil {
+	if err := installDeclaredDeps(manifest, "g/test-mold", false, true, true, false, nil); err != nil {
 		t.Errorf("frozen with already-installed deps should be a no-op, got: %v", err)
 	}
 }

--- a/internal/commands/cast_plugin.go
+++ b/internal/commands/cast_plugin.go
@@ -23,6 +23,10 @@ type pluginPackageOpts struct {
 	WithWorkflows   bool
 	NameOverride    string
 	VersionOverride string
+	// Logger receives non-fatal warnings (flux validation, unresolved template
+	// vars). Nil falls back to log.Default(); the TUI path passes a discarding
+	// logger so concurrent casts can't corrupt the alt-screen.
+	Logger *log.Logger
 }
 
 // pluginPackageResult summarizes a packaging run for callers that want to
@@ -38,12 +42,12 @@ type pluginPackageResult struct {
 // packageMoldAsClaudePlugin so foundry install / CastMold can share it.
 //
 // `source` is the resolved mold ref used to pick up persisted flux files; it
-// is "" for local mold dirs and embedded molds.
+// is "" for local mold dirs and embedded molds. CastMold bypasses this
+// function and calls packageMoldAsClaudePlugin directly with a discarding
+// logger, so this CLI path always prints.
 func castClaudePlugin(reader *blanks.MoldReader, source string) error {
-	if !castSilent.Load() {
-		fmt.Println(styles.WorkingBanner("Casting Ailloy mold as Claude Code plugin..."))
-		fmt.Println()
-	}
+	fmt.Println(styles.WorkingBanner("Casting Ailloy mold as Claude Code plugin..."))
+	fmt.Println()
 
 	flux, _, err := loadCastFlux(reader, source)
 	if err != nil {
@@ -60,14 +64,12 @@ func castClaudePlugin(reader *blanks.MoldReader, source string) error {
 		return err
 	}
 
-	if !castSilent.Load() {
-		if withWorkflows && res.HadWorkflows {
-			fmt.Println(styles.WarningStyle.Render("⚠️  --with-workflows has no effect with --claude-plugin: workflow blanks are not bundled into Claude Code plugins."))
-		}
-		fmt.Println()
-		fmt.Println(styles.SuccessStyle.Render("✅ Plugin written to ") + styles.CodeStyle.Render(res.TargetDir))
-		fmt.Println(styles.InfoStyle.Render("💡 Claude Code will discover the plugin at this path on its next start."))
+	if withWorkflows && res.HadWorkflows {
+		fmt.Println(styles.WarningStyle.Render("⚠️  --with-workflows has no effect with --claude-plugin: workflow blanks are not bundled into Claude Code plugins."))
 	}
+	fmt.Println()
+	fmt.Println(styles.SuccessStyle.Render("✅ Plugin written to ") + styles.CodeStyle.Render(res.TargetDir))
+	fmt.Println(styles.InfoStyle.Render("💡 Claude Code will discover the plugin at this path on its next start."))
 
 	return nil
 }
@@ -78,12 +80,17 @@ func castClaudePlugin(reader *blanks.MoldReader, source string) error {
 func packageMoldAsClaudePlugin(reader *blanks.MoldReader, flux map[string]any, opts pluginPackageOpts) (pluginPackageResult, error) {
 	var res pluginPackageResult
 
+	logger := opts.Logger
+	if logger == nil {
+		logger = log.Default()
+	}
+
 	manifest, err := reader.LoadManifest()
 	if err != nil {
 		return res, fmt.Errorf("loading mold manifest: %w", err)
 	}
 
-	rendered, err := renderMoldFiles(reader, manifest, flux)
+	rendered, err := renderMoldFiles(reader, manifest, flux, logger)
 	if err != nil {
 		return res, err
 	}
@@ -123,8 +130,11 @@ func packageMoldAsClaudePlugin(reader *blanks.MoldReader, flux map[string]any, o
 // renderMoldFiles runs the cast rendering pipeline (flux validation, ingot
 // resolver, template processing) and returns the resulting files in memory.
 // Files that render to empty content are skipped, matching cast's on-disk
-// behavior (#130).
-func renderMoldFiles(reader *blanks.MoldReader, manifest *mold.Mold, flux map[string]any) ([]plugin.RenderedFile, error) {
+// behavior (#130). logger receives non-fatal warnings.
+func renderMoldFiles(reader *blanks.MoldReader, manifest *mold.Mold, flux map[string]any, logger *log.Logger) ([]plugin.RenderedFile, error) {
+	if logger == nil {
+		logger = log.Default()
+	}
 	ignorePatterns := mold.LoadIgnorePatterns(reader.FS(), manifest)
 	var resolveOpts []mold.ResolveOption
 	if len(ignorePatterns) > 0 {
@@ -143,11 +153,14 @@ func renderMoldFiles(reader *blanks.MoldReader, manifest *mold.Mold, flux map[st
 		schema = manifest.Flux
 	}
 	if verr := mold.ValidateFlux(schema, flux); verr != nil {
-		log.Printf("warning: %v", verr)
+		logger.Printf("warning: %v", verr)
 	}
 
 	resolver := buildIngotResolver(flux, reader.Root())
-	tplOpts := []mold.TemplateOption{mold.WithIngotResolver(resolver)}
+	tplOpts := []mold.TemplateOption{
+		mold.WithIngotResolver(resolver),
+		mold.WithLogger(logger),
+	}
 
 	out := make([]plugin.RenderedFile, 0, len(resolved))
 	for _, rf := range resolved {

--- a/internal/commands/ingot.go
+++ b/internal/commands/ingot.go
@@ -159,7 +159,7 @@ func runIngotAdd(_ *cobra.Command, args []string) error {
 	fmt.Println(styles.SuccessStyle.Render("Ingot added: ") + styles.AccentStyle.Render(ingot.Name+" "+ingot.Version))
 	fmt.Println(styles.InfoStyle.Render("Installed to: ") + styles.CodeStyle.Render(destDir))
 
-	if err := recordInstalled(result, false); err != nil {
+	if err := recordInstalled(result, false, nil); err != nil {
 		log.Printf("warning: failed to update installed manifest: %v", err)
 	}
 

--- a/internal/commands/install_deps.go
+++ b/internal/commands/install_deps.go
@@ -35,11 +35,19 @@ import (
 // mutation. Already-installed deps are still indexed (so dependents lists
 // stay accurate).
 //
+// `silent` suppresses the "Installing %s %s…" / "Installed:" status prints —
+// CastMold (the foundries TUI path) sets this true so concurrent casts can't
+// corrupt the Bubble Tea alt-screen. `logger` receives the non-fatal
+// "warning: writing installed manifest" notice; nil falls back to log.Default().
+//
 // Pre-collision check: ore deps with explicit aliases that resolve to the
 // same install-dir name fail BEFORE any download.
-func installDeclaredDeps(manifest *mold.Mold, moldKey string, global, allowLocalDeps, frozen bool) error {
+func installDeclaredDeps(manifest *mold.Mold, moldKey string, global, allowLocalDeps, frozen, silent bool, logger *log.Logger) error {
 	if manifest == nil || len(manifest.Dependencies) == 0 {
 		return nil
+	}
+	if logger == nil {
+		logger = log.Default()
 	}
 
 	// Pre-validate kinds and pre-collide explicit aliases.
@@ -94,7 +102,7 @@ func installDeclaredDeps(manifest *mold.Mold, moldKey string, global, allowLocal
 			return fmt.Errorf("dependency %s %q is not installed and --frozen blocks auto-install; run `ailloy %s add %s` to satisfy it", kind, ref, kind, ref)
 		}
 
-		if !castSilent.Load() {
+		if !silent {
 			fmt.Println(styles.WorkingBanner(fmt.Sprintf("Installing %s %s...", kind, ref)))
 		}
 		fsys, resolvedSource, resolvedSubpath, version, commit, err := resolveDepFS(ref, d.Version, global)
@@ -166,13 +174,13 @@ func installDeclaredDeps(manifest *mold.Mold, moldKey string, global, allowLocal
 		}
 		im.UpsertArtifact(kind, entry)
 
-		if !castSilent.Load() {
+		if !silent {
 			fmt.Println(styles.SuccessStyle.Render("  Installed: ") + styles.AccentStyle.Render(manifestName+" "+version))
 		}
 	}
 
 	if err := foundry.WriteInstalledManifest(manifestPath, im); err != nil {
-		log.Printf("warning: writing installed manifest: %v", err)
+		logger.Printf("warning: writing installed manifest: %v", err)
 	}
 
 	// Update ailloy.lock if it exists (project-scope only).
@@ -479,9 +487,7 @@ func cascadeUninstallArtifacts(manifestPath, moldKey string, global bool) error 
 		if err := os.RemoveAll(baseDir); err != nil {
 			log.Printf("warning: removing %s: %v", baseDir, err)
 		}
-		if !castSilent.Load() {
-			fmt.Println(styles.SuccessStyle.Render("  Cascade-removed: ") + styles.AccentStyle.Render(kind+" "+installName))
-		}
+		fmt.Println(styles.SuccessStyle.Render("  Cascade-removed: ") + styles.AccentStyle.Render(kind+" "+installName))
 	}
 
 	if err := foundry.WriteInstalledManifest(manifestPath, im); err != nil {

--- a/internal/commands/recast.go
+++ b/internal/commands/recast.go
@@ -152,7 +152,7 @@ func runRecast(_ *cobra.Command, args []string) error {
 				// Auto-install newly declared deps. Recast operates on the
 				// project's installed.yaml (or global per --global). Local-path
 				// deps are refused because recast walks remote references.
-				if err := installDeclaredDeps(freshMold, moldKey, recastGlobal, false, recastFrozen); err != nil {
+				if err := installDeclaredDeps(freshMold, moldKey, recastGlobal, false, recastFrozen, false, nil); err != nil {
 					log.Printf("warning: installing deps for %s: %v", entry.Name, err)
 				}
 				// Cascade-prune deps the mold no longer declares.

--- a/pkg/foundry/foundry.go
+++ b/pkg/foundry/foundry.go
@@ -71,12 +71,19 @@ type resolveConfig struct {
 	// updated) when a file already exists at this path. Resolve never creates
 	// the lock — that is the job of `ailloy quench`.
 	lockPath string
+	// logger is used for non-fatal warnings (lock-file read/write failures,
+	// "using locked version" notices). Defaults to log.Default(). Callers
+	// running inside a TUI should pass a logger writing to io.Discard.
+	logger *log.Logger
 }
 
 // applyResolveDefaults sets the default lockPath. Exposed for tests.
 func applyResolveDefaults(c *resolveConfig) {
 	if c.lockPath == "" {
 		c.lockPath = LockFileName
+	}
+	if c.logger == nil {
+		c.logger = log.Default()
 	}
 }
 
@@ -85,6 +92,15 @@ func applyResolveDefaults(c *resolveConfig) {
 func WithLockPath(path string) ResolveOption {
 	return func(c *resolveConfig) {
 		c.lockPath = path
+	}
+}
+
+// WithLogger overrides the logger used for non-fatal resolve warnings. Pass a
+// logger writing to io.Discard to silence warnings — useful when Resolve runs
+// inside a Bubble Tea TUI where stray writes corrupt the alt-screen.
+func WithLogger(logger *log.Logger) ResolveOption {
+	return func(c *resolveConfig) {
+		c.logger = logger
 	}
 }
 
@@ -167,12 +183,12 @@ func resolveWithMeta(ref *Reference, git GitRunner, opts ...ResolveOption) (fs.F
 	if useLock {
 		lock, err := ReadLockFile(cfg.lockPath)
 		if err != nil {
-			log.Printf("warning: reading lock file: %v", err)
+			cfg.logger.Printf("warning: reading lock file: %v", err)
 		}
 		if entry := lock.FindEntry(ref.CacheKey(), ref.Subpath); entry != nil && ref.Type != Branch && ref.Type != SHA {
 			if lockedSatisfies(ref, entry) {
 				resolved = &ResolvedVersion{Tag: entry.Version, Commit: entry.Commit}
-				log.Printf("using locked version %s@%s", ref.CacheKey(), entry.Version)
+				cfg.logger.Printf("using locked version %s@%s", ref.CacheKey(), entry.Version)
 			}
 		}
 	}
@@ -196,7 +212,7 @@ func resolveWithMeta(ref *Reference, git GitRunner, opts ...ResolveOption) (fs.F
 
 	if useLock {
 		if err := updateLockAt(cfg.lockPath, ref, resolved); err != nil {
-			log.Printf("warning: updating lock file: %v", err)
+			cfg.logger.Printf("warning: updating lock file: %v", err)
 		}
 	}
 

--- a/pkg/mold/template.go
+++ b/pkg/mold/template.go
@@ -44,12 +44,23 @@ type TemplateOption func(*templateConfig)
 
 type templateConfig struct {
 	ingotResolver *IngotResolver
+	logger        *log.Logger
 }
 
 // WithIngotResolver enables the {{ingot "name"}} template function.
 func WithIngotResolver(r *IngotResolver) TemplateOption {
 	return func(c *templateConfig) {
 		c.ingotResolver = r
+	}
+}
+
+// WithLogger overrides the logger used for template warnings (e.g. unresolved
+// variables). Pass a logger writing to io.Discard to silence warnings — useful
+// when ProcessTemplate runs inside a Bubble Tea TUI where stray writes corrupt
+// the alt-screen.
+func WithLogger(logger *log.Logger) TemplateOption {
+	return func(c *templateConfig) {
+		c.logger = logger
 	}
 }
 
@@ -128,7 +139,11 @@ func ProcessTemplate(content string, flux map[string]any, opts ...TemplateOption
 		return "", fmt.Errorf("template parse error: %w", err)
 	}
 
-	warnUnresolvedVars(content, data)
+	logger := cfg.logger
+	if logger == nil {
+		logger = log.Default()
+	}
+	warnUnresolvedVars(content, data, logger)
 
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, data); err != nil {
@@ -152,7 +167,7 @@ func BuildTemplateData(flux map[string]any) map[string]any {
 
 // warnUnresolvedVars scans a template for variable references
 // and logs warnings for any that cannot be resolved from the data map.
-func warnUnresolvedVars(content string, data map[string]any) {
+func warnUnresolvedVars(content string, data map[string]any, logger *log.Logger) {
 	seen := make(map[string]bool)
 
 	for _, re := range []*regexp.Regexp{directVarRefPattern, actionVarRefPattern} {
@@ -167,7 +182,7 @@ func warnUnresolvedVars(content string, data map[string]any) {
 			seen[path] = true
 
 			if !resolveDataPath(data, path) {
-				log.Printf("warning: unresolved template variable: {{.%s}}", path)
+				logger.Printf("warning: unresolved template variable: {{.%s}}", path)
 			}
 		}
 	}


### PR DESCRIPTION
## Description

In the foundries TUI, selecting multiple molds and pressing Enter dispatches each cast as a separate goroutine via `tea.Batch`. `CastMold` previously suppressed output through a process-global `atomic.Bool` plus `log.SetOutput(io.Discard)` — the first goroutine's `defer` flipped silencing back off while the others were still inside `copyResolvedFiles`, leaking per-file `✅ Created` lines and lock-file warnings into the Bubble Tea alt-screen and producing the "jumbled output" symptom.

This refactors silencing onto per-call options (no globals): a `copyOpts` struct carrying `Silent` + `Logger`, a `WithLogger` option on `pkg/mold` and `pkg/foundry`, and a `Logger` field on `pluginPackageOpts`. `CastMold` constructs one discarding `*log.Logger` per call and threads it through every code path that previously hijacked the standard logger or read the global silence flag. `recordInstalled` likewise now takes a logger.

## Related Issue

N/A — surfaced via in-session bug report.

## Testing

- New `TestCastMold_ConcurrentRunsStaySilent` builds several local molds, captures stdout, runs `CastMold` concurrently across all of them, and asserts zero bytes leak.
- `go test -race ./...` passes; `go vet` and `golangci-lint run ./...` are clean.

## UAT

1. `ailloy foundries`, switch to Discover, space-select 2+ molds, press Enter.
2. Cast status updates inside the TUI; no `✅ Created`/warning text bleeds onto the alt-screen.
3. Repeat with `ailloy.lock` present (which was the noisiest leak — `using locked version …`).

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [ ] I have updated documentation (if applicable)
- [x] My commits have DCO sign-off (`git commit -s`)