### PR TITLE
fix: backfill Files for subpath molds so uninstall works

### DIFF
--- a/internal/commands/cast.go
+++ b/internal/commands/cast.go
@@ -341,13 +341,6 @@ func castProject(reader *blanks.MoldReader, source string) error {
 	// Drop directories that ended up empty after skipped renders (#145).
 	dirs = cleanupEmptyDirs(dirs, destPrefix)
 
-	// Record the cast in the installed manifest (provenance for `recast` / `quench`).
-	if resolvedRemote != nil {
-		if err := recordInstalled(resolvedRemote, castGlobal); err != nil {
-			log.Printf("warning: failed to update installed manifest: %v", err)
-		}
-	}
-
 	// Record where blanks were installed (non-fatal if this fails).
 	if destPrefix == "" {
 		if err := writeInstallState(dirs); err != nil {
@@ -355,26 +348,24 @@ func castProject(reader *blanks.MoldReader, source string) error {
 		}
 	}
 
-	// Backfill the manifest entry's Files list so uninstall knows what to remove.
-	// The manifest is always written (regardless of --global), so this works
-	// for both project and global installs.
-	if source != "" && resolvedRemote != nil {
-		manifestPath := manifestPathFor(castGlobal)
-		if manifestPath != "" {
-			installed := make([]foundry.InstalledFile, 0, len(filesToCast))
-			for _, f := range filesToCast {
-				sum, _ := hashFile(f.DestPath)
-				rel := f.DestPath
-				if destPrefix != "" {
-					if r, rerr := filepath.Rel(destPrefix, f.DestPath); rerr == nil {
-						rel = r
-					}
+	// Record the cast in the installed manifest and backfill the Files list
+	// so uninstall knows what to remove. The manifest is always written
+	// (regardless of --global), so this works for both project and global
+	// installs.
+	if resolvedRemote != nil {
+		installed := make([]foundry.InstalledFile, 0, len(filesToCast))
+		for _, f := range filesToCast {
+			sum, _ := hashFile(f.DestPath)
+			rel := f.DestPath
+			if destPrefix != "" {
+				if r, rerr := filepath.Rel(destPrefix, f.DestPath); rerr == nil {
+					rel = r
 				}
-				installed = append(installed, foundry.InstalledFile{RelPath: rel, SHA256: sum})
 			}
-			if err := foundry.RecordInstalledFiles(manifestPath, source, resolvedRemote.Ref.Subpath, installed); err != nil {
-				log.Printf("warning: recording installed files: %v", err)
-			}
+			installed = append(installed, foundry.InstalledFile{RelPath: rel, SHA256: sum})
+		}
+		if err := recordCastedFiles(resolvedRemote, installed, castGlobal); err != nil {
+			log.Printf("warning: failed to record installed files: %v", err)
 		}
 	}
 
@@ -780,6 +771,22 @@ func recordInstalled(result *foundry.ResolveResult, global bool) error {
 		CastAt:  time.Now().UTC(),
 	})
 	return foundry.WriteInstalledManifest(path, manifest)
+}
+
+// recordCastedFiles upserts the just-cast mold into the installed manifest
+// and backfills its Files list in one place so the lookup key cannot drift
+// from the write key. The lookup must use Ref.CacheKey() (host/owner/repo) —
+// not OverrideKey, which inlines the subpath and would not match the entry
+// recordInstalled just wrote for monorepo foundries.
+func recordCastedFiles(result *foundry.ResolveResult, files []foundry.InstalledFile, global bool) error {
+	if err := recordInstalled(result, global); err != nil {
+		return err
+	}
+	path := manifestPathFor(global)
+	if path == "" {
+		return nil
+	}
+	return foundry.RecordInstalledFiles(path, result.Ref.CacheKey(), result.Ref.Subpath, files)
 }
 
 // recordInstalledArtifact upserts an installed ingot or ore into the manifest.

--- a/internal/commands/cast_core.go
+++ b/internal/commands/cast_core.go
@@ -193,29 +193,21 @@ func CastMold(_ context.Context, ref string, opts CastOptions) (CastResult, erro
 		}
 	}
 
-	if remoteResult != nil {
-		manifestPath := manifestPathFor(opts.Global)
-		if manifestPath != "" {
-			// Upsert the manifest entry with provenance, then backfill Files
-			// + FileHashes. Mirrors what cast.go does via recordInstalled +
-			// RecordInstalledFiles.
-			if err := recordInstalled(remoteResult, opts.Global); err != nil {
-				log.Printf("warning: failed to update installed manifest: %v", err)
-			} else {
-				installed := make([]foundry.InstalledFile, 0, len(filesToCast))
-				for _, f := range filesToCast {
-					sum, _ := hashFile(f.DestPath)
-					rel := f.DestPath
-					if destPrefix != "" {
-						if r, rerr := filepath.Rel(destPrefix, f.DestPath); rerr == nil {
-							rel = r
-						}
-					}
-					installed = append(installed, foundry.InstalledFile{RelPath: rel, SHA256: sum})
+	if remoteResult != nil && manifestPathFor(opts.Global) != "" {
+		installed := make([]foundry.InstalledFile, 0, len(filesToCast))
+		for _, f := range filesToCast {
+			sum, _ := hashFile(f.DestPath)
+			rel := f.DestPath
+			if destPrefix != "" {
+				if r, rerr := filepath.Rel(destPrefix, f.DestPath); rerr == nil {
+					rel = r
 				}
-				res.FilesCast = installed
-				_ = foundry.RecordInstalledFiles(manifestPath, source, remoteResult.Ref.Subpath, installed)
 			}
+			installed = append(installed, foundry.InstalledFile{RelPath: rel, SHA256: sum})
+		}
+		res.FilesCast = installed
+		if err := recordCastedFiles(remoteResult, installed, opts.Global); err != nil {
+			log.Printf("warning: failed to record installed files: %v", err)
 		}
 	}
 

--- a/internal/commands/cast_core_test.go
+++ b/internal/commands/cast_core_test.go
@@ -71,6 +71,61 @@ opencode body
 	}
 }
 
+// TestRecordCastedFiles_SubpathMold reproduces the bug where monorepo-foundry
+// molds (those with a non-empty Subpath) installed via the foundries TUI's
+// batch install end up with `Files == nil` in the installed manifest, which
+// makes the TUI label them "legacy" and `UninstallMold` refuse to remove
+// them.
+//
+// Cause: cast.go and cast_core.go each open-coded the manifest write
+// (recordInstalled, keyed by Ref.CacheKey()) and the Files backfill
+// (RecordInstalledFiles, called with Ref.OverrideKey() as the lookup source).
+// For subpath molds CacheKey != OverrideKey, FindBySource returned nil, and
+// the error was silently swallowed (cast_core.go) or only logged into a
+// discard sink (CastMold runs with log output redirected). Net effect:
+// entry.Files stays nil.
+//
+// recordCastedFiles centralizes both writes so the source key cannot drift
+// between them. This test pins the contract.
+func TestRecordCastedFiles_SubpathMold(t *testing.T) {
+	projectDir := t.TempDir()
+	t.Chdir(projectDir)
+	t.Setenv("HOME", t.TempDir())
+
+	result := &foundry.ResolveResult{
+		Ref: &foundry.Reference{
+			Host:    "github.com",
+			Owner:   "replicated-collab",
+			Repo:    "foundry",
+			Subpath: "molds/shortcut",
+			Version: "v0.1.0",
+		},
+		Resolved: foundry.ResolvedVersion{Tag: "v0.1.0", Commit: "abc1234"},
+	}
+	files := []foundry.InstalledFile{
+		{RelPath: ".claude/agents/shortcut.md", SHA256: "deadbeef"},
+	}
+
+	if err := recordCastedFiles(result, files, false); err != nil {
+		t.Fatalf("recordCastedFiles: %v", err)
+	}
+
+	m, err := foundry.ReadInstalledManifest(manifestPathFor(false))
+	if err != nil {
+		t.Fatalf("ReadInstalledManifest: %v", err)
+	}
+	entry := m.FindBySource(result.Ref.CacheKey(), result.Ref.Subpath)
+	if entry == nil {
+		t.Fatalf("entry not found in manifest at (CacheKey=%q, Subpath=%q)", result.Ref.CacheKey(), result.Ref.Subpath)
+	}
+	if entry.Files == nil {
+		t.Fatalf("entry.Files is nil — Files backfill silently dropped (legacy bug); manifest=%+v", entry)
+	}
+	if len(entry.Files) != 1 || entry.Files[0] != ".claude/agents/shortcut.md" {
+		t.Fatalf("unexpected Files: %+v", entry.Files)
+	}
+}
+
 // TestLayerFluxForCore_AutoLoadsPersistedFluxFiles asserts that
 // ./.ailloy/flux/<slug>.yaml and ~/.ailloy/flux/<slug>.yaml are layered into
 // the cast pipeline between mold defaults and explicit -f files. This is the


### PR DESCRIPTION
## Description

When a remote mold was cast, the manifest entry was written keyed by `Ref.CacheKey()` (`host/owner/repo`) but the `Files` backfill looked it up via `Ref.OverrideKey()` (which inlines the subpath). For monorepo foundries (e.g. `replicated-collab/foundry`) the two keys differ, `FindBySource` returned nil, the error was silently dropped (cast_core.go used `_ =`; cast.go's logged warning is suppressed because `CastMold` redirects log output), and `entry.Files` stayed nil. The TUI then labels the entry "legacy" and `UninstallMold` returns `ErrLegacyEntry`.

Extracted the manifest-write + Files-backfill into a single `recordCastedFiles` helper so the source key cannot drift between the two writes. Both `cast.go` and `cast_core.go` now call it.

## Related Issue

N/A — bug surfaced installing from `replicated-collab/foundry`.

## Testing

- New `TestRecordCastedFiles_SubpathMold` regression test pins the contract; verified it catches the bug by temporarily reverting the helper to use `OverrideKey` (fails with `no installed manifest entry for source ...`).
- `go test ./...`, `go vet ./...`, `golangci-lint run ./internal/commands/...` all clean.

## UAT

1. Install a monorepo foundry: `ailloy foundry install replicated-collab/foundry --force`.
2. Open `ailloy foundries`, switch to the Installed tab — molds should no longer show the `⚠ legacy` badge.
3. Uninstall a mold from the TUI — files should be removed and the entry should disappear from `.ailloy/installed.yaml`.
4. Existing already-installed molds with `Files == nil` need a one-time `--force` re-cast to repair their manifest entries.

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [ ] I have updated documentation (if applicable)
- [x] My commits have DCO sign-off (`git commit -s`)