### PR TITLE
feat: add cache clear command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ Key CLI commands for working with molds:
 - **recast**: Re-resolve installed molds to newer versions; refreshes `.ailloy/installed.yaml` and (if present) `ailloy.lock`
 - **quench**: Opt in to `ailloy.lock` by pinning everything in `.ailloy/installed.yaml`; supports `--verify` (CI drift check) and `--global`
 - **evolve** (`reinstall`): Self-upgrade the ailloy CLI binary in place from the latest GitHub release; supports `--check`, `--version`, `--force`, and `--no-animate`. Refuses on Homebrew installs (use `brew upgrade nimble-giant/tap/ailloy`)
+- **cache clear**: Clear ailloy's on-disk cache (mold artifacts and foundry indexes under `~/.ailloy/cache/`). Supports `--molds`, `--indexes`, `--dry-run`, `--yes`. Bidirectional: `clear cache` also works.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -241,6 +241,22 @@ Requires a TTY. See the [TUI section in the foundry guide](docs/foundry.md#inter
 </details>
 
 <details>
+<summary><strong><code>cache clear</code></strong> — clear the on-disk cache</summary>
+
+`ailloy cache clear` (also: `ailloy clear cache`) wipes the global caches
+under `~/.ailloy/cache/` — both mold artifacts and foundry indexes.
+Prints a preview (counts + size) and prompts for confirmation. In a
+non-interactive shell it refuses to run without `--yes`. See
+[`docs/cache.md`](docs/cache.md) for the full guide.
+
+- `--molds` — clear only the mold artifact cache (preserve `indexes/`)
+- `--indexes` — clear only the foundry index cache
+- `--dry-run` — preview what would be cleared without deleting
+- `-y/--yes` — skip the confirmation prompt
+
+</details>
+
+<details>
 <summary><strong><code>uninstall</code></strong> — remove a casted mold</summary>
 
 `ailloy uninstall <source>` removes the files a previous `cast` wrote.

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,3 +30,4 @@ These guides teach you how to create, package, and share your own AI workflow pa
 - [Configuration Wizard](anneal.md) — Interactive wizard for flux variable configuration
 - [Validation](temper.md) — Lint and validate mold and ingot packages
 - [Plugins](plugin.md) — Generate plugins from molds (currently Claude Code)
+- [Cache Management](cache.md) — Clear cached molds and foundry indexes

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -1,0 +1,136 @@
+# Cache Management (`ailloy cache clear`)
+
+Ailloy stores two kinds of artifacts under `~/.ailloy/cache/`:
+
+- **Mold artifacts** — bare git clones and version snapshots of every mold
+  fetched by `cast`, `forge`, `mold get`, etc.
+- **Foundry indexes** — the `foundry.yaml` files downloaded for every
+  registered foundry.
+
+`cache clear` wipes those caches when you need a clean slate — for example,
+after a corrupt fetch, when a registry has been republished, or when you
+want to reclaim disk space.
+
+> **Note:** `cache clear` only touches the global cache. It does not delete
+> project metadata (`.ailloy/installed.yaml`, `ailloy.lock`) or rendered
+> output. Use [`uninstall`](foundry.md#uninstalling-a-casted-mold) for
+> casted files.
+
+## Quick Start
+
+```bash
+# Preview what would be cleared without deleting anything
+ailloy cache clear --dry-run
+
+# Clear everything (prompts for confirmation in a TTY)
+ailloy cache clear
+
+# Skip the prompt
+ailloy cache clear --yes
+```
+
+The bidirectional verb form works too:
+
+```bash
+ailloy clear cache --dry-run
+```
+
+## Preview and Confirmation
+
+Before deleting anything, `cache clear` prints a preview of what's in the
+cache and asks for confirmation:
+
+```
+Ailloy cache:  ~/.ailloy/cache
+
+  Molds      5 refs, 9 versions  (6.6 MB)
+  Indexes    1 indexes              (32.5 KB)
+
+  Total:                            (6.6 MB)
+
+Proceed? [y/N]
+```
+
+In a non-interactive shell (CI, piped stdin, etc.), `cache clear` refuses
+to run without `--yes`:
+
+```
+Error: refusing to clear cache without --yes in non-interactive shell
+```
+
+This prevents accidental wipes from stray invocations in scripts.
+
+## Narrowing the Scope
+
+By default, both subtrees are cleared. Use one of the scope flags to clear
+only one:
+
+| Flag        | Removes                                    | Preserves                  |
+| ----------- | ------------------------------------------ | -------------------------- |
+| _(none)_    | Mold artifacts **and** foundry indexes     | Project metadata           |
+| `--molds`   | Mold artifacts only                        | `~/.ailloy/cache/indexes/` |
+| `--indexes` | Foundry indexes only                       | All mold artifacts         |
+
+`--molds` is useful when you want to force every mold to refetch on the
+next `cast` / `recast` but keep your registry data intact. `--indexes` is
+useful after a foundry has been republished — clearing the cached index
+makes the next `foundry update` fetch fresh metadata.
+
+## Dry Run
+
+`--dry-run` prints the same preview block but does **not** delete anything
+and does **not** prompt. Pair it with the scope flags to see exactly what
+each invocation would remove:
+
+```bash
+ailloy cache clear --dry-run            # preview both
+ailloy cache clear --molds --dry-run    # preview molds only
+ailloy cache clear --indexes --dry-run  # preview indexes only
+```
+
+## Result Summary
+
+After a successful clear, `cache clear` prints what it removed and how much
+space it freed:
+
+```
+Cleared 5 molds (9 versions), 1 indexes — freed 6.6 MB.
+```
+
+If a particular file or directory could not be removed (e.g., due to file
+permissions), `cache clear` continues with the rest, prints a `warning:`
+line for each failure, and exits non-zero with a final summary:
+
+```
+warning: remove /Users/me/.ailloy/cache/github.com/foo/bar: permission denied
+Cleared 4 molds (8 versions), 1 indexes — freed 6.4 MB.
+Cleared with 1 errors.
+```
+
+## CLI Reference
+
+```
+ailloy cache clear [flags]
+ailloy clear cache [flags]
+```
+
+| Flag         | Short | Description                                              |
+| ------------ | ----- | -------------------------------------------------------- |
+| `--molds`    |       | Clear only the mold artifact cache                       |
+| `--indexes`  |       | Clear only the foundry index cache                       |
+| `--dry-run`  |       | Preview what would be cleared without deleting           |
+| `--yes`      | `-y`  | Skip the confirmation prompt (required in non-TTY)       |
+
+## Common Workflows
+
+```bash
+# Force all molds to refetch on the next cast
+ailloy cache clear --molds --yes
+
+# Refresh registry metadata after a foundry has been republished
+ailloy cache clear --indexes --yes
+ailloy foundry update
+
+# See total cache footprint before deciding to clear
+ailloy cache clear --dry-run
+```

--- a/docs/clidocs.go
+++ b/docs/clidocs.go
@@ -64,6 +64,7 @@ var summaries = map[string]string{
 	"agents-md":          "Tool-agnostic agent instructions in molds",
 	"cast-claude-plugin": "Cast a mold as a Claude Code plugin",
 	"helm-users":         "Concept map for Helm users coming to Ailloy",
+	"cache":              "Clear ailloy's on-disk cache (mold artifacts and foundry indexes)",
 }
 
 // CommandTopic maps a cobra command name to the topic slug rendered when
@@ -80,6 +81,7 @@ var CommandTopic = map[string]string{
 	"assay":   "assay",
 	"plugin":  "plugin",
 	"ingot":   "ingots",
+	"cache":   "cache",
 }
 
 // FS exposes the embedded filesystem for advanced consumers (e.g. tests).

--- a/internal/commands/cache.go
+++ b/internal/commands/cache.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/nimble-giant/ailloy/pkg/foundry"
 	"github.com/spf13/cobra"
@@ -180,6 +181,28 @@ func removeIndexes(indexRoot string) error {
 		return fmt.Errorf("remove %s: %w", indexRoot, err)
 	}
 	return nil
+}
+
+func renderCachePreview(cacheRootDisplay string, molds *moldStats, idx *indexStats) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Ailloy cache:  %s\n\n", cacheRootDisplay)
+
+	var totalBytes int64
+	if molds != nil {
+		fmt.Fprintf(&b, "  Molds      %d refs, %d versions  (%s)\n",
+			molds.Refs, molds.Versions, humanizeBytes(molds.Bytes))
+		totalBytes += molds.Bytes
+	}
+	if idx != nil {
+		fmt.Fprintf(&b, "  Indexes    %d indexes              (%s)\n",
+			idx.Indexes, humanizeBytes(idx.Bytes))
+		totalBytes += idx.Bytes
+	}
+
+	if molds != nil && idx != nil {
+		fmt.Fprintf(&b, "\n  Total:                            (%s)\n", humanizeBytes(totalBytes))
+	}
+	return b.String()
 }
 
 func humanizeBytes(n int64) string {

--- a/internal/commands/cache.go
+++ b/internal/commands/cache.go
@@ -154,13 +154,11 @@ func executeCacheClear(o cacheClearOptions) (int, error) {
 	}
 
 	var (
-		removedMolds   int
 		removedIndexes int
 		errs           []error
 	)
 	if wantMolds {
-		n, e := removeMolds(o.MoldRoot)
-		removedMolds = n
+		_, e := removeMolds(o.MoldRoot)
 		errs = append(errs, e...)
 	}
 	if wantIndexes && idx != nil {
@@ -184,19 +182,23 @@ func executeCacheClear(o cacheClearOptions) (int, error) {
 
 	switch {
 	case wantMolds && wantIndexes:
-		var versions int
+		refs := 0
+		versions := 0
 		if molds != nil {
+			refs = molds.Refs
 			versions = molds.Versions
 		}
 		fmt.Fprintf(o.Stdout, "Cleared %d molds (%d versions), %d indexes — freed %s.\n",
-			removedMolds, versions, removedIndexes, humanizeBytes(freed))
+			refs, versions, removedIndexes, humanizeBytes(freed))
 	case wantMolds:
-		var versions int
+		refs := 0
+		versions := 0
 		if molds != nil {
+			refs = molds.Refs
 			versions = molds.Versions
 		}
 		fmt.Fprintf(o.Stdout, "Cleared %d molds (%d versions) — freed %s.\n",
-			removedMolds, versions, humanizeBytes(freed))
+			refs, versions, humanizeBytes(freed))
 	case wantIndexes:
 		fmt.Fprintf(o.Stdout, "Cleared %d indexes — freed %s.\n",
 			removedIndexes, humanizeBytes(freed))
@@ -247,8 +249,11 @@ func gatherMoldStats(moldRoot, indexRoot string) (moldStats, error) {
 	if err != nil {
 		return stats, err
 	}
-	stats.Refs = len(entries)
 	for _, e := range entries {
+		if e.Host == "indexes" {
+			continue
+		}
+		stats.Refs++
 		stats.Versions += len(e.Versions)
 	}
 

--- a/internal/commands/cache.go
+++ b/internal/commands/cache.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
@@ -49,4 +51,22 @@ func registerCacheClearFlags(cmd *cobra.Command) {
 func runCacheClear(cmd *cobra.Command, _ []string) error {
 	// Implemented in Task 9.
 	return nil
+}
+
+func humanizeBytes(n int64) string {
+	const (
+		kb = 1024
+		mb = 1024 * kb
+		gb = 1024 * mb
+	)
+	switch {
+	case n >= gb:
+		return fmt.Sprintf("%.1f GB", float64(n)/float64(gb))
+	case n >= mb:
+		return fmt.Sprintf("%.1f MB", float64(n)/float64(mb))
+	case n >= kb:
+		return fmt.Sprintf("%.1f KB", float64(n)/float64(kb))
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
 }

--- a/internal/commands/cache.go
+++ b/internal/commands/cache.go
@@ -11,7 +11,9 @@ import (
 	"strings"
 
 	"github.com/nimble-giant/ailloy/pkg/foundry"
+	"github.com/nimble-giant/ailloy/pkg/foundry/index"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 var (
@@ -38,8 +40,10 @@ var cacheClearCmd = &cobra.Command{
 By default, clears both mold artifacts and foundry indexes under ~/.ailloy/cache.
 Use --molds or --indexes to narrow the scope. Use --dry-run to preview without
 deleting. Use --yes to skip the confirmation prompt.`,
-	Args: cobra.NoArgs,
-	RunE: runCacheClear,
+	Args:          cobra.NoArgs,
+	RunE:          runCacheClear,
+	SilenceErrors: true,
+	SilenceUsage:  true,
 }
 
 func init() {
@@ -57,8 +61,170 @@ func registerCacheClearFlags(cmd *cobra.Command) {
 }
 
 func runCacheClear(cmd *cobra.Command, _ []string) error {
-	// Implemented in Task 9.
+	moldRoot, err := foundry.CacheDir()
+	if err != nil {
+		return err
+	}
+	indexRoot, err := index.IndexCacheDir()
+	if err != nil {
+		return err
+	}
+	exit, runErr := executeCacheClear(cacheClearOptions{
+		MoldRoot:  moldRoot,
+		IndexRoot: indexRoot,
+		Molds:     cacheClearMolds,
+		Indexes:   cacheClearIndexes,
+		DryRun:    cacheClearDryRun,
+		Yes:       cacheClearYes,
+		Stdout:    cmd.OutOrStdout(),
+		Stdin:     cmd.InOrStdin(),
+		IsTTY:     stdinIsTTY,
+	})
+	if runErr != nil {
+		return runErr
+	}
+	if exit != 0 {
+		return fmt.Errorf("cache clear exited with status %d", exit)
+	}
 	return nil
+}
+
+type cacheClearOptions struct {
+	MoldRoot  string
+	IndexRoot string
+
+	Molds   bool
+	Indexes bool
+	DryRun  bool
+	Yes     bool
+
+	Stdout io.Writer
+	Stdin  io.Reader
+	IsTTY  func() bool
+}
+
+func executeCacheClear(o cacheClearOptions) (int, error) {
+	wantMolds, wantIndexes := o.Molds, o.Indexes
+	if !wantMolds && !wantIndexes {
+		wantMolds, wantIndexes = true, true
+	}
+
+	var (
+		molds *moldStats
+		idx   *indexStats
+	)
+	if wantMolds {
+		s, err := gatherMoldStats(o.MoldRoot, o.IndexRoot)
+		if err != nil {
+			return 1, fmt.Errorf("gather mold stats: %w", err)
+		}
+		molds = &s
+	}
+	if wantIndexes {
+		s, err := gatherIndexStats(o.IndexRoot)
+		if err != nil {
+			return 1, fmt.Errorf("gather index stats: %w", err)
+		}
+		idx = &s
+	}
+
+	if isEmptySelection(molds, idx) {
+		fmt.Fprintln(o.Stdout, "Cache is already empty.")
+		return 0, nil
+	}
+
+	fmt.Fprint(o.Stdout, renderCachePreview(displayPath(o.MoldRoot), molds, idx))
+
+	if o.DryRun {
+		return 0, nil
+	}
+
+	if !o.Yes {
+		if !o.IsTTY() {
+			return 1, fmt.Errorf("refusing to clear cache without --yes in non-interactive shell")
+		}
+		ok, err := confirmInteractive(o.Stdin, o.Stdout, "\nProceed? [y/N] ")
+		if err != nil {
+			return 1, err
+		}
+		if !ok {
+			fmt.Fprintln(o.Stdout, "Cancelled.")
+			return 0, nil
+		}
+	}
+
+	var (
+		removedMolds   int
+		removedIndexes int
+		errs           []error
+	)
+	if wantMolds {
+		n, e := removeMolds(o.MoldRoot)
+		removedMolds = n
+		errs = append(errs, e...)
+	}
+	if wantIndexes && idx != nil {
+		removedIndexes = idx.Indexes
+		if err := removeIndexes(o.IndexRoot); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	for _, e := range errs {
+		fmt.Fprintf(o.Stdout, "warning: %s\n", e.Error())
+	}
+
+	freed := int64(0)
+	if molds != nil {
+		freed += molds.Bytes
+	}
+	if idx != nil {
+		freed += idx.Bytes
+	}
+
+	switch {
+	case wantMolds && wantIndexes:
+		var versions int
+		if molds != nil {
+			versions = molds.Versions
+		}
+		fmt.Fprintf(o.Stdout, "Cleared %d molds (%d versions), %d indexes — freed %s.\n",
+			removedMolds, versions, removedIndexes, humanizeBytes(freed))
+	case wantMolds:
+		var versions int
+		if molds != nil {
+			versions = molds.Versions
+		}
+		fmt.Fprintf(o.Stdout, "Cleared %d molds (%d versions) — freed %s.\n",
+			removedMolds, versions, humanizeBytes(freed))
+	case wantIndexes:
+		fmt.Fprintf(o.Stdout, "Cleared %d indexes — freed %s.\n",
+			removedIndexes, humanizeBytes(freed))
+	}
+
+	if len(errs) > 0 {
+		fmt.Fprintf(o.Stdout, "Cleared with %d errors.\n", len(errs))
+		return 1, nil
+	}
+	return 0, nil
+}
+
+func isEmptySelection(molds *moldStats, idx *indexStats) bool {
+	moldsEmpty := molds == nil || (molds.Refs == 0 && molds.Bytes == 0)
+	idxEmpty := idx == nil || (idx.Indexes == 0 && idx.Bytes == 0)
+	return moldsEmpty && idxEmpty
+}
+
+func displayPath(p string) string {
+	home, err := os.UserHomeDir()
+	if err == nil && home != "" && strings.HasPrefix(p, home) {
+		return "~" + strings.TrimPrefix(p, home)
+	}
+	return p
+}
+
+func stdinIsTTY() bool {
+	return term.IsTerminal(int(os.Stdin.Fd()))
 }
 
 type moldStats struct {

--- a/internal/commands/cache.go
+++ b/internal/commands/cache.go
@@ -75,7 +75,10 @@ func gatherMoldStats(moldRoot, indexRoot string) (moldStats, error) {
 		stats.Versions += len(e.Versions)
 	}
 
-	indexAbs, _ := filepath.Abs(indexRoot)
+	indexAbs, err := filepath.Abs(indexRoot)
+	if err != nil {
+		return stats, fmt.Errorf("resolving index root: %w", err)
+	}
 
 	walkErr := filepath.WalkDir(moldRoot, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -85,7 +88,10 @@ func gatherMoldStats(moldRoot, indexRoot string) (moldStats, error) {
 			return err
 		}
 		if d.IsDir() {
-			abs, _ := filepath.Abs(path)
+			abs, absErr := filepath.Abs(path)
+			if absErr != nil {
+				return absErr
+			}
 			if abs == indexAbs {
 				return fs.SkipDir
 			}

--- a/internal/commands/cache.go
+++ b/internal/commands/cache.go
@@ -1,0 +1,52 @@
+package commands
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var (
+	cacheClearMolds   bool
+	cacheClearIndexes bool
+	cacheClearDryRun  bool
+	cacheClearYes     bool
+)
+
+var cacheCmd = &cobra.Command{
+	Use:   "cache",
+	Short: "Manage ailloy's on-disk cache",
+	Long: `Manage ailloy's on-disk cache.
+
+Available subcommands:
+  clear      Clear cached mold artifacts and foundry indexes`,
+}
+
+var cacheClearCmd = &cobra.Command{
+	Use:   "clear",
+	Short: "Clear ailloy's on-disk cache",
+	Long: `Clear ailloy's on-disk cache.
+
+By default, clears both mold artifacts and foundry indexes under ~/.ailloy/cache.
+Use --molds or --indexes to narrow the scope. Use --dry-run to preview without
+deleting. Use --yes to skip the confirmation prompt.`,
+	Args: cobra.NoArgs,
+	RunE: runCacheClear,
+}
+
+func init() {
+	rootCmd.AddCommand(cacheCmd)
+	cacheCmd.AddCommand(cacheClearCmd)
+
+	registerCacheClearFlags(cacheClearCmd)
+}
+
+func registerCacheClearFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&cacheClearMolds, "molds", false, "clear only the mold artifact cache")
+	cmd.Flags().BoolVar(&cacheClearIndexes, "indexes", false, "clear only the foundry index cache")
+	cmd.Flags().BoolVar(&cacheClearDryRun, "dry-run", false, "preview what would be cleared without deleting")
+	cmd.Flags().BoolVarP(&cacheClearYes, "yes", "y", false, "skip the confirmation prompt")
+}
+
+func runCacheClear(cmd *cobra.Command, _ []string) error {
+	// Implemented in Task 9.
+	return nil
+}

--- a/internal/commands/cache.go
+++ b/internal/commands/cache.go
@@ -84,7 +84,7 @@ func runCacheClear(cmd *cobra.Command, _ []string) error {
 		return runErr
 	}
 	if exit != 0 {
-		return fmt.Errorf("cache clear exited with status %d", exit)
+		return fmt.Errorf("cache clear completed with errors")
 	}
 	return nil
 }
@@ -217,7 +217,14 @@ func isEmptySelection(molds *moldStats, idx *indexStats) bool {
 
 func displayPath(p string) string {
 	home, err := os.UserHomeDir()
-	if err == nil && home != "" && strings.HasPrefix(p, home) {
+	if err != nil || home == "" {
+		return p
+	}
+	if p == home {
+		return "~"
+	}
+	sep := string(os.PathSeparator)
+	if strings.HasPrefix(p, home+sep) {
 		return "~" + strings.TrimPrefix(p, home)
 	}
 	return p

--- a/internal/commands/cache.go
+++ b/internal/commands/cache.go
@@ -1,8 +1,12 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
+	"path/filepath"
 
+	"github.com/nimble-giant/ailloy/pkg/foundry"
 	"github.com/spf13/cobra"
 )
 
@@ -51,6 +55,53 @@ func registerCacheClearFlags(cmd *cobra.Command) {
 func runCacheClear(cmd *cobra.Command, _ []string) error {
 	// Implemented in Task 9.
 	return nil
+}
+
+type moldStats struct {
+	Refs     int
+	Versions int
+	Bytes    int64
+}
+
+func gatherMoldStats(moldRoot, indexRoot string) (moldStats, error) {
+	var stats moldStats
+
+	entries, err := foundry.ListCachedMolds(moldRoot)
+	if err != nil {
+		return stats, err
+	}
+	stats.Refs = len(entries)
+	for _, e := range entries {
+		stats.Versions += len(e.Versions)
+	}
+
+	indexAbs, _ := filepath.Abs(indexRoot)
+
+	walkErr := filepath.WalkDir(moldRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return nil
+			}
+			return err
+		}
+		if d.IsDir() {
+			abs, _ := filepath.Abs(path)
+			if abs == indexAbs {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		info, ierr := d.Info()
+		if ierr != nil {
+			return ierr
+		}
+		stats.Bytes += info.Size()
+		return nil
+	})
+	if walkErr != nil && !errors.Is(walkErr, fs.ErrNotExist) {
+		return stats, walkErr
+	}
+	return stats, nil
 }
 
 func humanizeBytes(n int64) string {

--- a/internal/commands/cache.go
+++ b/internal/commands/cache.go
@@ -175,6 +175,13 @@ func removeMolds(moldRoot string) (int, []error) {
 	return removed, errs
 }
 
+func removeIndexes(indexRoot string) error {
+	if err := os.RemoveAll(indexRoot); err != nil {
+		return fmt.Errorf("remove %s: %w", indexRoot, err)
+	}
+	return nil
+}
+
 func humanizeBytes(n int64) string {
 	const (
 		kb = 1024

--- a/internal/commands/cache.go
+++ b/internal/commands/cache.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"os"
 	"path/filepath"
 
 	"github.com/nimble-giant/ailloy/pkg/foundry"
@@ -94,6 +95,44 @@ func gatherMoldStats(moldRoot, indexRoot string) (moldStats, error) {
 			}
 			if abs == indexAbs {
 				return fs.SkipDir
+			}
+			return nil
+		}
+		info, ierr := d.Info()
+		if ierr != nil {
+			return ierr
+		}
+		stats.Bytes += info.Size()
+		return nil
+	})
+	if walkErr != nil && !errors.Is(walkErr, fs.ErrNotExist) {
+		return stats, walkErr
+	}
+	return stats, nil
+}
+
+type indexStats struct {
+	Indexes int
+	Bytes   int64
+}
+
+func gatherIndexStats(indexRoot string) (indexStats, error) {
+	var stats indexStats
+
+	if _, err := os.Stat(indexRoot); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return stats, nil
+		}
+		return stats, err
+	}
+
+	walkErr := filepath.WalkDir(indexRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if _, statErr := os.Stat(filepath.Join(path, "foundry.yaml")); statErr == nil {
+				stats.Indexes++
 			}
 			return nil
 		}

--- a/internal/commands/cache.go
+++ b/internal/commands/cache.go
@@ -1,8 +1,10 @@
 package commands
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -203,6 +205,19 @@ func renderCachePreview(cacheRootDisplay string, molds *moldStats, idx *indexSta
 		fmt.Fprintf(&b, "\n  Total:                            (%s)\n", humanizeBytes(totalBytes))
 	}
 	return b.String()
+}
+
+func confirmInteractive(in io.Reader, out io.Writer, prompt string) (bool, error) {
+	if _, err := fmt.Fprint(out, prompt); err != nil {
+		return false, err
+	}
+	r := bufio.NewReader(in)
+	line, err := r.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return false, err
+	}
+	resp := strings.ToLower(strings.TrimSpace(line))
+	return resp == "y" || resp == "yes", nil
 }
 
 func humanizeBytes(n int64) string {

--- a/internal/commands/cache.go
+++ b/internal/commands/cache.go
@@ -149,6 +149,32 @@ func gatherIndexStats(indexRoot string) (indexStats, error) {
 	return stats, nil
 }
 
+func removeMolds(moldRoot string) (int, []error) {
+	entries, err := os.ReadDir(moldRoot)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return 0, nil
+		}
+		return 0, []error{err}
+	}
+	var (
+		removed int
+		errs    []error
+	)
+	for _, e := range entries {
+		if e.Name() == "indexes" {
+			continue
+		}
+		p := filepath.Join(moldRoot, e.Name())
+		if rmErr := os.RemoveAll(p); rmErr != nil {
+			errs = append(errs, fmt.Errorf("remove %s: %w", p, rmErr))
+			continue
+		}
+		removed++
+	}
+	return removed, errs
+}
+
 func humanizeBytes(n int64) string {
 	const (
 		kb = 1024

--- a/internal/commands/cache.go
+++ b/internal/commands/cache.go
@@ -129,11 +129,11 @@ func executeCacheClear(o cacheClearOptions) (int, error) {
 	}
 
 	if isEmptySelection(molds, idx) {
-		fmt.Fprintln(o.Stdout, "Cache is already empty.")
+		_, _ = fmt.Fprintln(o.Stdout, "Cache is already empty.")
 		return 0, nil
 	}
 
-	fmt.Fprint(o.Stdout, renderCachePreview(displayPath(o.MoldRoot), molds, idx))
+	_, _ = fmt.Fprint(o.Stdout, renderCachePreview(displayPath(o.MoldRoot), molds, idx))
 
 	if o.DryRun {
 		return 0, nil
@@ -148,7 +148,7 @@ func executeCacheClear(o cacheClearOptions) (int, error) {
 			return 1, err
 		}
 		if !ok {
-			fmt.Fprintln(o.Stdout, "Cancelled.")
+			_, _ = fmt.Fprintln(o.Stdout, "Cancelled.")
 			return 0, nil
 		}
 	}
@@ -169,7 +169,7 @@ func executeCacheClear(o cacheClearOptions) (int, error) {
 	}
 
 	for _, e := range errs {
-		fmt.Fprintf(o.Stdout, "warning: %s\n", e.Error())
+		_, _ = fmt.Fprintf(o.Stdout, "warning: %s\n", e.Error())
 	}
 
 	freed := int64(0)
@@ -188,7 +188,7 @@ func executeCacheClear(o cacheClearOptions) (int, error) {
 			refs = molds.Refs
 			versions = molds.Versions
 		}
-		fmt.Fprintf(o.Stdout, "Cleared %d molds (%d versions), %d indexes — freed %s.\n",
+		_, _ = fmt.Fprintf(o.Stdout, "Cleared %d molds (%d versions), %d indexes — freed %s.\n",
 			refs, versions, removedIndexes, humanizeBytes(freed))
 	case wantMolds:
 		refs := 0
@@ -197,15 +197,15 @@ func executeCacheClear(o cacheClearOptions) (int, error) {
 			refs = molds.Refs
 			versions = molds.Versions
 		}
-		fmt.Fprintf(o.Stdout, "Cleared %d molds (%d versions) — freed %s.\n",
+		_, _ = fmt.Fprintf(o.Stdout, "Cleared %d molds (%d versions) — freed %s.\n",
 			refs, versions, humanizeBytes(freed))
 	case wantIndexes:
-		fmt.Fprintf(o.Stdout, "Cleared %d indexes — freed %s.\n",
+		_, _ = fmt.Fprintf(o.Stdout, "Cleared %d indexes — freed %s.\n",
 			removedIndexes, humanizeBytes(freed))
 	}
 
 	if len(errs) > 0 {
-		fmt.Fprintf(o.Stdout, "Cleared with %d errors.\n", len(errs))
+		_, _ = fmt.Fprintf(o.Stdout, "Cleared with %d errors.\n", len(errs))
 		return 1, nil
 	}
 	return 0, nil

--- a/internal/commands/cache_test.go
+++ b/internal/commands/cache_test.go
@@ -1,0 +1,24 @@
+package commands
+
+import "testing"
+
+func TestHumanizeBytes(t *testing.T) {
+	cases := []struct {
+		in   int64
+		want string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1024, "1.0 KB"},
+		{1536, "1.5 KB"},
+		{1048576, "1.0 MB"},
+		{1572864, "1.5 MB"},
+		{1073741824, "1.0 GB"},
+	}
+	for _, tc := range cases {
+		got := humanizeBytes(tc.in)
+		if got != tc.want {
+			t.Errorf("humanizeBytes(%d) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/commands/cache_test.go
+++ b/internal/commands/cache_test.go
@@ -98,6 +98,44 @@ func TestGatherIndexStatsCounts(t *testing.T) {
 	}
 }
 
+func TestRemoveMoldsPreservesIndexes(t *testing.T) {
+	root := t.TempDir()
+	mustMkdirAll(t, filepath.Join(root, "github.com", "foo", "bar", "v1"))
+	mustWriteFile(t, filepath.Join(root, "github.com", "foo", "bar", "v1", "x"), []byte("x"))
+	mustMkdirAll(t, filepath.Join(root, "gitlab.com", "baz", "qux", "v1"))
+	mustWriteFile(t, filepath.Join(root, "gitlab.com", "baz", "qux", "v1", "y"), []byte("y"))
+	mustMkdirAll(t, filepath.Join(root, "indexes", "github.com", "alice", "molds"))
+	mustWriteFile(t, filepath.Join(root, "indexes", "github.com", "alice", "molds", "foundry.yaml"), []byte("z"))
+
+	removed, errs := removeMolds(root)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if removed != 2 {
+		t.Errorf("removed = %d, want 2 (top-level non-indexes entries)", removed)
+	}
+	if _, err := os.Stat(filepath.Join(root, "github.com")); !os.IsNotExist(err) {
+		t.Errorf("github.com should have been removed, err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "gitlab.com")); !os.IsNotExist(err) {
+		t.Errorf("gitlab.com should have been removed, err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "indexes", "github.com", "alice", "molds", "foundry.yaml")); err != nil {
+		t.Errorf("indexes/ should have been preserved, err = %v", err)
+	}
+}
+
+func TestRemoveMoldsMissingDirIsOK(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "nope")
+	removed, errs := removeMolds(missing)
+	if len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+	if removed != 0 {
+		t.Errorf("removed = %d, want 0", removed)
+	}
+}
+
 func mustMkdirAll(t *testing.T, p string) {
 	t.Helper()
 	if err := os.MkdirAll(p, 0o755); err != nil {

--- a/internal/commands/cache_test.go
+++ b/internal/commands/cache_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -153,6 +154,57 @@ func TestRemoveIndexesMissingDirIsOK(t *testing.T) {
 	missing := filepath.Join(t.TempDir(), "nope")
 	if err := removeIndexes(missing); err != nil {
 		t.Errorf("expected nil, got %v", err)
+	}
+}
+
+func TestRenderCachePreviewBoth(t *testing.T) {
+	out := renderCachePreview(
+		"~/.ailloy/cache",
+		&moldStats{Refs: 12, Versions: 47, Bytes: 327600000}, // ~312.4 MB
+		&indexStats{Indexes: 3, Bytes: 1258291},              // ~1.2 MB
+	)
+	for _, want := range []string{
+		"Ailloy cache:",
+		"~/.ailloy/cache",
+		"Molds",
+		"12 refs, 47 versions",
+		"312.4 MB",
+		"Indexes",
+		"3 indexes",
+		"1.2 MB",
+		"Total:",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("preview missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderCachePreviewMoldsOnly(t *testing.T) {
+	out := renderCachePreview(
+		"~/.ailloy/cache",
+		&moldStats{Refs: 1, Versions: 1, Bytes: 100},
+		nil,
+	)
+	if strings.Contains(out, "Indexes") {
+		t.Errorf("expected no Indexes row, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Molds") {
+		t.Errorf("expected Molds row, got:\n%s", out)
+	}
+}
+
+func TestRenderCachePreviewIndexesOnly(t *testing.T) {
+	out := renderCachePreview(
+		"~/.ailloy/cache",
+		nil,
+		&indexStats{Indexes: 1, Bytes: 100},
+	)
+	if strings.Contains(out, "Molds") {
+		t.Errorf("expected no Molds row, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Indexes") {
+		t.Errorf("expected Indexes row, got:\n%s", out)
 	}
 }
 

--- a/internal/commands/cache_test.go
+++ b/internal/commands/cache_test.go
@@ -136,6 +136,26 @@ func TestRemoveMoldsMissingDirIsOK(t *testing.T) {
 	}
 }
 
+func TestRemoveIndexes(t *testing.T) {
+	root := t.TempDir()
+	mustMkdirAll(t, filepath.Join(root, "github.com", "alice", "molds"))
+	mustWriteFile(t, filepath.Join(root, "github.com", "alice", "molds", "foundry.yaml"), []byte("z"))
+
+	if err := removeIndexes(root); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := os.Stat(root); !os.IsNotExist(err) {
+		t.Errorf("indexRoot should have been removed, err = %v", err)
+	}
+}
+
+func TestRemoveIndexesMissingDirIsOK(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "nope")
+	if err := removeIndexes(missing); err != nil {
+		t.Errorf("expected nil, got %v", err)
+	}
+}
+
 func mustMkdirAll(t *testing.T, p string) {
 	t.Helper()
 	if err := os.MkdirAll(p, 0o755); err != nil {

--- a/internal/commands/cache_test.go
+++ b/internal/commands/cache_test.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -205,6 +207,46 @@ func TestRenderCachePreviewIndexesOnly(t *testing.T) {
 	}
 	if !strings.Contains(out, "Indexes") {
 		t.Errorf("expected Indexes row, got:\n%s", out)
+	}
+}
+
+func TestConfirmInteractiveYes(t *testing.T) {
+	for _, in := range []string{"y\n", "Y\n", "yes\n"} {
+		var out bytes.Buffer
+		ok, err := confirmInteractive(strings.NewReader(in), &out, "Proceed? [y/N] ")
+		if err != nil {
+			t.Errorf("input %q: unexpected error %v", in, err)
+		}
+		if !ok {
+			t.Errorf("input %q: expected ok=true", in)
+		}
+		if !strings.Contains(out.String(), "Proceed?") {
+			t.Errorf("input %q: prompt not written, got %q", in, out.String())
+		}
+	}
+}
+
+func TestConfirmInteractiveNo(t *testing.T) {
+	for _, in := range []string{"n\n", "no\n", "\n", "anything\n"} {
+		var out bytes.Buffer
+		ok, err := confirmInteractive(strings.NewReader(in), &out, "Proceed? ")
+		if err != nil {
+			t.Errorf("input %q: unexpected error %v", in, err)
+		}
+		if ok {
+			t.Errorf("input %q: expected ok=false", in)
+		}
+	}
+}
+
+func TestConfirmInteractiveEOF(t *testing.T) {
+	var out bytes.Buffer
+	ok, err := confirmInteractive(strings.NewReader(""), &out, "Proceed? ")
+	if err != nil && err != io.EOF {
+		t.Errorf("expected nil or EOF, got %v", err)
+	}
+	if ok {
+		t.Errorf("expected ok=false on EOF")
 	}
 }
 

--- a/internal/commands/cache_test.go
+++ b/internal/commands/cache_test.go
@@ -379,6 +379,9 @@ func TestExecuteCacheClearNonTTYNoYesErrors(t *testing.T) {
 	if err == nil {
 		t.Errorf("expected error, got nil")
 	}
+	if err != nil && !strings.Contains(err.Error(), "--yes") {
+		t.Errorf("error message should mention --yes, got: %v", err)
+	}
 	if exit != 1 {
 		t.Errorf("exit = %d, want 1", exit)
 	}

--- a/internal/commands/cache_test.go
+++ b/internal/commands/cache_test.go
@@ -250,6 +250,179 @@ func TestConfirmInteractiveEOF(t *testing.T) {
 	}
 }
 
+func newTempCacheDirs(t *testing.T) (moldRoot, indexRoot string) {
+	t.Helper()
+	moldRoot = t.TempDir()
+	indexRoot = filepath.Join(moldRoot, "indexes")
+	mustMkdirAll(t, filepath.Join(moldRoot, "github.com", "foo", "bar", "v1"))
+	mustWriteFile(t, filepath.Join(moldRoot, "github.com", "foo", "bar", "v1", "x"), []byte("xx"))
+	mustMkdirAll(t, filepath.Join(indexRoot, "github.com", "alice", "molds"))
+	mustWriteFile(t, filepath.Join(indexRoot, "github.com", "alice", "molds", "foundry.yaml"), []byte("yy"))
+	return moldRoot, indexRoot
+}
+
+func TestExecuteCacheClearEmpty(t *testing.T) {
+	moldRoot := t.TempDir()
+	indexRoot := filepath.Join(moldRoot, "indexes")
+	var out bytes.Buffer
+	exit, err := executeCacheClear(cacheClearOptions{
+		MoldRoot: moldRoot, IndexRoot: indexRoot,
+		Molds: false, Indexes: false,
+		Yes:    true,
+		Stdout: &out, Stdin: strings.NewReader(""), IsTTY: func() bool { return false },
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exit != 0 {
+		t.Errorf("exit = %d, want 0", exit)
+	}
+	if !strings.Contains(out.String(), "Cache is already empty") {
+		t.Errorf("output missing 'Cache is already empty', got:\n%s", out.String())
+	}
+}
+
+func TestExecuteCacheClearDefaultWipesBoth(t *testing.T) {
+	moldRoot, indexRoot := newTempCacheDirs(t)
+	var out bytes.Buffer
+	exit, err := executeCacheClear(cacheClearOptions{
+		MoldRoot: moldRoot, IndexRoot: indexRoot,
+		Yes:    true,
+		Stdout: &out, Stdin: strings.NewReader(""), IsTTY: func() bool { return false },
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exit != 0 {
+		t.Errorf("exit = %d, want 0", exit)
+	}
+	if _, err := os.Stat(filepath.Join(moldRoot, "github.com")); !os.IsNotExist(err) {
+		t.Errorf("github.com should be gone, err = %v", err)
+	}
+	if _, err := os.Stat(indexRoot); !os.IsNotExist(err) {
+		t.Errorf("indexRoot should be gone, err = %v", err)
+	}
+	if !strings.Contains(out.String(), "Cleared") {
+		t.Errorf("output missing 'Cleared', got:\n%s", out.String())
+	}
+}
+
+func TestExecuteCacheClearMoldsOnly(t *testing.T) {
+	moldRoot, indexRoot := newTempCacheDirs(t)
+	var out bytes.Buffer
+	exit, err := executeCacheClear(cacheClearOptions{
+		MoldRoot: moldRoot, IndexRoot: indexRoot,
+		Molds:  true,
+		Yes:    true,
+		Stdout: &out, Stdin: strings.NewReader(""), IsTTY: func() bool { return false },
+	})
+	if err != nil || exit != 0 {
+		t.Fatalf("exit=%d err=%v", exit, err)
+	}
+	if _, err := os.Stat(filepath.Join(moldRoot, "github.com")); !os.IsNotExist(err) {
+		t.Errorf("molds should be gone")
+	}
+	if _, err := os.Stat(filepath.Join(indexRoot, "github.com", "alice", "molds", "foundry.yaml")); err != nil {
+		t.Errorf("indexes should be preserved, err = %v", err)
+	}
+	if strings.Contains(out.String(), "Indexes") {
+		t.Errorf("output should not mention Indexes, got:\n%s", out.String())
+	}
+}
+
+func TestExecuteCacheClearIndexesOnly(t *testing.T) {
+	moldRoot, indexRoot := newTempCacheDirs(t)
+	var out bytes.Buffer
+	exit, err := executeCacheClear(cacheClearOptions{
+		MoldRoot: moldRoot, IndexRoot: indexRoot,
+		Indexes: true,
+		Yes:     true,
+		Stdout:  &out, Stdin: strings.NewReader(""), IsTTY: func() bool { return false },
+	})
+	if err != nil || exit != 0 {
+		t.Fatalf("exit=%d err=%v", exit, err)
+	}
+	if _, err := os.Stat(filepath.Join(moldRoot, "github.com", "foo", "bar", "v1", "x")); err != nil {
+		t.Errorf("molds should be preserved, err = %v", err)
+	}
+	if _, err := os.Stat(indexRoot); !os.IsNotExist(err) {
+		t.Errorf("indexRoot should be gone, err = %v", err)
+	}
+}
+
+func TestExecuteCacheClearDryRunDoesNotDelete(t *testing.T) {
+	moldRoot, indexRoot := newTempCacheDirs(t)
+	var out bytes.Buffer
+	exit, err := executeCacheClear(cacheClearOptions{
+		MoldRoot: moldRoot, IndexRoot: indexRoot,
+		DryRun: true,
+		Stdout: &out, Stdin: strings.NewReader(""), IsTTY: func() bool { return false },
+	})
+	if err != nil || exit != 0 {
+		t.Fatalf("exit=%d err=%v", exit, err)
+	}
+	if _, err := os.Stat(filepath.Join(moldRoot, "github.com", "foo", "bar", "v1", "x")); err != nil {
+		t.Errorf("molds should be preserved on dry-run")
+	}
+	if _, err := os.Stat(indexRoot); err != nil {
+		t.Errorf("indexes should be preserved on dry-run")
+	}
+}
+
+func TestExecuteCacheClearNonTTYNoYesErrors(t *testing.T) {
+	moldRoot, indexRoot := newTempCacheDirs(t)
+	var out bytes.Buffer
+	exit, err := executeCacheClear(cacheClearOptions{
+		MoldRoot: moldRoot, IndexRoot: indexRoot,
+		Stdout: &out, Stdin: strings.NewReader(""), IsTTY: func() bool { return false },
+	})
+	if err == nil {
+		t.Errorf("expected error, got nil")
+	}
+	if exit != 1 {
+		t.Errorf("exit = %d, want 1", exit)
+	}
+	if _, statErr := os.Stat(filepath.Join(moldRoot, "github.com")); statErr != nil {
+		t.Errorf("nothing should have been deleted")
+	}
+}
+
+func TestExecuteCacheClearTTYPromptDecline(t *testing.T) {
+	moldRoot, indexRoot := newTempCacheDirs(t)
+	var out bytes.Buffer
+	exit, err := executeCacheClear(cacheClearOptions{
+		MoldRoot: moldRoot, IndexRoot: indexRoot,
+		Stdout: &out, Stdin: strings.NewReader("n\n"), IsTTY: func() bool { return true },
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exit != 0 {
+		t.Errorf("exit = %d, want 0", exit)
+	}
+	if _, statErr := os.Stat(filepath.Join(moldRoot, "github.com")); statErr != nil {
+		t.Errorf("decline should preserve files")
+	}
+	if !strings.Contains(out.String(), "Cancelled") {
+		t.Errorf("output should say Cancelled, got:\n%s", out.String())
+	}
+}
+
+func TestExecuteCacheClearTTYPromptAccept(t *testing.T) {
+	moldRoot, indexRoot := newTempCacheDirs(t)
+	var out bytes.Buffer
+	exit, err := executeCacheClear(cacheClearOptions{
+		MoldRoot: moldRoot, IndexRoot: indexRoot,
+		Stdout: &out, Stdin: strings.NewReader("y\n"), IsTTY: func() bool { return true },
+	})
+	if err != nil || exit != 0 {
+		t.Fatalf("exit=%d err=%v", exit, err)
+	}
+	if _, statErr := os.Stat(filepath.Join(moldRoot, "github.com")); !os.IsNotExist(statErr) {
+		t.Errorf("accept should delete files")
+	}
+}
+
 func mustMkdirAll(t *testing.T, p string) {
 	t.Helper()
 	if err := os.MkdirAll(p, 0o755); err != nil {

--- a/internal/commands/cache_test.go
+++ b/internal/commands/cache_test.go
@@ -305,6 +305,9 @@ func TestExecuteCacheClearDefaultWipesBoth(t *testing.T) {
 	if !strings.Contains(out.String(), "Cleared") {
 		t.Errorf("output missing 'Cleared', got:\n%s", out.String())
 	}
+	if !strings.Contains(out.String(), "Cleared 1 molds") {
+		t.Errorf("summary should report 1 mold (matching fixture refs), got:\n%s", out.String())
+	}
 }
 
 func TestExecuteCacheClearMoldsOnly(t *testing.T) {
@@ -423,6 +426,30 @@ func TestExecuteCacheClearTTYPromptAccept(t *testing.T) {
 	}
 	if _, statErr := os.Stat(filepath.Join(moldRoot, "github.com")); !os.IsNotExist(statErr) {
 		t.Errorf("accept should delete files")
+	}
+}
+
+func TestGatherMoldStatsSkipsIndexesAsHost(t *testing.T) {
+	// The indexes subtree has the same structural shape as host/owner/repo/version,
+	// so foundry.ListCachedMolds will enumerate it as a phantom host. Verify
+	// gatherMoldStats filters it out.
+	root := t.TempDir()
+	// Real mold: github.com/foo/bar @ v1
+	mustMkdirAll(t, filepath.Join(root, "github.com", "foo", "bar", "v1"))
+	mustWriteFile(t, filepath.Join(root, "github.com", "foo", "bar", "v1", "x"), []byte("x"))
+	// Indexes laid out the same way (indexes/<host>/<owner>/<repo>/foundry.yaml)
+	mustMkdirAll(t, filepath.Join(root, "indexes", "github.com", "alice", "molds"))
+	mustWriteFile(t, filepath.Join(root, "indexes", "github.com", "alice", "molds", "foundry.yaml"), []byte("yaml"))
+
+	stats, err := gatherMoldStats(root, filepath.Join(root, "indexes"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stats.Refs != 1 {
+		t.Errorf("Refs = %d, want 1 (indexes/ should be excluded)", stats.Refs)
+	}
+	if stats.Versions != 1 {
+		t.Errorf("Versions = %d, want 1", stats.Versions)
 	}
 }
 

--- a/internal/commands/cache_test.go
+++ b/internal/commands/cache_test.go
@@ -65,6 +65,39 @@ func TestGatherMoldStatsCountsAndSkipsIndexes(t *testing.T) {
 	}
 }
 
+func TestGatherIndexStatsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	stats, err := gatherIndexStats(filepath.Join(dir, "does-not-exist"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stats.Indexes != 0 || stats.Bytes != 0 {
+		t.Errorf("expected zero stats, got %+v", stats)
+	}
+}
+
+func TestGatherIndexStatsCounts(t *testing.T) {
+	root := t.TempDir()
+	mustMkdirAll(t, filepath.Join(root, "github.com", "alice", "molds"))
+	mustWriteFile(t, filepath.Join(root, "github.com", "alice", "molds", "foundry.yaml"), make([]byte, 1000))
+	mustMkdirAll(t, filepath.Join(root, "abc123hashurl"))
+	mustWriteFile(t, filepath.Join(root, "abc123hashurl", "foundry.yaml"), make([]byte, 500))
+	// A directory without foundry.yaml should not be counted as an index.
+	mustMkdirAll(t, filepath.Join(root, "stray"))
+	mustWriteFile(t, filepath.Join(root, "stray", "other.txt"), make([]byte, 7))
+
+	stats, err := gatherIndexStats(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stats.Indexes != 2 {
+		t.Errorf("Indexes = %d, want 2", stats.Indexes)
+	}
+	if stats.Bytes != 1507 {
+		t.Errorf("Bytes = %d, want 1507", stats.Bytes)
+	}
+}
+
 func mustMkdirAll(t *testing.T, p string) {
 	t.Helper()
 	if err := os.MkdirAll(p, 0o755); err != nil {

--- a/internal/commands/cache_test.go
+++ b/internal/commands/cache_test.go
@@ -1,6 +1,10 @@
 package commands
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestHumanizeBytes(t *testing.T) {
 	cases := []struct {
@@ -20,5 +24,57 @@ func TestHumanizeBytes(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("humanizeBytes(%d) = %q, want %q", tc.in, got, tc.want)
 		}
+	}
+}
+
+func TestGatherMoldStatsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	stats, err := gatherMoldStats(dir, filepath.Join(dir, "indexes"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stats.Refs != 0 || stats.Versions != 0 || stats.Bytes != 0 {
+		t.Errorf("expected zero stats, got %+v", stats)
+	}
+}
+
+func TestGatherMoldStatsCountsAndSkipsIndexes(t *testing.T) {
+	root := t.TempDir()
+	mustMkdirAll(t, filepath.Join(root, "github.com", "foo", "bar", "v1"))
+	mustWriteFile(t, filepath.Join(root, "github.com", "foo", "bar", "v1", "README.md"), make([]byte, 100))
+	mustMkdirAll(t, filepath.Join(root, "github.com", "foo", "bar", "v2"))
+	mustWriteFile(t, filepath.Join(root, "github.com", "foo", "bar", "v2", "README.md"), make([]byte, 200))
+	mustMkdirAll(t, filepath.Join(root, "gitlab.com", "baz", "qux", "v1"))
+	mustWriteFile(t, filepath.Join(root, "gitlab.com", "baz", "qux", "v1", "README.md"), make([]byte, 50))
+	indexRoot := filepath.Join(root, "indexes")
+	mustMkdirAll(t, indexRoot)
+	mustWriteFile(t, filepath.Join(indexRoot, "foundry.yaml"), make([]byte, 9999))
+
+	stats, err := gatherMoldStats(root, indexRoot)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stats.Refs != 2 {
+		t.Errorf("Refs = %d, want 2", stats.Refs)
+	}
+	if stats.Versions != 3 {
+		t.Errorf("Versions = %d, want 3", stats.Versions)
+	}
+	if stats.Bytes != 350 {
+		t.Errorf("Bytes = %d, want 350 (indexes/ should be skipped)", stats.Bytes)
+	}
+}
+
+func mustMkdirAll(t *testing.T, p string) {
+	t.Helper()
+	if err := os.MkdirAll(p, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", p, err)
+	}
+}
+
+func mustWriteFile(t *testing.T, p string, data []byte) {
+	t.Helper()
+	if err := os.WriteFile(p, data, 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", p, err)
 	}
 }

--- a/internal/commands/verbs.go
+++ b/internal/commands/verbs.go
@@ -156,6 +156,22 @@ Available subcommands:
   extension    Install an ailloy extension`,
 }
 
+var clearCmd = &cobra.Command{
+	Use:   "clear",
+	Short: "Clear resources",
+	Long: `Clear resources.
+
+Available subcommands:
+  cache      Clear ailloy's on-disk cache`,
+}
+
+var clearCacheSubCmd = &cobra.Command{
+	Use:   "cache",
+	Short: "Clear ailloy's on-disk cache",
+	Args:  cobra.NoArgs,
+	RunE:  runCacheClear,
+}
+
 func init() {
 	// Flags for bidirectional "new mold" must mirror "mold new" flags.
 	newMoldSubCmd.Flags().StringVarP(&newMoldOutput, "output", "o", ".", "parent directory to create the mold in")
@@ -201,6 +217,15 @@ func init() {
 	// install <noun>  (added with extensions)
 	rootCmd.AddCommand(installCmd)
 	installCmd.AddCommand(installExtensionSubCmd)
+
+	// clear <noun>  (mirrors "cache clear")
+	rootCmd.AddCommand(clearCmd)
+	clearCmd.AddCommand(clearCacheSubCmd)
+
+	// Mirror Long help and flags so "clear cache" matches "cache clear".
+	// Set in init() — package-level var initializer order across files is unspecified.
+	clearCacheSubCmd.Long = cacheClearCmd.Long
+	registerCacheClearFlags(clearCacheSubCmd)
 
 	// show <noun>  (showCmd is declared in mold.go; we just hang another sub on it)
 	showCmd.AddCommand(showExtensionSubCmd)

--- a/internal/commands/verbs.go
+++ b/internal/commands/verbs.go
@@ -166,10 +166,12 @@ Available subcommands:
 }
 
 var clearCacheSubCmd = &cobra.Command{
-	Use:   "cache",
-	Short: "Clear ailloy's on-disk cache",
-	Args:  cobra.NoArgs,
-	RunE:  runCacheClear,
+	Use:           "cache",
+	Short:         "Clear ailloy's on-disk cache",
+	Args:          cobra.NoArgs,
+	RunE:          runCacheClear,
+	SilenceErrors: true,
+	SilenceUsage:  true,
 }
 
 func init() {


### PR DESCRIPTION
## Description

Adds `ailloy cache clear` (with bidirectional `ailloy clear cache`) for wiping the global on-disk caches under `~/.ailloy/cache/` — both mold artifacts and foundry indexes. Supports `--molds`, `--indexes`, `--dry-run`, and `--yes`/`-y`; defaults to clearing both with a preview (counts + size) and a confirmation prompt that errors in non-TTY shells without `--yes`.

## Related Issue

N/A

## Testing

24 unit/integration tests in \`internal/commands/cache_test.go\` covering every helper plus the orchestrator's empty / default / molds-only / indexes-only / dry-run / non-TTY-no-yes / TTY-decline / TTY-accept paths. \`go test ./...\` and \`go vet ./...\` clean. Smoke-tested live against a populated cache (preview, dry-run, both verb forms) and against an empty \`HOME\` (\"Cache is already empty.\").

## UAT

\`ailloy cache clear --dry-run\` shows a preview without deleting; \`ailloy cache clear -y\` (or \`ailloy clear cache -y\`) wipes both subtrees; \`--molds\` / \`--indexes\` narrow the scope; running without \`--yes\` in a non-interactive shell exits 1 with a clear error.

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [x] I have updated documentation (if applicable)
- [ ] My commits have DCO sign-off (\`git commit -s\`)