### PR TITLE
feat: foundry-wide flux customization (cast rename + --set/-f flags + TUI picker)

### DIFF
--- a/internal/commands/cast_ore_test.go
+++ b/internal/commands/cast_ore_test.go
@@ -205,7 +205,7 @@ func TestCast_AutoInstallsOreFromMoldYAML(t *testing.T) {
 	}
 
 	moldFS := os.DirFS(".")
-	paths := buildOreSearchPaths(moldFS, false)
+	paths := mold.BuildDefaultOreSearchPaths(moldFS, false)
 
 	schema, defaults, _, err := mold.LoadMoldFluxWithOres(moldFS, paths)
 	if err != nil {

--- a/internal/commands/foundries.go
+++ b/internal/commands/foundries.go
@@ -67,12 +67,21 @@ func runFoundries(_ *cobra.Command, _ []string) error {
 			}
 			return out, err
 		},
-		InstallFoundry: func(ctx context.Context, cfg *index.Config, nameOrURL string, opts foundries.InstallFoundryOptions) ([]foundries.InstallFoundryReport, error) {
+		InstallFoundry: func(
+			ctx context.Context,
+			cfg *index.Config,
+			nameOrURL string,
+			opts foundries.InstallFoundryOptions,
+			perMoldOverrides map[string][]string,
+		) ([]foundries.InstallFoundryReport, error) {
 			rs, _, err := InstallFoundryCore(ctx, cfg, nameOrURL, InstallFoundryOptions{
-				Global:        opts.Global,
-				WithWorkflows: opts.WithWorkflows,
-				DryRun:        opts.DryRun,
-				Force:         opts.Force,
+				Global:           opts.Global,
+				WithWorkflows:    opts.WithWorkflows,
+				DryRun:           opts.DryRun,
+				Force:            opts.Force,
+				ValueFiles:       opts.ValueFiles,
+				SetOverrides:     opts.SetOverrides,
+				PerMoldOverrides: perMoldOverrides,
 			})
 			out := make([]foundries.InstallFoundryReport, 0, len(rs))
 			for _, r := range rs {

--- a/internal/commands/foundry.go
+++ b/internal/commands/foundry.go
@@ -86,6 +86,8 @@ var (
 	foundryCastForce         bool
 	foundryCastClaudePlugin  bool
 	foundryCastShallow       bool
+	foundryCastValueFiles    []string
+	foundryCastSetOverrides  []string
 )
 
 var foundryCastCmd = &cobra.Command{
@@ -120,6 +122,10 @@ func init() {
 	foundryCastCmd.Flags().BoolVar(&foundryCastForce, "force", false, "re-cast molds that are already installed")
 	foundryCastCmd.Flags().BoolVar(&foundryCastClaudePlugin, "claude-plugin", false, "package each mold as a Claude Code plugin under .claude/plugins/<slug>/")
 	foundryCastCmd.Flags().BoolVar(&foundryCastShallow, "shallow", false, "install only the named foundry's direct molds (skip nested foundries)")
+	foundryCastCmd.Flags().StringArrayVar(&foundryCastSetOverrides, "set", nil,
+		"override flux variable for every mold (format: key=value, can be repeated)")
+	foundryCastCmd.Flags().StringArrayVarP(&foundryCastValueFiles, "values", "f", nil,
+		"flux value files applied to every mold (can be repeated, later files override earlier)")
 }
 
 func runFoundrySearch(_ *cobra.Command, args []string) error {
@@ -412,6 +418,8 @@ func runFoundryCast(_ *cobra.Command, args []string) error {
 		Force:         foundryCastForce,
 		ClaudePlugin:  foundryCastClaudePlugin,
 		Shallow:       foundryCastShallow,
+		ValueFiles:    foundryCastValueFiles,
+		SetOverrides:  foundryCastSetOverrides,
 	})
 	if err != nil {
 		return err

--- a/internal/commands/foundry.go
+++ b/internal/commands/foundry.go
@@ -80,17 +80,17 @@ var foundryUpdateCmd = &cobra.Command{
 }
 
 var (
-	foundryInstallGlobal        bool
-	foundryInstallWithWorkflows bool
-	foundryInstallDryRun        bool
-	foundryInstallForce         bool
-	foundryInstallClaudePlugin  bool
-	foundryInstallShallow       bool
+	foundryCastGlobal        bool
+	foundryCastWithWorkflows bool
+	foundryCastDryRun        bool
+	foundryCastForce         bool
+	foundryCastClaudePlugin  bool
+	foundryCastShallow       bool
 )
 
-var foundryInstallCmd = &cobra.Command{
-	Use:     "install <name|url>",
-	Aliases: []string{"cast-all"},
+var foundryCastCmd = &cobra.Command{
+	Use:     "cast <name|url>",
+	Aliases: []string{"install"},
 	Short:   "Cast every mold listed by a foundry",
 	Long: `Cast every mold listed by the named foundry.
 
@@ -98,7 +98,7 @@ The foundry is looked up by name or URL across the effective foundries
 (verified default + registered). Molds already present in the target
 lockfile are skipped unless --force is given.`,
 	Args: cobra.ExactArgs(1),
-	RunE: runFoundryInstall,
+	RunE: runFoundryCast,
 }
 
 func init() {
@@ -109,17 +109,17 @@ func init() {
 	foundryCmd.AddCommand(foundryListCmd)
 	foundryCmd.AddCommand(foundryRemoveCmd)
 	foundryCmd.AddCommand(foundryUpdateCmd)
-	foundryCmd.AddCommand(foundryInstallCmd)
+	foundryCmd.AddCommand(foundryCastCmd)
 
 	foundrySearchCmd.Flags().BoolVar(&searchIndexOnly, "index-only", false, "only search registered foundry indexes")
 	foundrySearchCmd.Flags().BoolVar(&searchGitHubOnly, "github-only", false, "only search GitHub Topics")
 
-	foundryInstallCmd.Flags().BoolVarP(&foundryInstallGlobal, "global", "g", false, "install each mold under ~/ instead of the current project")
-	foundryInstallCmd.Flags().BoolVar(&foundryInstallWithWorkflows, "with-workflows", false, "include GitHub Actions workflow blanks")
-	foundryInstallCmd.Flags().BoolVar(&foundryInstallDryRun, "dry-run", false, "list what would be installed without casting")
-	foundryInstallCmd.Flags().BoolVar(&foundryInstallForce, "force", false, "re-cast molds that are already installed")
-	foundryInstallCmd.Flags().BoolVar(&foundryInstallClaudePlugin, "claude-plugin", false, "package each mold as a Claude Code plugin under .claude/plugins/<slug>/")
-	foundryInstallCmd.Flags().BoolVar(&foundryInstallShallow, "shallow", false, "install only the named foundry's direct molds (skip nested foundries)")
+	foundryCastCmd.Flags().BoolVarP(&foundryCastGlobal, "global", "g", false, "install each mold under ~/ instead of the current project")
+	foundryCastCmd.Flags().BoolVar(&foundryCastWithWorkflows, "with-workflows", false, "include GitHub Actions workflow blanks")
+	foundryCastCmd.Flags().BoolVar(&foundryCastDryRun, "dry-run", false, "list what would be installed without casting")
+	foundryCastCmd.Flags().BoolVar(&foundryCastForce, "force", false, "re-cast molds that are already installed")
+	foundryCastCmd.Flags().BoolVar(&foundryCastClaudePlugin, "claude-plugin", false, "package each mold as a Claude Code plugin under .claude/plugins/<slug>/")
+	foundryCastCmd.Flags().BoolVar(&foundryCastShallow, "shallow", false, "install only the named foundry's direct molds (skip nested foundries)")
 }
 
 func runFoundrySearch(_ *cobra.Command, args []string) error {
@@ -394,7 +394,7 @@ func nameFromFoundryURL(url string) string {
 	return "foundry"
 }
 
-func runFoundryInstall(_ *cobra.Command, args []string) error {
+func runFoundryCast(_ *cobra.Command, args []string) error {
 	nameOrURL := args[0]
 
 	cfg, err := index.LoadConfig()
@@ -406,12 +406,12 @@ func runFoundryInstall(_ *cobra.Command, args []string) error {
 	fmt.Println()
 
 	reports, warnings, err := InstallFoundryCore(context.Background(), cfg, nameOrURL, InstallFoundryOptions{
-		Global:        foundryInstallGlobal,
-		WithWorkflows: foundryInstallWithWorkflows,
-		DryRun:        foundryInstallDryRun,
-		Force:         foundryInstallForce,
-		ClaudePlugin:  foundryInstallClaudePlugin,
-		Shallow:       foundryInstallShallow,
+		Global:        foundryCastGlobal,
+		WithWorkflows: foundryCastWithWorkflows,
+		DryRun:        foundryCastDryRun,
+		Force:         foundryCastForce,
+		ClaudePlugin:  foundryCastClaudePlugin,
+		Shallow:       foundryCastShallow,
 	})
 	if err != nil {
 		return err
@@ -451,7 +451,7 @@ func runFoundryInstall(_ *cobra.Command, args []string) error {
 				extra = " " + styles.SubtleStyle.Render(r.Version)
 			}
 			fmt.Println(" " + styles.InfoStyle.Render("skipped (already installed)") + extra)
-		case foundryInstallDryRun:
+		case foundryCastDryRun:
 			fmt.Println(" " + styles.InfoStyle.Render("would install"))
 		default:
 			installed++
@@ -459,7 +459,7 @@ func runFoundryInstall(_ *cobra.Command, args []string) error {
 		}
 	}
 
-	if len(reports) == 0 && foundryInstallShallow {
+	if len(reports) == 0 && foundryCastShallow {
 		fmt.Println(styles.InfoStyle.Render("Nothing to install — this foundry only aggregates nested foundries."))
 		fmt.Println(styles.SubtleStyle.Render("Drop --shallow to install transitively."))
 		return nil
@@ -467,7 +467,7 @@ func runFoundryInstall(_ *cobra.Command, args []string) error {
 
 	fmt.Println()
 	summary := fmt.Sprintf("installed %d · skipped %d · failed %d", installed, skipped, failed)
-	if foundryInstallDryRun {
+	if foundryCastDryRun {
 		summary = fmt.Sprintf("would install %d · skipped %d · failed %d", len(reports)-skipped-failed, skipped, failed)
 	}
 	fmt.Println(styles.SuccessStyle.Render(summary))

--- a/internal/commands/foundry.go
+++ b/internal/commands/foundry.go
@@ -480,10 +480,29 @@ func runFoundryCast(_ *cobra.Command, args []string) error {
 	}
 	fmt.Println(styles.SuccessStyle.Render(summary))
 
+	// Per-key apply/skip summary for --set overrides.
+	keys := setOverrideKeys(foundryCastSetOverrides)
+	if fluxSummary := formatFoundryFluxSummary(reports, keys); fluxSummary != "" {
+		fmt.Println()
+		fmt.Print(fluxSummary)
+	}
+
 	if failed > 0 {
 		return fmt.Errorf("%d mold(s) failed to install", failed)
 	}
 	return nil
+}
+
+// setOverrideKeys returns the key portion of each "key=value" --set entry,
+// preserving order, so the foundry summary can iterate keys deterministically.
+func setOverrideKeys(setOverrides []string) []string {
+	keys := make([]string, 0, len(setOverrides))
+	for _, kv := range setOverrides {
+		if eq := strings.IndexByte(kv, '='); eq != -1 {
+			keys = append(keys, kv[:eq])
+		}
+	}
+	return keys
 }
 
 // renderResolutionWarnings prints non-fatal foundry resolution warnings —

--- a/internal/commands/foundry_core.go
+++ b/internal/commands/foundry_core.go
@@ -236,6 +236,10 @@ type InstallFoundryOptions struct {
 	// SetOverrides applies the same --set layering used by `cast` to every
 	// mold. Same precedence as on `cast`: highest layer.
 	SetOverrides []string
+	// PerMoldOverrides is keyed by mold name → already-encoded --set strings.
+	// These are appended after SetOverrides for that specific mold so
+	// per-mold values take precedence over foundry-wide values.
+	PerMoldOverrides map[string][]string
 }
 
 // InstallFoundryReport is the per-mold result of an InstallFoundryCore run.
@@ -348,12 +352,16 @@ func InstallFoundryCore(ctx context.Context, cfg *index.Config, nameOrURL string
 			continue
 		}
 
+		moldSet := opts.SetOverrides
+		if extra := opts.PerMoldOverrides[m.Entry.Name]; len(extra) > 0 {
+			moldSet = append(append([]string(nil), opts.SetOverrides...), extra...)
+		}
 		castRes, cerr := CastMold(ctx, m.Entry.Source, CastOptions{
 			Global:        opts.Global,
 			WithWorkflows: opts.WithWorkflows,
 			ClaudePlugin:  opts.ClaudePlugin,
 			ValueFiles:    opts.ValueFiles,
-			SetOverrides:  opts.SetOverrides,
+			SetOverrides:  moldSet,
 		})
 		if cerr != nil {
 			report.Err = cerr

--- a/internal/commands/foundry_core.go
+++ b/internal/commands/foundry_core.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,8 +17,12 @@ import (
 
 // splitFluxKeysForMold partitions user-supplied --set keys into those declared
 // by the mold's flux schema and those that aren't. Returns nil/nil when there
-// are no overrides. The mold's schema is loaded from flux.schema.yaml at source.
-func splitFluxKeysForMold(source string, setOverrides []string) (applied, skipped []string) {
+// are no overrides. The mold's schema is loaded from flux.schema.yaml at
+// source, and (for local-path sources) merged with any inline `flux:` block
+// declared in mold.yaml. Remote refs only see the flux.schema.yaml entries —
+// merging both for remote sources would require pkg/mold changes and is filed
+// as a follow-up.
+func splitFluxKeysForMold(ctx context.Context, source string, setOverrides []string) (applied, skipped []string) {
 	if len(setOverrides) == 0 {
 		return nil, nil
 	}
@@ -27,16 +32,28 @@ func splitFluxKeysForMold(source string, setOverrides []string) (applied, skippe
 			keys = append(keys, kv[:eq])
 		}
 	}
-	// Schema fetch tolerates local dirs and remote refs.
-	schema, _, err := mold.FetchSchemaFromSource(context.Background(), source)
-	if err != nil || len(schema) == 0 {
-		// If we can't read the schema, treat every key as skipped — better
-		// to report visibility than to assert things we can't verify.
-		return nil, append([]string(nil), keys...)
+	// Schema fetch tolerates local dirs and remote refs. A real fetch error
+	// is distinct from "no schema declared" — log the former so operators
+	// can diagnose, but fall through with an empty schema so any inline
+	// mold.yaml flux still gets a chance to declare keys.
+	schema, _, err := mold.FetchSchemaFromSource(ctx, source)
+	if err != nil {
+		log.Printf("warning: fetch flux schema for %s: %v", source, err)
+		schema = nil
 	}
 	declared := map[string]struct{}{}
 	for _, v := range schema {
 		declared[v.Name] = struct{}{}
+	}
+	// Inline flux declarations in mold.yaml — only readable for local-path
+	// sources. Remote refs go through FetchSchemaFromSource which would need
+	// pkg/mold changes to merge inline schema at fetch time.
+	if info, serr := os.Stat(source); serr == nil && info.IsDir() {
+		if m, lerr := mold.LoadMold(filepath.Join(source, "mold.yaml")); lerr == nil && m != nil {
+			for _, v := range m.Flux {
+				declared[v.Name] = struct{}{}
+			}
+		}
 	}
 	for _, k := range keys {
 		if _, ok := declared[k]; ok {
@@ -290,7 +307,7 @@ func InstallFoundryCore(ctx context.Context, cfg *index.Config, nameOrURL string
 			Foundry: m.Foundry.Index.Name,
 			Chain:   chain,
 		}
-		report.FluxApplied, report.FluxSkipped = splitFluxKeysForMold(m.Entry.Source, opts.SetOverrides)
+		report.FluxApplied, report.FluxSkipped = splitFluxKeysForMold(ctx, m.Entry.Source, opts.SetOverrides)
 
 		if v, already := installed[strings.ToLower(m.Entry.Source)]; already && !opts.Force {
 			report.Skipped = true

--- a/internal/commands/foundry_core.go
+++ b/internal/commands/foundry_core.go
@@ -149,6 +149,13 @@ type InstallFoundryOptions struct {
 	Force         bool // re-cast even if already installed in the target lockfile
 	ClaudePlugin  bool // package each mold as a Claude Code plugin
 	Shallow       bool // install only the root foundry's molds; skip nested foundries
+	// ValueFiles applies the same -f/--values layering used by `cast` to
+	// every mold installed by this run. Files are loaded left-to-right;
+	// later files override earlier.
+	ValueFiles []string
+	// SetOverrides applies the same --set layering used by `cast` to every
+	// mold. Same precedence as on `cast`: highest layer.
+	SetOverrides []string
 }
 
 // InstallFoundryReport is the per-mold result of an InstallFoundryCore run.
@@ -260,6 +267,8 @@ func InstallFoundryCore(ctx context.Context, cfg *index.Config, nameOrURL string
 			Global:        opts.Global,
 			WithWorkflows: opts.WithWorkflows,
 			ClaudePlugin:  opts.ClaudePlugin,
+			ValueFiles:    opts.ValueFiles,
+			SetOverrides:  opts.SetOverrides,
 		})
 		if cerr != nil {
 			report.Err = cerr

--- a/internal/commands/foundry_core.go
+++ b/internal/commands/foundry_core.go
@@ -65,6 +65,42 @@ func splitFluxKeysForMold(ctx context.Context, source string, setOverrides []str
 	return applied, skipped
 }
 
+// formatFoundryFluxSummary renders a per-key apply/skip report based on the
+// per-mold results returned by InstallFoundryCore. Empty when keys is empty.
+func formatFoundryFluxSummary(reports []InstallFoundryReport, keys []string) string {
+	if len(keys) == 0 || len(reports) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("Applied flux overrides:\n")
+	for _, k := range keys {
+		var skipped []string
+		applied := 0
+		for _, r := range reports {
+			if containsString(r.FluxSkipped, k) {
+				skipped = append(skipped, r.Name)
+				continue
+			}
+			applied++
+		}
+		fmt.Fprintf(&b, "  %s → %d/%d molds", k, applied, len(reports))
+		if len(skipped) > 0 {
+			fmt.Fprintf(&b, " (skipped: %s — key not in schema)", strings.Join(skipped, ", "))
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func containsString(ss []string, s string) bool {
+	for _, x := range ss {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}
+
 // AddFoundryResult reports the outcome of an add operation.
 type AddFoundryResult struct {
 	Entry         index.FoundryEntry

--- a/internal/commands/foundry_core.go
+++ b/internal/commands/foundry_core.go
@@ -11,7 +11,42 @@ import (
 
 	"github.com/nimble-giant/ailloy/pkg/foundry"
 	"github.com/nimble-giant/ailloy/pkg/foundry/index"
+	"github.com/nimble-giant/ailloy/pkg/mold"
 )
+
+// splitFluxKeysForMold partitions user-supplied --set keys into those declared
+// by the mold's flux schema and those that aren't. Returns nil/nil when there
+// are no overrides. The mold's schema is loaded from flux.schema.yaml at source.
+func splitFluxKeysForMold(source string, setOverrides []string) (applied, skipped []string) {
+	if len(setOverrides) == 0 {
+		return nil, nil
+	}
+	keys := make([]string, 0, len(setOverrides))
+	for _, kv := range setOverrides {
+		if eq := strings.IndexByte(kv, '='); eq != -1 {
+			keys = append(keys, kv[:eq])
+		}
+	}
+	// Schema fetch tolerates local dirs and remote refs.
+	schema, _, err := mold.FetchSchemaFromSource(context.Background(), source)
+	if err != nil || len(schema) == 0 {
+		// If we can't read the schema, treat every key as skipped — better
+		// to report visibility than to assert things we can't verify.
+		return nil, append([]string(nil), keys...)
+	}
+	declared := map[string]struct{}{}
+	for _, v := range schema {
+		declared[v.Name] = struct{}{}
+	}
+	for _, k := range keys {
+		if _, ok := declared[k]; ok {
+			applied = append(applied, k)
+		} else {
+			skipped = append(skipped, k)
+		}
+	}
+	return applied, skipped
+}
 
 // AddFoundryResult reports the outcome of an add operation.
 type AddFoundryResult struct {
@@ -167,6 +202,10 @@ type InstallFoundryReport struct {
 	Skipped bool     // true when already installed and !Force
 	Err     error    // non-nil if cast failed for this mold
 	Version string   // populated on success or skip (from CastResult / lockfile)
+	// FluxApplied lists user-supplied --set keys that are declared in this
+	// mold's flux schema. FluxSkipped lists keys that are not.
+	FluxApplied []string
+	FluxSkipped []string
 }
 
 // ErrFoundryNotFound is returned when nameOrURL doesn't match any effective
@@ -251,6 +290,7 @@ func InstallFoundryCore(ctx context.Context, cfg *index.Config, nameOrURL string
 			Foundry: m.Foundry.Index.Name,
 			Chain:   chain,
 		}
+		report.FluxApplied, report.FluxSkipped = splitFluxKeysForMold(m.Entry.Source, opts.SetOverrides)
 
 		if v, already := installed[strings.ToLower(m.Entry.Source)]; already && !opts.Force {
 			report.Skipped = true

--- a/internal/commands/foundry_core.go
+++ b/internal/commands/foundry_core.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -77,7 +78,7 @@ func formatFoundryFluxSummary(reports []InstallFoundryReport, keys []string) str
 		var skipped []string
 		applied := 0
 		for _, r := range reports {
-			if containsString(r.FluxSkipped, k) {
+			if slices.Contains(r.FluxSkipped, k) {
 				skipped = append(skipped, r.Name)
 				continue
 			}
@@ -90,15 +91,6 @@ func formatFoundryFluxSummary(reports []InstallFoundryReport, keys []string) str
 		b.WriteString("\n")
 	}
 	return b.String()
-}
-
-func containsString(ss []string, s string) bool {
-	for _, x := range ss {
-		if x == s {
-			return true
-		}
-	}
-	return false
 }
 
 // AddFoundryResult reports the outcome of an add operation.

--- a/internal/commands/foundry_core.go
+++ b/internal/commands/foundry_core.go
@@ -43,7 +43,7 @@ func splitFluxKeysForMold(ctx context.Context, source string, setOverrides []str
 	if info, err := os.Stat(source); err == nil && info.IsDir() {
 		// Local dir: use ore-aware loader so ore.<ns>.* keys are recognized.
 		moldFS := os.DirFS(source)
-		mergedSchema, _, _, lerr := mold.LoadMoldFluxWithOres(moldFS, buildOreSearchPaths(moldFS, false))
+		mergedSchema, _, _, lerr := mold.LoadMoldFluxWithOres(moldFS, mold.BuildDefaultOreSearchPaths(moldFS, false))
 		if lerr != nil {
 			log.Printf("warning: load merged flux schema for %s: %v", source, lerr)
 		}

--- a/internal/commands/foundry_core.go
+++ b/internal/commands/foundry_core.go
@@ -18,11 +18,16 @@ import (
 
 // splitFluxKeysForMold partitions user-supplied --set keys into those declared
 // by the mold's flux schema and those that aren't. Returns nil/nil when there
-// are no overrides. The mold's schema is loaded from flux.schema.yaml at
-// source, and (for local-path sources) merged with any inline `flux:` block
-// declared in mold.yaml. Remote refs only see the flux.schema.yaml entries —
-// merging both for remote sources would require pkg/mold changes and is filed
-// as a follow-up.
+// are no overrides.
+//
+// For local-path sources, declared keys come from:
+//   - flux.schema.yaml (via LoadMoldFluxWithOres),
+//   - inline `flux:` block in mold.yaml,
+//   - ore overlays under <mold>/ores/, .ailloy/ores/, ~/.ailloy/ores/
+//     (prefixed as ore.<namespace>.*).
+//
+// For remote refs, only flux.schema.yaml is read — ore-awareness for remote
+// sources would require pkg/mold changes and is filed as a follow-up.
 func splitFluxKeysForMold(ctx context.Context, source string, setOverrides []string) (applied, skipped []string) {
 	if len(setOverrides) == 0 {
 		return nil, nil
@@ -33,29 +38,37 @@ func splitFluxKeysForMold(ctx context.Context, source string, setOverrides []str
 			keys = append(keys, kv[:eq])
 		}
 	}
-	// Schema fetch tolerates local dirs and remote refs. A real fetch error
-	// is distinct from "no schema declared" — log the former so operators
-	// can diagnose, but fall through with an empty schema so any inline
-	// mold.yaml flux still gets a chance to declare keys.
-	schema, _, err := mold.FetchSchemaFromSource(ctx, source)
-	if err != nil {
-		log.Printf("warning: fetch flux schema for %s: %v", source, err)
-		schema = nil
-	}
 	declared := map[string]struct{}{}
-	for _, v := range schema {
-		declared[v.Name] = struct{}{}
-	}
-	// Inline flux declarations in mold.yaml — only readable for local-path
-	// sources. Remote refs go through FetchSchemaFromSource which would need
-	// pkg/mold changes to merge inline schema at fetch time.
-	if info, serr := os.Stat(source); serr == nil && info.IsDir() {
-		if m, lerr := mold.LoadMold(filepath.Join(source, "mold.yaml")); lerr == nil && m != nil {
+
+	if info, err := os.Stat(source); err == nil && info.IsDir() {
+		// Local dir: use ore-aware loader so ore.<ns>.* keys are recognized.
+		moldFS := os.DirFS(source)
+		mergedSchema, _, _, lerr := mold.LoadMoldFluxWithOres(moldFS, buildOreSearchPaths(moldFS, false))
+		if lerr != nil {
+			log.Printf("warning: load merged flux schema for %s: %v", source, lerr)
+		}
+		for _, v := range mergedSchema {
+			declared[v.Name] = struct{}{}
+		}
+		// LoadMoldFluxWithOres does not pick up inline mold.yaml flux; merge
+		// it explicitly so molds that declare schema inline still report
+		// their keys as applied.
+		if m, mlerr := mold.LoadMold(filepath.Join(source, "mold.yaml")); mlerr == nil && m != nil {
 			for _, v := range m.Flux {
 				declared[v.Name] = struct{}{}
 			}
 		}
+	} else {
+		// Remote ref or unreadable path: fall back to plain schema fetch.
+		schema, _, ferr := mold.FetchSchemaFromSource(ctx, source)
+		if ferr != nil {
+			log.Printf("warning: fetch flux schema for %s: %v", source, ferr)
+		}
+		for _, v := range schema {
+			declared[v.Name] = struct{}{}
+		}
 	}
+
 	for _, k := range keys {
 		if _, ok := declared[k]; ok {
 			applied = append(applied, k)

--- a/internal/commands/foundry_core_test.go
+++ b/internal/commands/foundry_core_test.go
@@ -121,6 +121,93 @@ molds:
 	}
 }
 
+// TestInstallFoundryCoreFluxApplyResults verifies that for each mold we
+// record which user-supplied flux keys are present in that mold's schema
+// (Applied) vs. absent (Skipped). DryRun keeps us out of CastMold but the
+// schema lookup still runs.
+func TestInstallFoundryCoreFluxApplyResults(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("AILLOY_INDEX_CACHE_DIR", tmp)
+
+	// Build a real local mold for "alpha" with an agents.targets schema, and a
+	// second mold "beta" without it. Source paths in the foundry index point
+	// at on-disk paths so FetchSchemaFromSource can find them — DryRun skips
+	// the actual cast.
+	moldDir := func(name string, schemaYAML string) string {
+		d := filepath.Join(tmp, name)
+		if err := os.MkdirAll(d, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		manifest := []byte("apiVersion: v1\nkind: mold\nname: " + name + "\nversion: 0.0.1\n")
+		if err := os.WriteFile(filepath.Join(d, "mold.yaml"), manifest, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if schemaYAML != "" {
+			if err := os.WriteFile(filepath.Join(d, "flux.schema.yaml"), []byte(schemaYAML), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return d
+	}
+	alphaPath := moldDir("alpha", `- name: agents.targets
+  type: list
+  default: "[claude]"
+`)
+	betaPath := moldDir("beta", "")
+
+	parentURL := "https://github.com/example/parent"
+	entry := &index.FoundryEntry{URL: parentURL, Type: "git"}
+	dir := index.CachedIndexDir(tmp, entry)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	yaml := []byte(`apiVersion: v1
+kind: foundry-index
+name: parent
+molds:
+  - name: alpha
+    source: ` + alphaPath + `
+  - name: beta
+    source: ` + betaPath + `
+`)
+	if err := os.WriteFile(filepath.Join(dir, "foundry.yaml"), yaml, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &index.Config{
+		Foundries: []index.FoundryEntry{{Name: "parent", URL: parentURL, Type: "git", Status: "ok"}},
+	}
+
+	reports, _, err := InstallFoundryCore(context.Background(), cfg, "parent", InstallFoundryOptions{
+		DryRun:       true,
+		Shallow:      true,
+		SetOverrides: []string{"agents.targets=[claude,opencode]"},
+	})
+	if err != nil {
+		t.Fatalf("InstallFoundryCore: %v", err)
+	}
+	if len(reports) != 2 {
+		t.Fatalf("got %d reports, want 2", len(reports))
+	}
+
+	byName := map[string]InstallFoundryReport{}
+	for _, r := range reports {
+		byName[r.Name] = r
+	}
+
+	if got := byName["alpha"].FluxApplied; !reflect.DeepEqual(got, []string{"agents.targets"}) {
+		t.Errorf("alpha.FluxApplied = %v, want [agents.targets]", got)
+	}
+	if got := byName["alpha"].FluxSkipped; len(got) != 0 {
+		t.Errorf("alpha.FluxSkipped = %v, want empty", got)
+	}
+	if got := byName["beta"].FluxApplied; len(got) != 0 {
+		t.Errorf("beta.FluxApplied = %v, want empty", got)
+	}
+	if got := byName["beta"].FluxSkipped; !reflect.DeepEqual(got, []string{"agents.targets"}) {
+		t.Errorf("beta.FluxSkipped = %v, want [agents.targets]", got)
+	}
+}
+
 func TestFoundryCastCommandShape(t *testing.T) {
 	if foundryCastCmd.Use == "" || !strings.HasPrefix(foundryCastCmd.Use, "cast") {
 		t.Fatalf("foundryCastCmd.Use = %q, want it to start with %q", foundryCastCmd.Use, "cast")

--- a/internal/commands/foundry_core_test.go
+++ b/internal/commands/foundry_core_test.go
@@ -129,17 +129,18 @@ func TestInstallFoundryCoreFluxApplyResults(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("AILLOY_INDEX_CACHE_DIR", tmp)
 
-	// Build a real local mold for "alpha" with an agents.targets schema, and a
-	// second mold "beta" without it. Source paths in the foundry index point
-	// at on-disk paths so FetchSchemaFromSource can find them — DryRun skips
-	// the actual cast.
-	moldDir := func(name string, schemaYAML string) string {
+	// Build local molds whose source paths the foundry index points at, so
+	// FetchSchemaFromSource (and the inline mold.yaml read) can find them —
+	// DryRun skips the actual cast.
+	//   - alpha:  declares agents.targets via flux.schema.yaml
+	//   - beta:   declares no flux
+	//   - gamma:  declares agents.targets inline in mold.yaml (no schema file)
+	moldDir := func(name string, manifestYAML string, schemaYAML string) string {
 		d := filepath.Join(tmp, name)
 		if err := os.MkdirAll(d, 0o750); err != nil {
 			t.Fatal(err)
 		}
-		manifest := []byte("apiVersion: v1\nkind: mold\nname: " + name + "\nversion: 0.0.1\n")
-		if err := os.WriteFile(filepath.Join(d, "mold.yaml"), manifest, 0o644); err != nil {
+		if err := os.WriteFile(filepath.Join(d, "mold.yaml"), []byte(manifestYAML), 0o644); err != nil {
 			t.Fatal(err)
 		}
 		if schemaYAML != "" {
@@ -149,11 +150,23 @@ func TestInstallFoundryCoreFluxApplyResults(t *testing.T) {
 		}
 		return d
 	}
-	alphaPath := moldDir("alpha", `- name: agents.targets
+	plainManifest := func(name string) string {
+		return "apiVersion: v1\nkind: mold\nname: " + name + "\nversion: 0.0.1\n"
+	}
+	alphaPath := moldDir("alpha", plainManifest("alpha"), `- name: agents.targets
   type: list
   default: "[claude]"
 `)
-	betaPath := moldDir("beta", "")
+	betaPath := moldDir("beta", plainManifest("beta"), "")
+	gammaPath := moldDir("gamma", `apiVersion: v1
+kind: mold
+name: gamma
+version: 0.0.1
+flux:
+  - name: agents.targets
+    type: list
+    default: "[claude]"
+`, "")
 
 	parentURL := "https://github.com/example/parent"
 	entry := &index.FoundryEntry{URL: parentURL, Type: "git"}
@@ -169,6 +182,8 @@ molds:
     source: ` + alphaPath + `
   - name: beta
     source: ` + betaPath + `
+  - name: gamma
+    source: ` + gammaPath + `
 `)
 	if err := os.WriteFile(filepath.Join(dir, "foundry.yaml"), yaml, 0o644); err != nil {
 		t.Fatal(err)
@@ -185,8 +200,8 @@ molds:
 	if err != nil {
 		t.Fatalf("InstallFoundryCore: %v", err)
 	}
-	if len(reports) != 2 {
-		t.Fatalf("got %d reports, want 2", len(reports))
+	if len(reports) != 3 {
+		t.Fatalf("got %d reports, want 3", len(reports))
 	}
 
 	byName := map[string]InstallFoundryReport{}
@@ -205,6 +220,14 @@ molds:
 	}
 	if got := byName["beta"].FluxSkipped; !reflect.DeepEqual(got, []string{"agents.targets"}) {
 		t.Errorf("beta.FluxSkipped = %v, want [agents.targets]", got)
+	}
+	// gamma proves we honor inline mold.yaml flux declarations, not just
+	// flux.schema.yaml — without this the summary lies for inline-schema molds.
+	if got := byName["gamma"].FluxApplied; !reflect.DeepEqual(got, []string{"agents.targets"}) {
+		t.Errorf("gamma.FluxApplied = %v, want [agents.targets]", got)
+	}
+	if got := byName["gamma"].FluxSkipped; len(got) != 0 {
+		t.Errorf("gamma.FluxSkipped = %v, want empty", got)
 	}
 }
 

--- a/internal/commands/foundry_core_test.go
+++ b/internal/commands/foundry_core_test.go
@@ -73,11 +73,11 @@ foundries:
 	}
 }
 
-// TestInstallFoundryCoreForwardsFluxOptions asserts that --set / -f values on
-// the foundry cast command flow into each per-mold CastMold call. We use
-// DryRun to avoid actually invoking CastMold; the test stops at the report
-// shape, then a second sub-test exercises the real CastMold path with a
-// fixture local mold to assert the values land in the resolved flux.
+// TestInstallFoundryCoreForwardsFluxOptions is a compile-time guard for the
+// new ValueFiles / SetOverrides fields on InstallFoundryOptions. It uses
+// DryRun to short-circuit before CastMold runs (no real cast happens).
+// Behavioral coverage of the actual forwarding lands in Task 3, which
+// asserts per-mold flux apply/skip results from the same call path.
 func TestInstallFoundryCoreForwardsFluxOptions(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("AILLOY_INDEX_CACHE_DIR", tmp)
@@ -102,8 +102,8 @@ molds:
 		Foundries: []index.FoundryEntry{{Name: "parent", URL: parentURL, Type: "git", Status: "ok"}},
 	}
 
-	// DryRun keeps us out of CastMold; we just assert the options carry
-	// through and that no mold is reported as failed for malformed --set.
+	// DryRun short-circuits before CastMold; we just verify the options
+	// struct accepts the new fields and the run completes cleanly.
 	reports, _, err := InstallFoundryCore(context.Background(), cfg, "parent", InstallFoundryOptions{
 		DryRun:       true,
 		Shallow:      true,

--- a/internal/commands/foundry_core_test.go
+++ b/internal/commands/foundry_core_test.go
@@ -73,6 +73,54 @@ foundries:
 	}
 }
 
+// TestInstallFoundryCoreForwardsFluxOptions asserts that --set / -f values on
+// the foundry cast command flow into each per-mold CastMold call. We use
+// DryRun to avoid actually invoking CastMold; the test stops at the report
+// shape, then a second sub-test exercises the real CastMold path with a
+// fixture local mold to assert the values land in the resolved flux.
+func TestInstallFoundryCoreForwardsFluxOptions(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("AILLOY_INDEX_CACHE_DIR", tmp)
+
+	parentURL := "https://github.com/example/parent"
+	entry := &index.FoundryEntry{URL: parentURL, Type: "git"}
+	dir := index.CachedIndexDir(tmp, entry)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	yaml := []byte(`apiVersion: v1
+kind: foundry-index
+name: parent
+molds:
+  - name: alpha
+    source: github.com/x/alpha
+`)
+	if err := os.WriteFile(filepath.Join(dir, "foundry.yaml"), yaml, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &index.Config{
+		Foundries: []index.FoundryEntry{{Name: "parent", URL: parentURL, Type: "git", Status: "ok"}},
+	}
+
+	// DryRun keeps us out of CastMold; we just assert the options carry
+	// through and that no mold is reported as failed for malformed --set.
+	reports, _, err := InstallFoundryCore(context.Background(), cfg, "parent", InstallFoundryOptions{
+		DryRun:       true,
+		Shallow:      true,
+		ValueFiles:   []string{"./team-defaults.yaml"},
+		SetOverrides: []string{"agents.targets=[claude,opencode]"},
+	})
+	if err != nil {
+		t.Fatalf("InstallFoundryCore: %v", err)
+	}
+	if len(reports) != 1 {
+		t.Fatalf("got %d reports, want 1", len(reports))
+	}
+	if reports[0].Err != nil {
+		t.Errorf("dry-run report carried err: %v", reports[0].Err)
+	}
+}
+
 func TestFoundryCastCommandShape(t *testing.T) {
 	if foundryCastCmd.Use == "" || !strings.HasPrefix(foundryCastCmd.Use, "cast") {
 		t.Fatalf("foundryCastCmd.Use = %q, want it to start with %q", foundryCastCmd.Use, "cast")

--- a/internal/commands/foundry_core_test.go
+++ b/internal/commands/foundry_core_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/nimble-giant/ailloy/pkg/foundry/index"
@@ -68,5 +70,16 @@ foundries:
 	}
 	if warnings[0].Source != "github.com/example/missing" {
 		t.Errorf("warnings[0].Source = %q, want github.com/example/missing", warnings[0].Source)
+	}
+}
+
+func TestFoundryCastCommandShape(t *testing.T) {
+	if foundryCastCmd.Use == "" || !strings.HasPrefix(foundryCastCmd.Use, "cast") {
+		t.Fatalf("foundryCastCmd.Use = %q, want it to start with %q", foundryCastCmd.Use, "cast")
+	}
+	gotAliases := foundryCastCmd.Aliases
+	wantAliases := []string{"install"}
+	if !reflect.DeepEqual(gotAliases, wantAliases) {
+		t.Fatalf("foundryCastCmd.Aliases = %v, want %v", gotAliases, wantAliases)
 	}
 }

--- a/internal/commands/foundry_core_test.go
+++ b/internal/commands/foundry_core_test.go
@@ -231,6 +231,83 @@ molds:
 	}
 }
 
+// TestInstallFoundryCoreFluxApplyResultsIncludesOres verifies that --set keys
+// referring to ore-namespaced fields (e.g. ore.status.value) are correctly
+// reported as "applied" for molds that declare an ore in their <mold>/ores/
+// directory. Without this, the summary would mis-report ore keys as skipped
+// even though the cast pipeline applies them.
+func TestInstallFoundryCoreFluxApplyResultsIncludesOres(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("AILLOY_INDEX_CACHE_DIR", tmp)
+
+	// Build a mold "delta" with an ore "status" under <mold>/ores/status.
+	// The ore declares a flux entry "value" which becomes "ore.status.value"
+	// after namespace prefixing.
+	deltaPath := filepath.Join(tmp, "delta")
+	if err := os.MkdirAll(filepath.Join(deltaPath, "ores", "status"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(deltaPath, "mold.yaml"), []byte(`apiVersion: v1
+kind: mold
+name: delta
+version: 0.0.1
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(deltaPath, "ores", "status", "ore.yaml"), []byte(`apiVersion: v1
+kind: ore
+name: status
+version: 1.0.0
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// flux.schema.yaml is a top-level YAML list of FluxVar entries (no `flux:` wrapper).
+	if err := os.WriteFile(filepath.Join(deltaPath, "ores", "status", "flux.schema.yaml"), []byte(`- name: value
+  type: string
+  default: pending
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	parentURL := "https://github.com/example/parent"
+	entry := &index.FoundryEntry{URL: parentURL, Type: "git"}
+	dir := index.CachedIndexDir(tmp, entry)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	yaml := []byte(`apiVersion: v1
+kind: foundry-index
+name: parent
+molds:
+  - name: delta
+    source: ` + deltaPath + `
+`)
+	if err := os.WriteFile(filepath.Join(dir, "foundry.yaml"), yaml, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &index.Config{
+		Foundries: []index.FoundryEntry{{Name: "parent", URL: parentURL, Type: "git", Status: "ok"}},
+	}
+
+	reports, _, err := InstallFoundryCore(context.Background(), cfg, "parent", InstallFoundryOptions{
+		DryRun:       true,
+		Shallow:      true,
+		SetOverrides: []string{"ore.status.value=done"},
+	})
+	if err != nil {
+		t.Fatalf("InstallFoundryCore: %v", err)
+	}
+	if len(reports) != 1 {
+		t.Fatalf("got %d reports, want 1", len(reports))
+	}
+	if got := reports[0].FluxApplied; !reflect.DeepEqual(got, []string{"ore.status.value"}) {
+		t.Errorf("delta.FluxApplied = %v, want [ore.status.value]", got)
+	}
+	if got := reports[0].FluxSkipped; len(got) != 0 {
+		t.Errorf("delta.FluxSkipped = %v, want empty", got)
+	}
+}
+
 func TestFoundryCastCommandShape(t *testing.T) {
 	if foundryCastCmd.Use == "" || !strings.HasPrefix(foundryCastCmd.Use, "cast") {
 		t.Fatalf("foundryCastCmd.Use = %q, want it to start with %q", foundryCastCmd.Use, "cast")

--- a/internal/commands/foundry_summary_test.go
+++ b/internal/commands/foundry_summary_test.go
@@ -1,0 +1,36 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatFoundryFluxSummary(t *testing.T) {
+	reports := []InstallFoundryReport{
+		{Name: "alpha", FluxApplied: []string{"agents.targets"}},
+		{Name: "beta", FluxApplied: []string{"agents.targets", "theme"}},
+		{Name: "gamma", FluxSkipped: []string{"agents.targets"}, FluxApplied: []string{"theme"}},
+	}
+	keys := []string{"agents.targets", "theme"}
+
+	out := formatFoundryFluxSummary(reports, keys)
+	if !strings.Contains(out, "agents.targets") {
+		t.Errorf("missing agents.targets in summary: %q", out)
+	}
+	if !strings.Contains(out, "2/3") {
+		t.Errorf("agents.targets should report 2/3 molds: %q", out)
+	}
+	if !strings.Contains(out, "theme") || !strings.Contains(out, "3/3") {
+		t.Errorf("theme should report 3/3 molds: %q", out)
+	}
+	if !strings.Contains(out, "gamma") {
+		t.Errorf("gamma (skipped agents.targets) should appear in skip list: %q", out)
+	}
+}
+
+func TestFormatFoundryFluxSummaryEmpty(t *testing.T) {
+	out := formatFoundryFluxSummary(nil, nil)
+	if out != "" {
+		t.Errorf("empty inputs should yield empty summary, got %q", out)
+	}
+}

--- a/internal/commands/install_deps.go
+++ b/internal/commands/install_deps.go
@@ -550,42 +550,13 @@ func artifactToLock(e foundry.ArtifactEntry) foundry.LockEntry {
 	}
 }
 
-// buildOreSearchPaths returns the ore-search-path order for cast-time merge:
-// mold-local → project (./.ailloy/ores) → global (~/.ailloy/ores). Lower
-// priority paths only contribute ore namespaces not already seen, mirroring
-// how flux defaults are layered.
-func buildOreSearchPaths(moldFS fs.FS, global bool) []mold.OreSearchPath {
-	paths := []mold.OreSearchPath{
-		{Name: "mold-local", FS: moldFS, Root: "ores"},
-	}
-	// Project scope is meaningful even on a global cast — the user may have
-	// project-installed ores they want to layer in. Global cast users who
-	// want strict isolation can run from a clean cwd.
-	if cwd, err := os.Getwd(); err == nil {
-		paths = append(paths, mold.OreSearchPath{
-			Name: "project",
-			FS:   os.DirFS(cwd),
-			Root: ".ailloy/ores",
-		})
-	}
-	if home, err := os.UserHomeDir(); err == nil {
-		paths = append(paths, mold.OreSearchPath{
-			Name: "global",
-			FS:   os.DirFS(home),
-			Root: ".ailloy/ores",
-		})
-	}
-	_ = global // currently only affects install-dir, not search-path order
-	return paths
-}
-
 // readerSearchPaths is a thin convenience wrapper for callers that have a
 // MoldReader in hand (cast.go / cast_core.go). It threads the reader's FS
-// into buildOreSearchPaths so mold-local ores under <mold>/ores/ are picked
-// up first.
+// into mold.BuildDefaultOreSearchPaths so mold-local ores under <mold>/ores/
+// are picked up first.
 func readerSearchPaths(reader *blanks.MoldReader, global bool) []mold.OreSearchPath {
 	if reader == nil {
-		return buildOreSearchPaths(nil, global)
+		return mold.BuildDefaultOreSearchPaths(nil, global)
 	}
-	return buildOreSearchPaths(reader.FS(), global)
+	return mold.BuildDefaultOreSearchPaths(reader.FS(), global)
 }

--- a/internal/tui/foundries/app.go
+++ b/internal/tui/foundries/app.go
@@ -107,11 +107,15 @@ func New(deps Deps) App {
 		_, err := deps.UpdateFoundries(cfg)
 		return err
 	}
-	regInstall := func(cfg *index.Config, nameOrURL string) ([]registered.InstallReport, error) {
+	regInstall := func(
+		cfg *index.Config,
+		nameOrURL string,
+		perMoldOverrides map[string][]string,
+	) ([]registered.InstallReport, error) {
 		if deps.InstallFoundry == nil {
 			return nil, errMissingDep
 		}
-		reports, err := deps.InstallFoundry(context.Background(), cfg, nameOrURL, InstallFoundryOptions{})
+		reports, err := deps.InstallFoundry(context.Background(), cfg, nameOrURL, InstallFoundryOptions{}, perMoldOverrides)
 		out := make([]registered.InstallReport, 0, len(reports))
 		for _, r := range reports {
 			out = append(out, registered.InstallReport{

--- a/internal/tui/foundries/app.go
+++ b/internal/tui/foundries/app.go
@@ -3,6 +3,8 @@ package foundries
 import (
 	"context"
 	"errors"
+	"fmt"
+	"os/exec"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -151,6 +153,9 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Picker is sized here; tabs receive WindowSizeMsg via the broadcast
 		// loop below.
 		a.picker, _ = a.picker.Update(m)
+	case fluxpicker.FoundrySchemasFetchedMsg:
+		a.picker = a.picker.WithFoundrySchemas(m.FoundryName, m.Schemas, m.SourceRefs)
+		return a, nil
 	case fluxpicker.SchemaFetchedMsg:
 		var cmd tea.Cmd
 		a.picker, cmd = a.picker.Update(m)
@@ -184,6 +189,14 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.active = (a.active + tabCount - 1) % tabCount
 			return a, nil
 		case "f":
+			if a.active == TabFoundries {
+				name, scope, ok := a.registered.CurrentFoundry()
+				if !ok {
+					return a, nil
+				}
+				a.picker = a.picker.OpenForFoundry(name, scope, nil, nil).SetFetching(true)
+				return a, fetchFoundrySchemasCmd(a.cfg, name)
+			}
 			ref, scope, ok := a.currentMold()
 			if !ok {
 				return a, nil
@@ -275,6 +288,74 @@ func fetchSchemaCmd(ref string) tea.Cmd {
 			Defaults: defaults,
 			Err:      err,
 		}
+	}
+}
+
+// fetchFoundrySchemasCmd resolves a foundry by name, walks its molds, and
+// fetches each one's flux schema. The result is delivered as a
+// FoundrySchemasFetchedMsg for the picker to fold in.
+func fetchFoundrySchemasCmd(cfg *index.Config, foundryName string) tea.Cmd {
+	return func() tea.Msg {
+		schemas, refs, err := loadFoundrySchemas(cfg, foundryName)
+		return fluxpicker.FoundrySchemasFetchedMsg{
+			FoundryName: foundryName,
+			Schemas:     schemas,
+			SourceRefs:  refs,
+			Err:         err,
+		}
+	}
+}
+
+// loadFoundrySchemas resolves the foundry by name and fetches the schema for
+// each mold it exposes. Returned maps are keyed by mold name.
+func loadFoundrySchemas(cfg *index.Config, foundryName string) (
+	map[string][]mold.FluxVar,
+	map[string]string,
+	error,
+) {
+	cacheDir, err := index.IndexCacheDir()
+	if err != nil {
+		return nil, nil, err
+	}
+	var match *index.FoundryEntry
+	for _, e := range cfg.EffectiveFoundries() {
+		if strings.EqualFold(e.Name, foundryName) {
+			c := e
+			match = &c
+			break
+		}
+	}
+	if match == nil {
+		return nil, nil, fmt.Errorf("foundry %q not found", foundryName)
+	}
+	fetcher, err := index.NewFetcher(defaultGitRunner())
+	if err != nil {
+		return nil, nil, err
+	}
+	r := index.NewResolver(index.CacheFirstLookup(cacheDir, fetcher))
+	_, allMolds, err := r.Resolve(match.URL)
+	if err != nil {
+		return nil, nil, err
+	}
+	schemas := map[string][]mold.FluxVar{}
+	refs := map[string]string{}
+	for _, mm := range allMolds {
+		schema, _, ferr := mold.FetchSchemaFromSource(context.Background(), mm.Entry.Source)
+		if ferr != nil {
+			// Skip molds whose schema can't be fetched; the picker still
+			// works for the rest. Better than aborting the whole flow.
+			continue
+		}
+		schemas[mm.Entry.Name] = schema
+		refs[mm.Entry.Name] = mm.Entry.Source
+	}
+	return schemas, refs, nil
+}
+
+func defaultGitRunner() index.GitRunner {
+	return func(args ...string) ([]byte, error) {
+		cmd := exec.Command("git", args...) // #nosec G204 -- args constructed internally
+		return cmd.CombinedOutput()
 	}
 }
 

--- a/internal/tui/foundries/app.go
+++ b/internal/tui/foundries/app.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -340,16 +342,67 @@ func loadFoundrySchemas(cfg *index.Config, foundryName string) (
 	schemas := map[string][]mold.FluxVar{}
 	refs := map[string]string{}
 	for _, mm := range allMolds {
-		schema, _, ferr := mold.FetchSchemaFromSource(context.Background(), mm.Entry.Source)
-		if ferr != nil {
-			// Skip molds whose schema can't be fetched; the picker still
-			// works for the rest. Better than aborting the whole flow.
+		schema := loadMoldSchemaForPicker(mm.Entry.Source)
+		if len(schema) == 0 {
 			continue
 		}
 		schemas[mm.Entry.Name] = schema
 		refs[mm.Entry.Name] = mm.Entry.Source
 	}
 	return schemas, refs, nil
+}
+
+// loadMoldSchemaForPicker returns the deduplicated flux schema for a single
+// mold source. For local-path sources it mirrors the cast pipeline by using
+// LoadMoldFluxWithOres with the canonical search paths (so ore-namespaced
+// keys appear) and merging in any inline mold.yaml flux entries. For remote
+// refs it falls back to the plain schema fetch.
+//
+// Entries are deduped by Name (mold-local definitions win over inline ones)
+// because fluxpicker.AggregateSchemas treats every per-mold entry as a
+// distinct declaration when computing conflicts; duplicates within a single
+// mold's slice would falsely double-count and could trigger spurious
+// conflict markers.
+func loadMoldSchemaForPicker(source string) []mold.FluxVar {
+	if info, err := os.Stat(source); err == nil && info.IsDir() {
+		moldFS := os.DirFS(source)
+		var collected []mold.FluxVar
+		if merged, _, _, lerr := mold.LoadMoldFluxWithOres(moldFS, mold.BuildDefaultOreSearchPaths(moldFS, false)); lerr == nil {
+			collected = merged
+		}
+		// Inline mold.yaml flux declarations are not picked up by
+		// LoadMoldFluxWithOres; merge them in so molds that declare schema
+		// inline still surface their keys in the picker.
+		if mm, mlerr := mold.LoadMold(filepath.Join(source, "mold.yaml")); mlerr == nil && mm != nil {
+			collected = append(collected, mm.Flux...)
+		}
+		return dedupeFluxVarsByName(collected)
+	}
+	schema, _, ferr := mold.FetchSchemaFromSource(context.Background(), source)
+	if ferr != nil {
+		// Skip molds whose schema can't be fetched; the picker still works
+		// for the rest. Better than aborting the whole flow.
+		return nil
+	}
+	return schema
+}
+
+// dedupeFluxVarsByName returns a slice with duplicate Names removed,
+// preserving first-seen order.
+func dedupeFluxVarsByName(in []mold.FluxVar) []mold.FluxVar {
+	if len(in) == 0 {
+		return in
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]mold.FluxVar, 0, len(in))
+	for _, v := range in {
+		if _, ok := seen[v.Name]; ok {
+			continue
+		}
+		seen[v.Name] = struct{}{}
+		out = append(out, v)
+	}
+	return out
 }
 
 func defaultGitRunner() index.GitRunner {

--- a/internal/tui/foundries/app_test.go
+++ b/internal/tui/foundries/app_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/nimble-giant/ailloy/internal/tui/foundries/data"
 	"github.com/nimble-giant/ailloy/internal/tui/foundries/discover"
 	"github.com/nimble-giant/ailloy/internal/tui/foundries/fluxpicker"
+	"github.com/nimble-giant/ailloy/internal/tui/foundries/registered"
+	"github.com/nimble-giant/ailloy/pkg/foundry/index"
 )
 
 func TestApp_FOpensPickerWhenMoldHighlighted(t *testing.T) {
@@ -70,6 +72,34 @@ func TestApp_FluxOverridesMsg_SessionRoutesToDiscover(t *testing.T) {
 	// then re-cast and check downstream effects in the integration test (Task 14).
 	if app.picker.IsOpen() {
 		t.Fatal("expected picker to close")
+	}
+}
+
+func TestPressingFOnFoundriesTabOpensFoundryPicker(t *testing.T) {
+	cfg := &index.Config{
+		Foundries: []index.FoundryEntry{{Name: "alpha", URL: "https://github.com/x/alpha"}},
+	}
+	a := App{
+		cfg:        cfg,
+		registered: registered.New(cfg, nil, nil, nil, nil),
+		picker:     fluxpicker.New(),
+		active:     TabFoundries,
+	}
+	// Move cursor onto "alpha". For this synthetic cfg there is no project
+	// foundries entry — registered shows official + alpha. Cursor 0 is the
+	// official foundry; cursor 1 is alpha.
+	a.registered.SetCursorForTest(1)
+
+	updated, _ := a.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	app := updated.(App)
+	if !app.picker.IsOpen() {
+		t.Fatalf("picker should be open after pressing f on Foundries tab")
+	}
+	if !app.picker.IsFoundryMode() {
+		t.Fatalf("picker should be in foundry mode")
+	}
+	if app.picker.FoundryName() != "alpha" {
+		t.Errorf("FoundryName = %q, want alpha", app.picker.FoundryName())
 	}
 }
 

--- a/internal/tui/foundries/app_test.go
+++ b/internal/tui/foundries/app_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/nimble-giant/ailloy/internal/tui/foundries/fluxpicker"
 	"github.com/nimble-giant/ailloy/internal/tui/foundries/registered"
 	"github.com/nimble-giant/ailloy/pkg/foundry/index"
-	"github.com/nimble-giant/ailloy/pkg/mold"
 )
 
 func TestApp_FOpensPickerWhenMoldHighlighted(t *testing.T) {
@@ -177,16 +176,15 @@ molds:
 		}
 		t.Fatalf("schemas missing delta entry; got keys=%v", keys)
 	}
-	var got []mold.FluxVar = deltaSchema // explicit type assertion as a guard
 	found := false
-	for _, fv := range got {
+	for _, fv := range deltaSchema {
 		if fv.Name == "ore.status.value" {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Errorf("delta schema missing ore.status.value; got %+v", got)
+		t.Errorf("delta schema missing ore.status.value; got %+v", deltaSchema)
 	}
 }
 

--- a/internal/tui/foundries/app_test.go
+++ b/internal/tui/foundries/app_test.go
@@ -1,6 +1,8 @@
 package foundries
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -10,6 +12,7 @@ import (
 	"github.com/nimble-giant/ailloy/internal/tui/foundries/fluxpicker"
 	"github.com/nimble-giant/ailloy/internal/tui/foundries/registered"
 	"github.com/nimble-giant/ailloy/pkg/foundry/index"
+	"github.com/nimble-giant/ailloy/pkg/mold"
 )
 
 func TestApp_FOpensPickerWhenMoldHighlighted(t *testing.T) {
@@ -100,6 +103,90 @@ func TestPressingFOnFoundriesTabOpensFoundryPicker(t *testing.T) {
 	}
 	if app.picker.FoundryName() != "alpha" {
 		t.Errorf("FoundryName = %q, want alpha", app.picker.FoundryName())
+	}
+}
+
+// TestLoadFoundrySchemas_IncludesOreNamespacedKeys verifies the foundry-mode
+// picker's per-mold schema population picks up ore-namespaced flux keys for
+// local-path mold sources, mirroring what the cast pipeline applies. Without
+// this, the picker would silently omit ore.<ns>.* rows even though the
+// underlying cast accepts them.
+func TestLoadFoundrySchemas_IncludesOreNamespacedKeys(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("AILLOY_INDEX_CACHE_DIR", tmp)
+
+	// Build a local mold "delta" with an ore "status" under <mold>/ores/.
+	deltaPath := filepath.Join(tmp, "delta")
+	if err := os.MkdirAll(filepath.Join(deltaPath, "ores", "status"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(deltaPath, "mold.yaml"), []byte(`apiVersion: v1
+kind: mold
+name: delta
+version: 0.0.1
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(deltaPath, "ores", "status", "ore.yaml"), []byte(`apiVersion: v1
+kind: ore
+name: status
+version: 1.0.0
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(deltaPath, "ores", "status", "flux.schema.yaml"), []byte(`- name: value
+  type: string
+  default: pending
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	parentURL := "https://github.com/example/parent"
+	entry := &index.FoundryEntry{URL: parentURL, Type: "git"}
+	cacheDir := index.CachedIndexDir(tmp, entry)
+	if err := os.MkdirAll(cacheDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	yaml := []byte(`apiVersion: v1
+kind: foundry-index
+name: parent
+molds:
+  - name: delta
+    source: ` + deltaPath + `
+`)
+	if err := os.WriteFile(filepath.Join(cacheDir, "foundry.yaml"), yaml, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &index.Config{
+		Foundries: []index.FoundryEntry{{Name: "parent", URL: parentURL, Type: "git", Status: "ok"}},
+	}
+
+	schemas, refs, err := loadFoundrySchemas(cfg, "parent")
+	if err != nil {
+		t.Fatalf("loadFoundrySchemas: %v", err)
+	}
+	if refs["delta"] != deltaPath {
+		t.Errorf("refs[delta] = %q, want %q", refs["delta"], deltaPath)
+	}
+	deltaSchema, ok := schemas["delta"]
+	if !ok {
+		keys := make([]string, 0, len(schemas))
+		for k := range schemas {
+			keys = append(keys, k)
+		}
+		t.Fatalf("schemas missing delta entry; got keys=%v", keys)
+	}
+	var got []mold.FluxVar = deltaSchema // explicit type assertion as a guard
+	found := false
+	for _, fv := range got {
+		if fv.Name == "ore.status.value" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("delta schema missing ore.status.value; got %+v", got)
 	}
 }
 

--- a/internal/tui/foundries/deps.go
+++ b/internal/tui/foundries/deps.go
@@ -67,10 +67,18 @@ type InstallFoundryOptions struct {
 	WithWorkflows bool
 	DryRun        bool
 	Force         bool
+	ValueFiles    []string
+	SetOverrides  []string
 }
 
 // InstallFoundryFunc casts every mold listed by a foundry.
-type InstallFoundryFunc func(ctx context.Context, cfg *index.Config, nameOrURL string, opts InstallFoundryOptions) ([]InstallFoundryReport, error)
+type InstallFoundryFunc func(
+	ctx context.Context,
+	cfg *index.Config,
+	nameOrURL string,
+	opts InstallFoundryOptions,
+	perMoldOverrides map[string][]string,
+) ([]InstallFoundryReport, error)
 
 // Deps wires platform-level operations into the TUI without forcing the
 // tui package to import internal/commands (which would create a cycle).

--- a/internal/tui/foundries/fluxpicker/aggregate.go
+++ b/internal/tui/foundries/fluxpicker/aggregate.go
@@ -1,0 +1,64 @@
+package fluxpicker
+
+import (
+	"sort"
+
+	"github.com/nimble-giant/ailloy/pkg/mold"
+)
+
+// AggregateSchemas merges per-mold flux schemas into a single deduped slice.
+// Keys whose Type or Default differs across declaring molds are returned in
+// `conflicts`, keyed by var name → sorted list of declaring mold names.
+//
+// The unified slice contains exactly one entry per unique name. For
+// conflicting keys the first observed declaration wins for the unified row;
+// callers (the foundry-mode picker) use the conflicts map to expand the row
+// into per-mold sub-rows so the user can set each independently.
+//
+// Output order is alphabetical by var name for deterministic rendering.
+func AggregateSchemas(perMold map[string][]mold.FluxVar) ([]mold.FluxVar, map[string][]string) {
+	if len(perMold) == 0 {
+		return nil, nil
+	}
+
+	// Iterate molds in sorted order so "first observed" is deterministic.
+	moldNames := make([]string, 0, len(perMold))
+	for name := range perMold {
+		moldNames = append(moldNames, name)
+	}
+	sort.Strings(moldNames)
+
+	type seen struct {
+		first   mold.FluxVar
+		molds   []string // names that DECLARE this key
+		differs bool     // true once we've seen a Type/Default mismatch
+	}
+	byName := map[string]*seen{}
+
+	for _, m := range moldNames {
+		for _, v := range perMold[m] {
+			s, ok := byName[v.Name]
+			if !ok {
+				byName[v.Name] = &seen{first: v, molds: []string{m}}
+				continue
+			}
+			s.molds = append(s.molds, m)
+			if v.Type != s.first.Type || v.Default != s.first.Default {
+				s.differs = true
+			}
+		}
+	}
+
+	unified := make([]mold.FluxVar, 0, len(byName))
+	conflicts := map[string][]string{}
+	for name, s := range byName {
+		unified = append(unified, s.first)
+		if s.differs {
+			cm := append([]string(nil), s.molds...)
+			sort.Strings(cm)
+			conflicts[name] = cm
+		}
+	}
+	sort.Slice(unified, func(i, j int) bool { return unified[i].Name < unified[j].Name })
+	return unified, conflicts
+}

--- a/internal/tui/foundries/fluxpicker/aggregate_test.go
+++ b/internal/tui/foundries/fluxpicker/aggregate_test.go
@@ -1,0 +1,78 @@
+package fluxpicker
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/nimble-giant/ailloy/pkg/mold"
+)
+
+func TestAggregateSchemasIdentical(t *testing.T) {
+	v := mold.FluxVar{Name: "agents.targets", Type: "list", Default: "[claude]"}
+	per := map[string][]mold.FluxVar{
+		"alpha": {v},
+		"beta":  {v},
+	}
+	unified, conflicts := AggregateSchemas(per)
+	if len(unified) != 1 || unified[0].Name != "agents.targets" {
+		t.Errorf("unified = %v", unified)
+	}
+	if len(conflicts) != 0 {
+		t.Errorf("expected no conflicts, got %v", conflicts)
+	}
+}
+
+func TestAggregateSchemasTypeConflict(t *testing.T) {
+	per := map[string][]mold.FluxVar{
+		"alpha": {{Name: "x", Type: "list"}},
+		"beta":  {{Name: "x", Type: "string"}},
+	}
+	unified, conflicts := AggregateSchemas(per)
+	if len(unified) != 1 || unified[0].Name != "x" {
+		t.Errorf("unified = %v", unified)
+	}
+	if got := conflicts["x"]; len(got) != 2 {
+		t.Errorf("conflicts[x] = %v, want both molds", got)
+	}
+}
+
+func TestAggregateSchemasDefaultConflict(t *testing.T) {
+	per := map[string][]mold.FluxVar{
+		"alpha": {{Name: "theme", Type: "string", Default: "dark"}},
+		"beta":  {{Name: "theme", Type: "string", Default: "light"}},
+	}
+	_, conflicts := AggregateSchemas(per)
+	if got := conflicts["theme"]; len(got) != 2 {
+		t.Errorf("conflicts[theme] = %v, want both molds", got)
+	}
+}
+
+func TestAggregateSchemasDisjoint(t *testing.T) {
+	per := map[string][]mold.FluxVar{
+		"alpha": {{Name: "a", Type: "string"}},
+		"beta":  {{Name: "b", Type: "string"}},
+	}
+	unified, conflicts := AggregateSchemas(per)
+	names := []string{}
+	for _, v := range unified {
+		names = append(names, v.Name)
+	}
+	sort.Strings(names)
+	if !reflect.DeepEqual(names, []string{"a", "b"}) {
+		t.Errorf("unified names = %v, want [a b]", names)
+	}
+	if len(conflicts) != 0 {
+		t.Errorf("expected no conflicts, got %v", conflicts)
+	}
+}
+
+func TestAggregateSchemasEmpty(t *testing.T) {
+	unified, conflicts := AggregateSchemas(nil)
+	if len(unified) != 0 {
+		t.Errorf("unified = %v, want empty", unified)
+	}
+	if len(conflicts) != 0 {
+		t.Errorf("conflicts = %v, want empty", conflicts)
+	}
+}

--- a/internal/tui/foundries/fluxpicker/foundry_mode.go
+++ b/internal/tui/foundries/fluxpicker/foundry_mode.go
@@ -1,0 +1,63 @@
+package fluxpicker
+
+import (
+	"github.com/nimble-giant/ailloy/internal/tui/foundries/data"
+	"github.com/nimble-giant/ailloy/pkg/mold"
+)
+
+// OpenForFoundry opens the picker scoped to every mold in a foundry.
+// `perMoldSchemas` carries each mold's flux schema (used for aggregation).
+// `perMoldSourceRefs` carries each mold's source ref string (used at save
+// time to derive the per-mold flux file slug — must match the slug used by
+// the cast pipeline so subsequent casts pick up these values). Pass nil for
+// `perMoldSourceRefs` when the picker is opened before refs are known; it
+// can be filled in later via WithFoundrySchemas (added in Task 10).
+//
+// The picker aggregates schemas: keys with consistent type AND default
+// render as one unified row whose value applies to every declaring mold;
+// keys whose type or default differs across molds are flagged in
+// SchemaConflicts and rendered as expandable per-mold sub-rows by the View.
+func (m Model) OpenForFoundry(
+	foundryName string,
+	scope data.Scope,
+	perMoldSchemas map[string][]mold.FluxVar,
+	perMoldSourceRefs map[string]string,
+) Model {
+	unified, conflicts := AggregateSchemas(perMoldSchemas)
+	m.open = true
+	m.moldRef = "" // foundry-scope, no single mold ref
+	m.scope = scope
+	m.schema = unified
+	m.defaults = map[string]any{} // no aggregated defaults; per-mold defaults shown in conflict expansions
+	m.overrides = map[string]any{}
+	m.cursor = 0
+	m.focus = focusFilter
+	m.filter.SetValue("")
+	m.filter.Focus()
+	m.err = nil
+	m.fetching = false
+	m.foundryName = foundryName
+	m.perMoldSchemas = perMoldSchemas
+	m.perMoldSourceRefs = perMoldSourceRefs
+	m.schemaConflicts = conflicts
+	return m
+}
+
+// IsFoundryMode reports whether the picker is scoped to a foundry rather than
+// a single mold.
+func (m Model) IsFoundryMode() bool { return m.foundryName != "" }
+
+// FoundryName returns the foundry name when in foundry mode, "" otherwise.
+func (m Model) FoundryName() string { return m.foundryName }
+
+// PerMoldSchemas returns the per-mold schemas captured at open time. Used by
+// persistence to decide which mold flux files to write at fan-out.
+func (m Model) PerMoldSchemas() map[string][]mold.FluxVar { return m.perMoldSchemas }
+
+// PerMoldSourceRefs returns the per-mold source refs captured at open time.
+// Used at save time to derive each mold's flux file slug.
+func (m Model) PerMoldSourceRefs() map[string]string { return m.perMoldSourceRefs }
+
+// SchemaConflicts returns conflict info: var name → sorted list of mold names
+// that disagree on Type or Default for that var.
+func (m Model) SchemaConflicts() map[string][]string { return m.schemaConflicts }

--- a/internal/tui/foundries/fluxpicker/foundry_mode.go
+++ b/internal/tui/foundries/fluxpicker/foundry_mode.go
@@ -61,3 +61,58 @@ func (m Model) PerMoldSourceRefs() map[string]string { return m.perMoldSourceRef
 // SchemaConflicts returns conflict info: var name → sorted list of mold names
 // that disagree on Type or Default for that var.
 func (m Model) SchemaConflicts() map[string][]string { return m.schemaConflicts }
+
+// SetMoldOverride records a per-mold value for a conflict-expanded key. Only
+// meaningful in foundry mode; no-op otherwise.
+func (m Model) SetMoldOverride(moldName, key string, value any) Model {
+	if !m.IsFoundryMode() {
+		return m
+	}
+	if m.moldOverrides == nil {
+		m.moldOverrides = map[string]any{}
+	}
+	m.moldOverrides[moldOverrideKey(moldName, key)] = value
+	return m
+}
+
+// MoldOverride returns the per-mold value for a conflict-expanded key, or
+// nil if unset.
+func (m Model) MoldOverride(moldName, key string) any {
+	if m.moldOverrides == nil {
+		return nil
+	}
+	return m.moldOverrides[moldOverrideKey(moldName, key)]
+}
+
+// MoldOverrides returns the full per-mold override map. Result keyed by
+// mold name → flat dotted-key map (e.g. "alpha" → {"theme": "midnight"}).
+func (m Model) MoldOverrides() map[string]map[string]any {
+	if m.moldOverrides == nil {
+		return nil
+	}
+	out := map[string]map[string]any{}
+	for k, v := range m.moldOverrides {
+		moldName, key, ok := splitMoldOverrideKey(k)
+		if !ok {
+			continue
+		}
+		if out[moldName] == nil {
+			out[moldName] = map[string]any{}
+		}
+		out[moldName][key] = v
+	}
+	return out
+}
+
+func moldOverrideKey(moldName, key string) string {
+	return moldName + "\x00" + key
+}
+
+func splitMoldOverrideKey(k string) (moldName, key string, ok bool) {
+	for i := 0; i < len(k); i++ {
+		if k[i] == 0 {
+			return k[:i], k[i+1:], true
+		}
+	}
+	return "", "", false
+}

--- a/internal/tui/foundries/fluxpicker/foundry_mode.go
+++ b/internal/tui/foundries/fluxpicker/foundry_mode.go
@@ -116,3 +116,19 @@ func splitMoldOverrideKey(k string) (moldName, key string, ok bool) {
 	}
 	return "", "", false
 }
+
+// WithFoundrySchemas folds asynchronously-fetched per-mold schemas into the
+// picker, runs aggregation, and clears the fetching flag. No-op when the
+// picker is not currently scoped to the named foundry.
+func (m Model) WithFoundrySchemas(foundryName string, schemas map[string][]mold.FluxVar, refs map[string]string) Model {
+	if m.foundryName != foundryName {
+		return m
+	}
+	unified, conflicts := AggregateSchemas(schemas)
+	m.schema = unified
+	m.schemaConflicts = conflicts
+	m.perMoldSchemas = schemas
+	m.perMoldSourceRefs = refs
+	m.fetching = false
+	return m
+}

--- a/internal/tui/foundries/fluxpicker/foundry_mode_test.go
+++ b/internal/tui/foundries/fluxpicker/foundry_mode_test.go
@@ -48,3 +48,53 @@ func TestOpenForFoundryDetectsConflicts(t *testing.T) {
 		t.Errorf("conflicts[theme] = %v, want both molds", got)
 	}
 }
+
+func TestSetMoldOverrideRecordsPerMoldValue(t *testing.T) {
+	per := map[string][]mold.FluxVar{
+		"alpha": {{Name: "theme", Type: "string", Default: "dark"}},
+		"beta":  {{Name: "theme", Type: "string", Default: "light"}},
+	}
+	m := New().OpenForFoundry("brand", data.ScopeProject, per, nil)
+	m = m.SetMoldOverride("alpha", "theme", "midnight")
+	m = m.SetMoldOverride("beta", "theme", "noon")
+	if got := m.MoldOverride("alpha", "theme"); got != "midnight" {
+		t.Errorf("alpha:theme = %v, want midnight", got)
+	}
+	if got := m.MoldOverride("beta", "theme"); got != "noon" {
+		t.Errorf("beta:theme = %v, want noon", got)
+	}
+	if got := m.MoldOverride("gamma", "theme"); got != nil {
+		t.Errorf("gamma:theme = %v, want nil (unset)", got)
+	}
+}
+
+func TestSetMoldOverrideClearedByClose(t *testing.T) {
+	per := map[string][]mold.FluxVar{
+		"alpha": {{Name: "theme", Type: "string", Default: "dark"}},
+		"beta":  {{Name: "theme", Type: "string", Default: "light"}},
+	}
+	m := New().OpenForFoundry("brand", data.ScopeProject, per, nil).
+		SetMoldOverride("alpha", "theme", "midnight").
+		Close()
+	if got := m.MoldOverride("alpha", "theme"); got != nil {
+		t.Errorf("after Close, alpha:theme = %v, want nil", got)
+	}
+}
+
+func TestMoldOverridesGroupedByMold(t *testing.T) {
+	per := map[string][]mold.FluxVar{
+		"alpha": {{Name: "theme", Type: "string", Default: "dark"}},
+		"beta":  {{Name: "theme", Type: "string", Default: "light"}},
+	}
+	m := New().OpenForFoundry("brand", data.ScopeProject, per, nil).
+		SetMoldOverride("alpha", "theme", "midnight").
+		SetMoldOverride("beta", "agents.targets", []string{"claude"})
+	out := m.MoldOverrides()
+	if got := out["alpha"]["theme"]; got != "midnight" {
+		t.Errorf("MoldOverrides()[alpha][theme] = %v, want midnight", got)
+	}
+	beta := out["beta"]
+	if got, ok := beta["agents.targets"].([]string); !ok || len(got) != 1 || got[0] != "claude" {
+		t.Errorf("MoldOverrides()[beta][agents.targets] = %v (type %T), want [claude]", beta["agents.targets"], beta["agents.targets"])
+	}
+}

--- a/internal/tui/foundries/fluxpicker/foundry_mode_test.go
+++ b/internal/tui/foundries/fluxpicker/foundry_mode_test.go
@@ -1,0 +1,50 @@
+package fluxpicker
+
+import (
+	"testing"
+
+	"github.com/nimble-giant/ailloy/internal/tui/foundries/data"
+	"github.com/nimble-giant/ailloy/pkg/mold"
+)
+
+func TestOpenForFoundryStoresState(t *testing.T) {
+	per := map[string][]mold.FluxVar{
+		"alpha": {{Name: "agents.targets", Type: "list"}},
+		"beta":  {{Name: "agents.targets", Type: "list"}},
+	}
+	refs := map[string]string{
+		"alpha": "github.com/example/alpha",
+		"beta":  "github.com/example/beta",
+	}
+	m := New().OpenForFoundry("nimble-mold", data.ScopeProject, per, refs)
+	if !m.IsOpen() {
+		t.Fatalf("picker should be open")
+	}
+	if got := m.FoundryName(); got != "nimble-mold" {
+		t.Errorf("FoundryName = %q, want nimble-mold", got)
+	}
+	if !m.IsFoundryMode() {
+		t.Errorf("IsFoundryMode = false, want true")
+	}
+	if got := m.PerMoldSchemas(); len(got) != 2 {
+		t.Errorf("PerMoldSchemas len = %d, want 2", len(got))
+	}
+	if got := m.PerMoldSourceRefs(); len(got) != 2 {
+		t.Errorf("PerMoldSourceRefs len = %d, want 2", len(got))
+	}
+	if got := m.SchemaConflicts(); len(got) != 0 {
+		t.Errorf("expected no conflicts, got %v", got)
+	}
+}
+
+func TestOpenForFoundryDetectsConflicts(t *testing.T) {
+	per := map[string][]mold.FluxVar{
+		"alpha": {{Name: "theme", Type: "string", Default: "dark"}},
+		"beta":  {{Name: "theme", Type: "string", Default: "light"}},
+	}
+	m := New().OpenForFoundry("brand", data.ScopeProject, per, nil)
+	conflicts := m.SchemaConflicts()
+	if got := conflicts["theme"]; len(got) != 2 {
+		t.Errorf("conflicts[theme] = %v, want both molds", got)
+	}
+}

--- a/internal/tui/foundries/fluxpicker/messages.go
+++ b/internal/tui/foundries/fluxpicker/messages.go
@@ -33,3 +33,12 @@ type SchemaFetchedMsg struct {
 	Defaults map[string]any
 	Err      error
 }
+
+// FoundrySchemasFetchedMsg is dispatched by the App after the foundry-mode
+// picker is opened. The picker stitches the schemas in via WithFoundrySchemas.
+type FoundrySchemasFetchedMsg struct {
+	FoundryName string
+	Schemas     map[string][]mold.FluxVar
+	SourceRefs  map[string]string
+	Err         error
+}

--- a/internal/tui/foundries/fluxpicker/model.go
+++ b/internal/tui/foundries/fluxpicker/model.go
@@ -40,6 +40,20 @@ type Model struct {
 	width     int
 	height    int
 	fetching  bool
+	// Foundry-mode fields. When foundryName != "" the picker is scoped to a
+	// whole foundry. `perMoldSchemas` carries the source-of-truth schemas
+	// for aggregation; `perMoldSourceRefs` carries each mold's source ref
+	// (used at save time to derive the per-mold flux file slug);
+	// `schemaConflicts` is populated by AggregateSchemas. `moldOverrides`
+	// stores conflict-expanded per-mold values; key shape is
+	// "<moldName>\x00<dottedFluxKey>" — the NUL separator avoids collisions
+	// with mold names that contain colons or dots. (moldOverrides is
+	// populated in Task 7 — declared here so Close() can reset it.)
+	foundryName       string
+	perMoldSchemas    map[string][]mold.FluxVar
+	perMoldSourceRefs map[string]string
+	schemaConflicts   map[string][]string
+	moldOverrides     map[string]any
 }
 
 // New returns a closed picker model.
@@ -88,6 +102,11 @@ func (m Model) Close() Model {
 	m.focus = focusFilter
 	m.editor = editorState{}
 	m.saving = saveState{}
+	m.foundryName = ""
+	m.perMoldSchemas = nil
+	m.perMoldSourceRefs = nil
+	m.schemaConflicts = nil
+	m.moldOverrides = nil
 	return m
 }
 

--- a/internal/tui/foundries/fluxpicker/persist.go
+++ b/internal/tui/foundries/fluxpicker/persist.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
@@ -116,6 +117,85 @@ func persistOverrides(moldName string, target SaveTarget, overrides map[string]a
 		return path, writeFluxFile(path, overrides)
 	}
 	return "", fmt.Errorf("unknown save target %v", target)
+}
+
+// persistFoundryOverrides writes foundry-scope picker output to per-mold flux
+// files. Returns the list of paths written.
+//
+// `unified` carries values from non-conflicting picker rows (apply to every
+// mold whose schema declares the key). `perMold` carries values from
+// conflict-expanded sub-rows (apply to that single mold only). Per-mold
+// values win over unified values for the same key on the same mold. The slug
+// used for each file is mold.FluxFileSlug(perMoldSourceRefs[moldName]) so the
+// cast pipeline's PersistedFluxPaths picks them up on subsequent casts.
+//
+// SaveTargetSession is a no-op (returns nil paths) because session overrides
+// live in the picker model and are forwarded by the App via FluxOverridesMsg.
+func persistFoundryOverrides(
+	target SaveTarget,
+	perMoldSchemas map[string][]mold.FluxVar,
+	perMoldSourceRefs map[string]string,
+	unified map[string]any,
+	perMold map[string]map[string]any,
+) ([]string, error) {
+	if target == SaveTargetSession {
+		return nil, nil
+	}
+
+	// Build per-mold combined override map.
+	combined := map[string]map[string]any{}
+	for moldName, schema := range perMoldSchemas {
+		for _, v := range schema {
+			if val, ok := unified[v.Name]; ok {
+				if combined[moldName] == nil {
+					combined[moldName] = map[string]any{}
+				}
+				combined[moldName][v.Name] = val
+			}
+		}
+	}
+	for moldName, kv := range perMold {
+		if combined[moldName] == nil {
+			combined[moldName] = map[string]any{}
+		}
+		for k, v := range kv {
+			combined[moldName][k] = v
+		}
+	}
+
+	var written []string
+	for moldName, overrides := range combined {
+		if len(overrides) == 0 {
+			continue
+		}
+		ref := perMoldSourceRefs[moldName]
+		if ref == "" {
+			// Fall back to mold name as a deterministic slug input. The cast
+			// pipeline won't pick this up via PersistedFluxPaths, but the
+			// file is still readable for manual inspection.
+			ref = moldName
+		}
+		slug := fluxFileSlug(ref)
+		var path string
+		switch target {
+		case SaveTargetProject:
+			path = filepath.Join(".ailloy", "flux", slug+".yaml")
+		case SaveTargetGlobal:
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return written, err
+			}
+			path = filepath.Join(home, ".ailloy", "flux", slug+".yaml")
+		default:
+			return written, fmt.Errorf("unknown save target %v", target)
+		}
+		if err := writeFluxFile(path, overrides); err != nil {
+			return written, err
+		}
+		written = append(written, path)
+	}
+	sort.Strings(written)
+	return written, nil
 }
 
 // mergeOverrides returns a new map combining defaults and overrides

--- a/internal/tui/foundries/fluxpicker/persist_test.go
+++ b/internal/tui/foundries/fluxpicker/persist_test.go
@@ -3,9 +3,12 @@ package fluxpicker
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	yaml "github.com/goccy/go-yaml"
+
+	"github.com/nimble-giant/ailloy/pkg/mold"
 )
 
 func TestWriteFluxFile_CreatesFile(t *testing.T) {
@@ -122,4 +125,79 @@ func TestFluxFileSlug_AvoidsCrossFoundryCollision(t *testing.T) {
 	if a == b {
 		t.Fatalf("expected distinct slugs across foundries; both = %q", a)
 	}
+}
+
+func TestPersistFoundryOverridesFansOutToProject(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+
+	per := map[string][]mold.FluxVar{
+		"alpha": {{Name: "agents.targets", Type: "list"}},
+		"beta":  {{Name: "agents.targets", Type: "list"}, {Name: "theme", Type: "string"}},
+		"gamma": {{Name: "theme", Type: "string"}},
+	}
+	refs := map[string]string{
+		"alpha": "github.com/example/alpha",
+		"beta":  "github.com/example/beta",
+		"gamma": "github.com/example/gamma",
+	}
+	unified := map[string]any{
+		"agents.targets": []any{"claude", "opencode"},
+	}
+	perMold := map[string]map[string]any{
+		"beta":  {"theme": "noon"},
+		"gamma": {"theme": "midnight"},
+	}
+
+	written, err := persistFoundryOverrides(SaveTargetProject, per, refs, unified, perMold)
+	if err != nil {
+		t.Fatalf("persistFoundryOverrides: %v", err)
+	}
+
+	// alpha and beta have agents.targets, so they get the unified value.
+	// beta also gets its per-mold theme. gamma gets only per-mold theme.
+	for _, name := range []string{"alpha", "beta", "gamma"} {
+		slug := mold.FluxFileSlug(refs[name])
+		path := filepath.Join(".ailloy", "flux", slug+".yaml")
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("expected %s to exist (%s flux file): %v", path, name, err)
+		}
+		if !contains(written, path) {
+			t.Errorf("written paths missing %s: %v", path, written)
+		}
+	}
+
+	// Spot-check beta's content.
+	betaSlug := mold.FluxFileSlug(refs["beta"])
+	b, _ := os.ReadFile(filepath.Join(".ailloy", "flux", betaSlug+".yaml"))
+	if !strings.Contains(string(b), "claude") || !strings.Contains(string(b), "noon") {
+		t.Errorf("beta flux file missing expected content:\n%s", b)
+	}
+}
+
+func TestPersistFoundryOverridesSessionIsNoOp(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+	written, err := persistFoundryOverrides(
+		SaveTargetSession,
+		map[string][]mold.FluxVar{"alpha": {{Name: "k", Type: "string"}}},
+		map[string]string{"alpha": "ref"},
+		map[string]any{"k": "v"},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if len(written) != 0 {
+		t.Errorf("session save wrote files: %v", written)
+	}
+}
+
+func contains(ss []string, s string) bool {
+	for _, x := range ss {
+		if x == s {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/tui/foundries/fluxpicker/view.go
+++ b/internal/tui/foundries/fluxpicker/view.go
@@ -28,8 +28,12 @@ func (m Model) View() string {
 		return ""
 	}
 	var b strings.Builder
+	headerLabel := "Flux: " + m.moldRef
+	if m.IsFoundryMode() {
+		headerLabel = "Foundry: " + m.foundryName
+	}
 	fmt.Fprintf(&b, "%s — %s\n\n",
-		headerStyle.Render("Flux: "+m.moldRef),
+		headerStyle.Render(headerLabel),
 		strings.ToLower(string(m.scope)))
 
 	b.WriteString(m.filter.View())
@@ -61,6 +65,11 @@ func (m Model) View() string {
 			line = highlight.Render("▸ " + line)
 		} else {
 			line = "  " + row.Render(line)
+		}
+		if m.IsFoundryMode() {
+			if _, conflict := m.schemaConflicts[fv.Name]; conflict {
+				line += "  ⚠ conflicts — expand to set per mold"
+			}
 		}
 		b.WriteString(line)
 		b.WriteString("\n")

--- a/internal/tui/foundries/fluxpicker/view_test.go
+++ b/internal/tui/foundries/fluxpicker/view_test.go
@@ -71,3 +71,22 @@ type _e struct{}
 func (_e) Error() string { return "boom" }
 
 var errSentinel = _e{}
+
+func TestViewFoundryModeShowsConflictMarker(t *testing.T) {
+	per := map[string][]mold.FluxVar{
+		"alpha": {{Name: "theme", Type: "string", Default: "dark"}},
+		"beta":  {{Name: "theme", Type: "string", Default: "light"}},
+	}
+	m := New().OpenForFoundry("brand", data.ScopeProject, per, nil)
+	out := m.View()
+
+	if !strings.Contains(out, "Foundry: brand") {
+		t.Errorf("expected foundry header, got:\n%s", out)
+	}
+	if !strings.Contains(out, "theme") {
+		t.Errorf("expected theme row, got:\n%s", out)
+	}
+	if !strings.Contains(out, "conflicts") {
+		t.Errorf("expected conflict marker for theme, got:\n%s", out)
+	}
+}

--- a/internal/tui/foundries/registered/model.go
+++ b/internal/tui/foundries/registered/model.go
@@ -268,6 +268,11 @@ func (m Model) removeCmd(urlOrName string) tea.Cmd {
 	}
 }
 
+// SetCursorForTest sets the cursor index. Exported only because cross-package
+// tests in the foundries app package need to position the cursor without
+// simulating key events.
+func (m *Model) SetCursorForTest(i int) { m.cursor = i }
+
 // CurrentMold returns ok=false; the foundries tab has no per-mold context.
 func (m Model) CurrentMold() (ref string, scope data.Scope, ok bool) {
 	return "", "", false

--- a/internal/tui/foundries/registered/model.go
+++ b/internal/tui/foundries/registered/model.go
@@ -3,6 +3,7 @@ package registered
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -56,7 +57,11 @@ type InstallReport struct {
 type AddFn func(cfg *index.Config, url string) (AddFoundryResult, error)
 type RemoveFn func(cfg *index.Config, nameOrURL string) (index.FoundryEntry, error)
 type UpdateFn func(cfg *index.Config) ([]UpdateFoundryReport, error)
-type InstallFn func(cfg *index.Config, nameOrURL string) ([]InstallReport, error)
+
+// InstallFn casts every mold listed by a foundry, optionally with per-mold
+// --set overrides. perMoldOverrides is keyed by mold name → encoded --set
+// strings (k=v form, with YAML flow sequences for slices).
+type InstallFn func(cfg *index.Config, nameOrURL string, perMoldOverrides map[string][]string) ([]InstallReport, error)
 
 // ErrCannotRemoveDefault must be returned by RemoveFn when the user tries
 // to remove the virtual official foundry.
@@ -64,15 +69,16 @@ var ErrCannotRemoveDefault = errors.New("cannot remove the default verified foun
 
 // Model is the Foundries tab.
 type Model struct {
-	cfg     *index.Config
-	add     AddFn
-	remove  RemoveFn
-	update  UpdateFn
-	install InstallFn
-	cursor  int
-	addMode bool
-	addInp  textinput.Model
-	flash   string
+	cfg            *index.Config
+	add            AddFn
+	remove         RemoveFn
+	update         UpdateFn
+	install        InstallFn
+	cursor         int
+	addMode        bool
+	addInp         textinput.Model
+	flash          string
+	pendingFoundry map[string]map[string][]string // foundryName → moldName → encoded --set strings
 }
 
 type updateDoneMsg struct {
@@ -216,11 +222,12 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 func (m Model) installCmd(name string) tea.Cmd {
 	install := m.install
 	cfg := m.cfg
+	pending := m.pendingFoundry[name] // captured at Cmd build time
 	return func() tea.Msg {
 		if install == nil {
 			return installDoneMsg{name: name, err: fmt.Errorf("no install function configured")}
 		}
-		reports, err := install(cfg, name)
+		reports, err := install(cfg, name, pending)
 		return installDoneMsg{name: name, reports: reports, err: err}
 	}
 }
@@ -264,6 +271,58 @@ func (m Model) removeCmd(urlOrName string) tea.Cmd {
 // CurrentMold returns ok=false; the foundries tab has no per-mold context.
 func (m Model) CurrentMold() (ref string, scope data.Scope, ok bool) {
 	return "", "", false
+}
+
+// CurrentFoundry returns the name and scope of the highlighted foundry.
+// Scope is always project for foundry-scope ops; the picker's project/global
+// save target is independent.
+func (m Model) CurrentFoundry() (name string, scope data.Scope, ok bool) {
+	eff := m.cfg.EffectiveFoundries()
+	if m.cursor < 0 || m.cursor >= len(eff) {
+		return "", "", false
+	}
+	return eff[m.cursor].Name, data.ScopeProject, true
+}
+
+// ApplyFoundrySessionOverrides records pending --set overrides for each mold
+// in the named foundry. The next bulk install consumes them.
+func (m Model) ApplyFoundrySessionOverrides(foundryName string, perMold map[string]map[string]any) Model {
+	if m.pendingFoundry == nil {
+		m.pendingFoundry = map[string]map[string][]string{}
+	}
+	encoded := map[string][]string{}
+	for moldName, kv := range perMold {
+		encoded[moldName] = encodeSetOverrides(kv)
+	}
+	m.pendingFoundry[foundryName] = encoded
+	return m
+}
+
+// encodeSetOverrides mirrors the discover-tab encoder. Slices emit as YAML
+// flow sequences ([a,b,c]) so the cast core's --set parser produces real
+// lists. Result is sorted for deterministic ordering.
+func encodeSetOverrides(overrides map[string]any) []string {
+	out := make([]string, 0, len(overrides))
+	for k, v := range overrides {
+		out = append(out, fmt.Sprintf("%s=%s", k, formatSetValue(v)))
+	}
+	sort.Strings(out)
+	return out
+}
+
+func formatSetValue(v any) string {
+	switch x := v.(type) {
+	case []string:
+		return "[" + strings.Join(x, ",") + "]"
+	case []any:
+		parts := make([]string, 0, len(x))
+		for _, e := range x {
+			parts = append(parts, fmt.Sprint(e))
+		}
+		return "[" + strings.Join(parts, ",") + "]"
+	default:
+		return fmt.Sprint(v)
+	}
 }
 
 func (m Model) View() string {

--- a/internal/tui/foundries/registered/model_test.go
+++ b/internal/tui/foundries/registered/model_test.go
@@ -1,0 +1,77 @@
+package registered
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/nimble-giant/ailloy/internal/tui/foundries/data"
+	"github.com/nimble-giant/ailloy/pkg/foundry/index"
+)
+
+func TestCurrentFoundryReturnsHighlight(t *testing.T) {
+	cfg := &index.Config{
+		Foundries: []index.FoundryEntry{
+			{Name: "alpha", URL: "https://github.com/x/alpha"},
+			{Name: "beta", URL: "https://github.com/x/beta"},
+		},
+	}
+	m := New(cfg, nil, nil, nil, nil)
+	// EffectiveFoundries prepends the official one when not present, so we
+	// can't assume cursor 0 is "alpha". Walk the slice to find it.
+	for i, e := range cfg.EffectiveFoundries() {
+		if e.Name == "alpha" {
+			m.cursor = i
+			break
+		}
+	}
+
+	name, scope, ok := m.CurrentFoundry()
+	if !ok {
+		t.Fatalf("CurrentFoundry ok = false, want true")
+	}
+	if name != "alpha" {
+		t.Errorf("CurrentFoundry name = %q, want alpha", name)
+	}
+	if scope != data.ScopeProject {
+		t.Errorf("CurrentFoundry scope = %q, want project", scope)
+	}
+}
+
+func TestApplyFoundrySessionOverridesStoresPerMold(t *testing.T) {
+	cfg := &index.Config{}
+	m := New(cfg, nil, nil, nil, nil)
+
+	overrides := map[string]map[string]any{
+		"alpha": {"agents.targets": []any{"claude"}},
+		"beta":  {"theme": "midnight"},
+	}
+	m = m.ApplyFoundrySessionOverrides("nimble-mold", overrides)
+
+	got := m.pendingFoundry["nimble-mold"]
+	if !reflect.DeepEqual(got["alpha"], []string{"agents.targets=[claude]"}) {
+		t.Errorf("alpha pending = %v, want [agents.targets=[claude]]", got["alpha"])
+	}
+	if !reflect.DeepEqual(got["beta"], []string{"theme=midnight"}) {
+		t.Errorf("beta pending = %v, want [theme=midnight]", got["beta"])
+	}
+}
+
+func TestInstallCmdForwardsPendingOverrides(t *testing.T) {
+	cfg := &index.Config{}
+	var captured map[string][]string
+	install := func(cfg *index.Config, name string, perMold map[string][]string) ([]InstallReport, error) {
+		captured = perMold
+		return nil, nil
+	}
+	m := New(cfg, nil, nil, nil, install).
+		ApplyFoundrySessionOverrides("nimble-mold", map[string]map[string]any{
+			"alpha": {"agents.targets": []any{"claude"}},
+		})
+
+	cmd := m.installCmd("nimble-mold")
+	cmd() // run the tea.Cmd inline
+
+	if got := captured["alpha"]; !reflect.DeepEqual(got, []string{"agents.targets=[claude]"}) {
+		t.Errorf("captured alpha = %v, want [agents.targets=[claude]]", got)
+	}
+}

--- a/pkg/mold/ore_search_paths.go
+++ b/pkg/mold/ore_search_paths.go
@@ -1,0 +1,50 @@
+package mold
+
+import (
+	"io/fs"
+	"os"
+)
+
+// BuildDefaultOreSearchPaths returns the canonical ore-search-path order used
+// by the cast pipeline (and any other consumer that wants to mirror it):
+//
+//  1. mold-local — ores under the mold's own filesystem at "ores/".
+//     Highest priority; keys here shadow project/global ores of the same
+//     namespace.
+//  2. project — ores installed into the current working directory under
+//     ".ailloy/ores". Honored even when the caller is doing a global cast,
+//     because users may have project-installed ores they want to layer in.
+//     Skipped if the cwd cannot be determined.
+//  3. global — ores installed into the user's home directory under
+//     ".ailloy/ores". Lowest priority; only contributes namespaces not
+//     already provided by mold-local or project. Skipped if the home dir
+//     cannot be determined.
+//
+// Lower-priority entries only contribute ore namespaces not already seen,
+// mirroring how flux defaults are layered.
+//
+// The global flag is currently unused — it does not change the search-path
+// order. It is kept on the signature so callers can express intent and so a
+// future change (e.g. global cast skips project ores for strict isolation)
+// can land without re-threading every call site.
+func BuildDefaultOreSearchPaths(moldFS fs.FS, global bool) []OreSearchPath {
+	paths := []OreSearchPath{
+		{Name: "mold-local", FS: moldFS, Root: "ores"},
+	}
+	if cwd, err := os.Getwd(); err == nil {
+		paths = append(paths, OreSearchPath{
+			Name: "project",
+			FS:   os.DirFS(cwd),
+			Root: ".ailloy/ores",
+		})
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		paths = append(paths, OreSearchPath{
+			Name: "global",
+			FS:   os.DirFS(home),
+			Root: ".ailloy/ores",
+		})
+	}
+	_ = global // currently only affects install-dir, not search-path order
+	return paths
+}

--- a/pkg/mold/ore_search_paths_test.go
+++ b/pkg/mold/ore_search_paths_test.go
@@ -1,0 +1,78 @@
+package mold_test
+
+import (
+	"reflect"
+	"testing"
+	"testing/fstest"
+
+	"github.com/nimble-giant/ailloy/pkg/mold"
+)
+
+// TestBuildDefaultOreSearchPaths_OrderAndContent verifies the helper returns
+// the documented precedence: mold-local first, then project (if cwd
+// resolvable), then global (if home resolvable), and uses the caller-provided
+// moldFS for the mold-local entry.
+func TestBuildDefaultOreSearchPaths_OrderAndContent(t *testing.T) {
+	moldFS := fstest.MapFS{
+		"ores/example/ore.yaml": &fstest.MapFile{Data: []byte("name: example\n")},
+	}
+
+	paths := mold.BuildDefaultOreSearchPaths(moldFS, false)
+
+	if len(paths) == 0 {
+		t.Fatalf("expected at least the mold-local entry, got none")
+	}
+	if paths[0].Name != "mold-local" {
+		t.Errorf("paths[0].Name = %q, want mold-local", paths[0].Name)
+	}
+	if paths[0].Root != "ores" {
+		t.Errorf("paths[0].Root = %q, want ores", paths[0].Root)
+	}
+	// Cannot compare maps with !=; verify identity by reading a known file.
+	if _, err := paths[0].FS.Open("ores/example/ore.yaml"); err != nil {
+		t.Errorf("paths[0].FS missing caller-provided file: %v", err)
+	}
+
+	// project + global are best-effort — only assert that, when present,
+	// they appear after mold-local and use the right Root.
+	gotNames := make([]string, 0, len(paths))
+	for _, p := range paths {
+		gotNames = append(gotNames, p.Name)
+		switch p.Name {
+		case "project", "global":
+			if p.Root != ".ailloy/ores" {
+				t.Errorf("%s path Root = %q, want .ailloy/ores", p.Name, p.Root)
+			}
+		}
+	}
+	// Ensure mold-local is strictly first.
+	for i, n := range gotNames {
+		if n == "mold-local" && i != 0 {
+			t.Errorf("mold-local appears at index %d, want 0", i)
+		}
+	}
+}
+
+// TestBuildDefaultOreSearchPaths_GlobalFlagDoesNotChangeOrder pins the current
+// behavior: the global flag is reserved for future use and must not alter
+// the returned path list. If this assumption changes, update the doc comment
+// on BuildDefaultOreSearchPaths and this test together.
+func TestBuildDefaultOreSearchPaths_GlobalFlagDoesNotChangeOrder(t *testing.T) {
+	moldFS := fstest.MapFS{}
+
+	a := mold.BuildDefaultOreSearchPaths(moldFS, false)
+	b := mold.BuildDefaultOreSearchPaths(moldFS, true)
+
+	if len(a) != len(b) {
+		t.Fatalf("len differs: false=%d true=%d", len(a), len(b))
+	}
+	aNames := make([]string, len(a))
+	bNames := make([]string, len(b))
+	for i := range a {
+		aNames[i] = a[i].Name
+		bNames[i] = b[i].Name
+	}
+	if !reflect.DeepEqual(aNames, bNames) {
+		t.Errorf("path Name order differs: false=%v true=%v", aNames, bNames)
+	}
+}


### PR DESCRIPTION
## Description

Adds foundry-wide flux customization to `ailloy`:

- **CLI rename:** `foundry install` → `foundry cast` (with `install` as the only alias; `cast-all` dropped)
- **CLI flags:** `--set k=v` and `-f/--values file.yaml` on `foundry cast` apply flux overrides to every mold in the foundry, with the same Helm-style precedence as single-mold `cast`
- **CLI summary:** after a foundry cast, prints per-key apply/skip report (`agents.targets → 4/6 molds (skipped: blank-foo, blank-bar — key not in schema)`); reads each mold's schema from `flux.schema.yaml` AND inline `mold.yaml` flux
- **TUI:** pressing `f` on the Foundries tab opens a foundry-scoped flux picker that aggregates schemas across the foundry's molds (deduped union, with conflict markers for keys whose type/default differs); per-mold conflict overrides supported; save fan-out helper writes to per-mold `.ailloy/flux/<slug>.yaml` files

Save-dispatch wiring from picker save → per-mold persistence → `pendingFoundry` consumption is the next task in this series and not yet wired (the picker opens, renders, and the data plane is in place; the Save button doesn't yet trigger fan-out).

## Related Issue

N/A

## Testing

- 14 commits, all TDD (failing test → minimal impl → green)
- New unit tests cover: CLI rename shape, `--set`/`-f` plumbing, per-mold flux apply/skip (incl. inline `mold.yaml` flux), CLI summary formatter, schema aggregation (5 cases), foundry-mode picker state, per-mold conflict overrides, persistence fan-out, registered tab `CurrentFoundry` + pending overrides + install consumption, app `f`-key routing, view conflict markers
- All `go test ./...` green; `go vet`, `gofmt`, `golangci-lint`, `go test -race` pass via lefthook pre-push

## UAT

```bash
ailloy foundry cast <foundry> --set agents.targets='[claude,opencode]' --dry-run
# observe per-key apply/skip summary

ailloy foundries
# tab to Foundries, press f, observe foundry-scoped picker with conflict markers
```

## Checklist

- [x] My code follows the project style
- [x] I have added tests
- [ ] I have updated documentation (deferred to follow-up — `AGENTS.md`/README still reference `foundry install`)
- [x] My commits have DCO sign-off