### PR TITLE
feat(recast): re-render mold content and persist cast options

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ Key CLI commands for working with molds:
 - **temper** (`validate`): Validate a mold or ingot package; use `--assay` (alias: `--lint`) to also render and assay output
 - **anneal** (`configure`): Configure flux variables interactively
 - **smelt** (`package`): Package a mold for distribution
-- **recast**: Re-resolve installed molds to newer versions; refreshes `.ailloy/installed.yaml` and (if present) `ailloy.lock`
+- **recast**: Re-resolve installed molds to newer versions AND re-render their content (alias: `upgrade`); refreshes `.ailloy/installed.yaml` and (if present) `ailloy.lock`. Accepts `--set`, `--values`/`-f`, `--with-workflows`, and `--force-replace-on-parse-error` — flags layer on top of the options the original cast recorded in the manifest.
 - **quench**: Opt in to `ailloy.lock` by pinning everything in `.ailloy/installed.yaml`; supports `--verify` (CI drift check) and `--global`
 - **evolve** (`reinstall`): Self-upgrade the ailloy CLI binary in place from the latest GitHub release; supports `--check`, `--version`, `--force`, and `--no-animate`. Refuses on Homebrew installs (use `brew upgrade nimble-giant/tap/ailloy`)
 - **cache clear**: Clear ailloy's on-disk cache (mold artifacts and foundry indexes under `~/.ailloy/cache/`). Supports `--molds`, `--indexes`, `--dry-run`, `--yes`. Bidirectional: `clear cache` also works.

--- a/internal/commands/cast.go
+++ b/internal/commands/cast.go
@@ -363,7 +363,12 @@ func castProject(reader *blanks.MoldReader, source string) error {
 
 	// Record the cast in the installed manifest (provenance for `recast` / `quench`).
 	if resolvedRemote != nil {
-		if err := recordInstalled(resolvedRemote, castGlobal, nil); err != nil {
+		opts := &foundry.CastOptionsRecord{
+			WithWorkflows: withWorkflows,
+			ValueFiles:    append([]string(nil), castValFiles...),
+			SetOverrides:  append([]string(nil), castSetFlags...),
+		}
+		if err := recordInstalled(resolvedRemote, castGlobal, opts, nil); err != nil {
 			log.Printf("warning: failed to update installed manifest: %v", err)
 		}
 	}
@@ -782,10 +787,12 @@ func copyResolvedFilesWithSchema(reader *blanks.MoldReader, manifest *mold.Mold,
 	return nil
 }
 
-// recordInstalled upserts the just-cast mold into the installed manifest.
-// logger receives the "corrupt manifest, resetting" warning; pass a discarding
-// logger from TUI callers to keep the alt-screen clean.
-func recordInstalled(result *foundry.ResolveResult, global bool, logger *log.Logger) error {
+// recordInstalled upserts the just-cast mold into the installed manifest,
+// preserving the option-shaped flags that drove this cast so a future
+// `recast` can replay them. logger receives the "corrupt manifest, resetting"
+// warning; pass a discarding logger from TUI callers to keep the alt-screen
+// clean.
+func recordInstalled(result *foundry.ResolveResult, global bool, opts *foundry.CastOptionsRecord, logger *log.Logger) error {
 	if logger == nil {
 		logger = log.Default()
 	}
@@ -801,14 +808,26 @@ func recordInstalled(result *foundry.ResolveResult, global bool, logger *log.Log
 	if manifest == nil {
 		manifest = &foundry.InstalledManifest{APIVersion: "v1"}
 	}
-	manifest.UpsertEntry(foundry.InstalledEntry{
+	entry := foundry.InstalledEntry{
 		Name:    result.Ref.Repo,
 		Source:  result.Ref.CacheKey(),
 		Subpath: result.Ref.Subpath,
 		Version: result.Resolved.Tag,
 		Commit:  result.Resolved.Commit,
 		CastAt:  time.Now().UTC(),
-	})
+	}
+	if opts != nil && (opts.WithWorkflows || len(opts.ValueFiles) > 0 || len(opts.SetOverrides) > 0) {
+		// Copy to detach from caller's slice ownership.
+		copied := *opts
+		if len(opts.ValueFiles) > 0 {
+			copied.ValueFiles = append([]string(nil), opts.ValueFiles...)
+		}
+		if len(opts.SetOverrides) > 0 {
+			copied.SetOverrides = append([]string(nil), opts.SetOverrides...)
+		}
+		entry.CastOptions = &copied
+	}
+	manifest.UpsertEntry(entry)
 	return foundry.WriteInstalledManifest(path, manifest)
 }
 

--- a/internal/commands/cast.go
+++ b/internal/commands/cast.go
@@ -365,8 +365,8 @@ func castProject(reader *blanks.MoldReader, source string) error {
 	if resolvedRemote != nil {
 		opts := &foundry.CastOptionsRecord{
 			WithWorkflows: withWorkflows,
-			ValueFiles:    append([]string(nil), castValFiles...),
-			SetOverrides:  append([]string(nil), castSetFlags...),
+			ValueFiles:    castValFiles,
+			SetOverrides:  castSetFlags,
 		}
 		if err := recordInstalled(resolvedRemote, castGlobal, opts, nil); err != nil {
 			log.Printf("warning: failed to update installed manifest: %v", err)
@@ -819,12 +819,8 @@ func recordInstalled(result *foundry.ResolveResult, global bool, opts *foundry.C
 	if opts != nil && (opts.WithWorkflows || len(opts.ValueFiles) > 0 || len(opts.SetOverrides) > 0) {
 		// Copy to detach from caller's slice ownership.
 		copied := *opts
-		if len(opts.ValueFiles) > 0 {
-			copied.ValueFiles = append([]string(nil), opts.ValueFiles...)
-		}
-		if len(opts.SetOverrides) > 0 {
-			copied.SetOverrides = append([]string(nil), opts.SetOverrides...)
-		}
+		copied.ValueFiles = append([]string(nil), opts.ValueFiles...)
+		copied.SetOverrides = append([]string(nil), opts.SetOverrides...)
 		entry.CastOptions = &copied
 	}
 	manifest.UpsertEntry(entry)

--- a/internal/commands/cast_core.go
+++ b/internal/commands/cast_core.go
@@ -203,8 +203,8 @@ func CastMold(_ context.Context, ref string, opts CastOptions) (CastResult, erro
 			// RecordInstalledFiles.
 			record := &foundry.CastOptionsRecord{
 				WithWorkflows: opts.WithWorkflows,
-				ValueFiles:    append([]string(nil), opts.ValueFiles...),
-				SetOverrides:  append([]string(nil), opts.SetOverrides...),
+				ValueFiles:    opts.ValueFiles,
+				SetOverrides:  opts.SetOverrides,
 			}
 			if err := recordInstalled(remoteResult, opts.Global, record, silentLogger); err != nil {
 				silentLogger.Printf("warning: failed to update installed manifest: %v", err)

--- a/internal/commands/cast_core.go
+++ b/internal/commands/cast_core.go
@@ -201,7 +201,12 @@ func CastMold(_ context.Context, ref string, opts CastOptions) (CastResult, erro
 			// Upsert the manifest entry with provenance, then backfill Files
 			// + FileHashes. Mirrors what cast.go does via recordInstalled +
 			// RecordInstalledFiles.
-			if err := recordInstalled(remoteResult, opts.Global, silentLogger); err != nil {
+			record := &foundry.CastOptionsRecord{
+				WithWorkflows: opts.WithWorkflows,
+				ValueFiles:    append([]string(nil), opts.ValueFiles...),
+				SetOverrides:  append([]string(nil), opts.SetOverrides...),
+			}
+			if err := recordInstalled(remoteResult, opts.Global, record, silentLogger); err != nil {
 				silentLogger.Printf("warning: failed to update installed manifest: %v", err)
 			} else {
 				installed := make([]foundry.InstalledFile, 0, len(filesToCast))

--- a/internal/commands/ingot.go
+++ b/internal/commands/ingot.go
@@ -159,7 +159,7 @@ func runIngotAdd(_ *cobra.Command, args []string) error {
 	fmt.Println(styles.SuccessStyle.Render("Ingot added: ") + styles.AccentStyle.Render(ingot.Name+" "+ingot.Version))
 	fmt.Println(styles.InfoStyle.Render("Installed to: ") + styles.CodeStyle.Render(destDir))
 
-	if err := recordInstalled(result, false, nil); err != nil {
+	if err := recordInstalled(result, false, nil, nil); err != nil {
 		log.Printf("warning: failed to update installed manifest: %v", err)
 	}
 

--- a/internal/commands/recast.go
+++ b/internal/commands/recast.go
@@ -270,9 +270,13 @@ func runRecast(cmd *cobra.Command, args []string) error {
 		// CastMold has already upserted the manifest entry; now overlay the
 		// merged effective options so subsequent recasts replay them.
 		if persistErr := persistEffectiveOptions(manifestPath, entry.Source, entry.Subpath, effective); persistErr != nil {
-			fmt.Printf("%s warning: %s: failed to persist options: %v\n",
+			// The on-disk files were updated by CastMold, but we couldn't record
+			// the effective options on the manifest entry. Surface as a failure
+			// (non-zero exit) so it doesn't get silently lost — this state means
+			// the next recast won't replay these options.
+			fmt.Printf("%s %s: re-rendered, but failed to persist options: %v\n",
 				styles.WarningStyle.Render("!"), entry.Name, persistErr)
-			// Non-fatal — files are already updated.
+			failures++
 		}
 
 		changes = append(changes, change)
@@ -299,7 +303,11 @@ func runRecast(cmd *cobra.Command, args []string) error {
 			styles.CodeStyle.Render(c.NewVersion),
 		)
 		if c.OptionsChanged {
-			line += "  " + styles.InfoStyle.Render("(options overridden)")
+			if recastDryRun {
+				line += "  " + styles.InfoStyle.Render("(would override options)")
+			} else {
+				line += "  " + styles.InfoStyle.Render("(options overridden)")
+			}
 		}
 		fmt.Println(line)
 	}
@@ -324,6 +332,11 @@ func runRecast(cmd *cobra.Command, args []string) error {
 // canonical ref-string format accepted by CastMold and foundry.ParseReference:
 //
 //	<host>/<owner>/<repo>@<tag>[//<subpath>]
+//
+// Unlike (*Reference).String(), this uses the resolved tag rather than
+// ref.Version. References built from installed entries via
+// referenceFromInstalledEntry have Type=Latest and an empty Version field,
+// so String() would emit no @tag.
 func buildVersionedRefString(ref *foundry.Reference, tag string) string {
 	s := ref.CacheKey()
 	if tag != "" {
@@ -337,8 +350,10 @@ func buildVersionedRefString(ref *foundry.Reference, tag string) string {
 
 // persistEffectiveOptions writes the merged CastOptions back onto the manifest
 // entry identified by (source, subpath). It re-reads the manifest because
-// CastMold has just rewritten it; we layer the options on top of CastMold's
-// upsert without otherwise modifying the entry.
+// CastMold has just rewritten it; do not be tempted to reuse an in-memory
+// manifest from earlier in the recast loop, since CastMold's writes would be
+// silently overwritten on save. The TOCTOU window is acceptable here because
+// no other process writes to installed.yaml during a recast.
 func persistEffectiveOptions(manifestPath, source, subpath string, eff foundry.CastOptionsRecord) error {
 	manifest, err := foundry.ReadInstalledManifest(manifestPath)
 	if err != nil {

--- a/internal/commands/recast.go
+++ b/internal/commands/recast.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"slices"
 	"strings"
-	"time"
 
 	"github.com/nimble-giant/ailloy/internal/tui/ceremony"
 	"github.com/nimble-giant/ailloy/pkg/blanks"
@@ -132,17 +131,18 @@ func init() {
 }
 
 type recastChange struct {
-	Name       string
-	Source     string
-	OldVersion string
-	OldCommit  string
-	NewVersion string
-	NewCommit  string
+	Name           string
+	Source         string
+	OldVersion     string
+	OldCommit      string
+	NewVersion     string
+	NewCommit      string
+	Effective      foundry.CastOptionsRecord // applied options for this run
+	OptionsChanged bool                      // true when CLI overrode recorded options
 }
 
-func runRecast(_ *cobra.Command, args []string) error {
+func runRecast(cmd *cobra.Command, args []string) error {
 	manifestPath := manifestPathFor(recastGlobal)
-	lockPath := lockPathFor(recastGlobal)
 
 	manifest, err := foundry.ReadInstalledManifest(manifestPath)
 	if err != nil {
@@ -154,7 +154,6 @@ func runRecast(_ *cobra.Command, args []string) error {
 			styles.CodeStyle.Render("ailloy cast"))
 	}
 
-	// Optional name filter.
 	entries := manifest.Molds
 	if len(args) == 1 {
 		match := manifest.FindByName(args[0])
@@ -164,9 +163,14 @@ func runRecast(_ *cobra.Command, args []string) error {
 		entries = []foundry.InstalledEntry{*match}
 	}
 
+	cli := recastCLIOptions{
+		WithWorkflows:            recastWithWorkflows,
+		ValueFiles:               recastValFiles,
+		SetOverrides:             recastSetFlags,
+		ForceReplaceOnParseError: recastForceReplace,
+	}
+
 	if recastDryRun {
-		// Dry-run keeps the lighter informational banner — no full ceremony
-		// because nothing actually changes on disk.
 		fmt.Println(styles.WorkingBanner("Previewing dependency updates (dry run)..."))
 		fmt.Println()
 	} else {
@@ -175,139 +179,185 @@ func runRecast(_ *cobra.Command, args []string) error {
 
 	git := foundry.DefaultGitRunner()
 	var changes []recastChange
-
-	// Read existing lock (if any) so we can update it in lockstep.
-	existingLock, _ := foundry.ReadLockFile(lockPath)
+	failures := 0
 
 	for _, entry := range entries {
-		ref, err := referenceFromInstalledEntry(&entry)
-		if err != nil {
-			fmt.Printf("%s skipping %s: %v\n", styles.WarningStyle.Render("!"), entry.Name, err)
+		ref, refErr := referenceFromInstalledEntry(&entry)
+		if refErr != nil {
+			fmt.Printf("%s skipping %s: %v\n", styles.WarningStyle.Render("!"), entry.Name, refErr)
+			failures++
 			continue
 		}
-		resolved, err := foundry.ResolveVersion(ref, git)
-		if err != nil {
-			fmt.Printf("%s skipping %s: %v\n", styles.WarningStyle.Render("!"), entry.Name, err)
+		resolved, resolveErr := foundry.ResolveVersion(ref, git)
+		if resolveErr != nil {
+			fmt.Printf("%s skipping %s: %v\n", styles.WarningStyle.Render("!"), entry.Name, resolveErr)
+			failures++
 			continue
 		}
-		if resolved.Tag == entry.Version && resolved.Commit == entry.Commit {
-			fmt.Println(styles.InfoStyle.Render("  ") + entry.Name + " is already up to date (" + styles.CodeStyle.Render(entry.Version) + ")")
+
+		versionUnchanged := resolved.Tag == entry.Version && resolved.Commit == entry.Commit
+		if versionUnchanged && !cli.hasOverrides() {
+			fmt.Println(styles.InfoStyle.Render("  ") + entry.Name + " is already up to date (" +
+				styles.CodeStyle.Render(entry.Version) + ")")
 			continue
 		}
-		changes = append(changes, recastChange{
-			Name:       entry.Name,
-			Source:     entry.Source,
-			OldVersion: entry.Version,
-			OldCommit:  entry.Commit,
-			NewVersion: resolved.Tag,
-			NewCommit:  resolved.Commit,
-		})
 
-		if !recastDryRun {
-			fetcher, ferr := foundry.NewFetcher(git)
-			if ferr != nil {
-				fmt.Printf("%s skipping %s: fetcher: %v\n", styles.WarningStyle.Render("!"), entry.Name, ferr)
-				changes = changes[:len(changes)-1]
-				continue
-			}
-			fetchedFS, _, fetchErr := fetcher.Fetch(ref, resolved)
-			if fetchErr != nil {
-				fmt.Printf("%s skipping %s: fetch: %v\n", styles.WarningStyle.Render("!"), entry.Name, fetchErr)
-				changes = changes[:len(changes)-1]
-				continue
-			}
+		effective := mergeRecastOptions(entry.CastOptions, cli)
+		change := recastChange{
+			Name:           entry.Name,
+			Source:         entry.Source,
+			OldVersion:     entry.Version,
+			OldCommit:      entry.Commit,
+			NewVersion:     resolved.Tag,
+			NewCommit:      resolved.Commit,
+			Effective:      effective,
+			OptionsChanged: cli.hasOverrides(),
+		}
 
-			manifest.UpsertEntry(foundry.InstalledEntry{
-				Name:    entry.Name,
-				Source:  entry.Source,
-				Subpath: entry.Subpath,
-				Version: resolved.Tag,
-				Commit:  resolved.Commit,
-				CastAt:  time.Now().UTC(),
-			})
+		if recastDryRun {
+			changes = append(changes, change)
+			continue
+		}
 
-			// Reconcile the freshly resolved mold's dependency graph: install
-			// any newly declared deps and prune any that the mold no longer
-			// declares. moldKey mirrors the cast-time key (source@subpath when
-			// subpath is set) so dependent strings stay consistent.
-			moldKey := entry.Source
-			if entry.Subpath != "" {
-				moldKey += "@" + entry.Subpath
-			}
-			reader := blanks.NewMoldReader(fetchedFS)
-			freshMold, mErr := reader.LoadManifest()
-			if mErr != nil {
-				log.Printf("warning: loading fresh mold manifest for %s: %v", entry.Name, mErr)
-			} else if freshMold != nil {
-				// Auto-install newly declared deps. Recast operates on the
-				// project's installed.yaml (or global per --global). Local-path
-				// deps are refused because recast walks remote references.
-				if err := installDeclaredDeps(freshMold, moldKey, recastGlobal, false, recastFrozen, false, nil); err != nil {
-					log.Printf("warning: installing deps for %s: %v", entry.Name, err)
+		// Build a versioned ref string and re-cast. CastMold owns the
+		// installed-manifest update, lock update (when present), state.yaml
+		// write, and FileHashes recording — recast does not duplicate any
+		// of that work.
+		versionedRef := buildVersionedRefString(ref, resolved.Tag)
+		castOpts := CastOptions{
+			Global:                   recastGlobal,
+			WithWorkflows:            effective.WithWorkflows,
+			ValueFiles:               effective.ValueFiles,
+			SetOverrides:             effective.SetOverrides,
+			ForceReplaceOnParseError: cli.ForceReplaceOnParseError,
+		}
+		if _, castErr := CastMold(cmd.Context(), versionedRef, castOpts); castErr != nil {
+			fmt.Printf("%s skipping %s: %v\n", styles.WarningStyle.Render("!"), entry.Name, castErr)
+			failures++
+			continue
+		}
+
+		// Reconcile the freshly resolved mold's dependency graph: install
+		// any newly declared deps and prune any that the mold no longer
+		// declares. moldKey mirrors the cast-time key (source@subpath when
+		// subpath is set) so dependent strings stay consistent. The fetch
+		// here hits the foundry cache CastMold just populated, so it's
+		// near-free.
+		moldKey := entry.Source
+		if entry.Subpath != "" {
+			moldKey += "@" + entry.Subpath
+		}
+		if fetcher, ferr := foundry.NewFetcher(git); ferr == nil {
+			if fetchedFS, _, fetchErr := fetcher.Fetch(ref, resolved); fetchErr == nil {
+				reader := blanks.NewMoldReader(fetchedFS)
+				if freshMold, mErr := reader.LoadManifest(); mErr != nil {
+					log.Printf("warning: loading fresh mold manifest for %s: %v", entry.Name, mErr)
+				} else if freshMold != nil {
+					// Auto-install newly declared deps. Recast operates on the
+					// project's installed.yaml (or global per --global). Local-path
+					// deps are refused because recast walks remote references.
+					if err := installDeclaredDeps(freshMold, moldKey, recastGlobal, false, recastFrozen, false, nil); err != nil {
+						log.Printf("warning: installing deps for %s: %v", entry.Name, err)
+					}
+					// Cascade-prune deps the mold no longer declares.
+					if err := pruneRemovedDeps(manifestPathFor(recastGlobal), moldKey, freshMold.Dependencies, recastGlobal); err != nil {
+						log.Printf("warning: pruning removed deps for %s: %v", entry.Name, err)
+					}
 				}
-				// Cascade-prune deps the mold no longer declares.
-				if err := pruneRemovedDeps(manifestPathFor(recastGlobal), moldKey, freshMold.Dependencies, recastGlobal); err != nil {
-					log.Printf("warning: pruning removed deps for %s: %v", entry.Name, err)
-				}
-				// Re-read manifest so subsequent mold iterations see the
-				// changes from installDeclaredDeps + pruneRemovedDeps.
-				if reread, _ := foundry.ReadInstalledManifest(manifestPathFor(recastGlobal)); reread != nil {
-					manifest = reread
-				}
-			}
-
-			if existingLock != nil {
-				existingLock.UpsertEntry(foundry.LockEntry{
-					Name:      entry.Name,
-					Source:    entry.Source,
-					Version:   resolved.Tag,
-					Commit:    resolved.Commit,
-					Subpath:   entry.Subpath,
-					Timestamp: time.Now().UTC(),
-				})
 			}
 		}
+
+		// CastMold has already upserted the manifest entry; now overlay the
+		// merged effective options so subsequent recasts replay them.
+		if persistErr := persistEffectiveOptions(manifestPath, entry.Source, entry.Subpath, effective); persistErr != nil {
+			fmt.Printf("%s warning: %s: failed to persist options: %v\n",
+				styles.WarningStyle.Render("!"), entry.Name, persistErr)
+			// Non-fatal — files are already updated.
+		}
+
+		changes = append(changes, change)
 	}
 
-	if len(changes) == 0 {
+	if len(changes) == 0 && failures == 0 {
 		fmt.Println()
 		fmt.Println(styles.SuccessStyle.Render("All dependencies are up to date."))
 		return nil
 	}
 
-	if !recastDryRun {
-		if err := foundry.WriteInstalledManifest(manifestPath, manifest); err != nil {
-			return fmt.Errorf("writing installed manifest: %w", err)
-		}
-		if existingLock != nil {
-			if err := foundry.WriteLockFile(lockPath, existingLock); err != nil {
-				return fmt.Errorf("writing lock file: %w", err)
-			}
-		}
-	}
-
 	fmt.Println()
 	if recastDryRun {
 		fmt.Println(styles.InfoStyle.Render("Changes that would be applied:"))
-	} else {
+	} else if len(changes) > 0 {
 		fmt.Println(styles.SuccessStyle.Render("Updated dependencies:"))
 	}
 	fmt.Println()
 	for _, c := range changes {
-		fmt.Printf("  %s  %s %s %s\n",
+		line := fmt.Sprintf("  %s  %s %s %s",
 			styles.FoxBullet(c.Name),
 			styles.CodeStyle.Render(c.OldVersion),
 			styles.InfoStyle.Render("->"),
 			styles.CodeStyle.Render(c.NewVersion),
 		)
+		if c.OptionsChanged {
+			line += "  " + styles.InfoStyle.Render("(options overridden)")
+		}
+		fmt.Println(line)
 	}
 
-	fmt.Println()
-	if recastDryRun {
-		fmt.Println(styles.InfoStyle.Render("Run without --dry-run to apply these changes."))
-	} else {
+	if !recastDryRun && len(changes) > 0 {
+		fmt.Println()
 		fmt.Println(styles.SuccessBanner("Recast complete!"))
 		ceremony.Stamp(ceremony.Recast, fmt.Sprintf("%d mold(s) updated", len(changes)))
 	}
+	if recastDryRun {
+		fmt.Println()
+		fmt.Println(styles.InfoStyle.Render("Run without --dry-run to apply these changes."))
+	}
+
+	if failures > 0 {
+		return fmt.Errorf("%d mold(s) failed to recast", failures)
+	}
 	return nil
+}
+
+// buildVersionedRefString turns a Reference plus a resolved tag into the
+// canonical ref-string format accepted by CastMold and foundry.ParseReference:
+//
+//	<host>/<owner>/<repo>@<tag>[//<subpath>]
+func buildVersionedRefString(ref *foundry.Reference, tag string) string {
+	s := ref.CacheKey()
+	if tag != "" {
+		s += "@" + tag
+	}
+	if ref.Subpath != "" {
+		s += "//" + ref.Subpath
+	}
+	return s
+}
+
+// persistEffectiveOptions writes the merged CastOptions back onto the manifest
+// entry identified by (source, subpath). It re-reads the manifest because
+// CastMold has just rewritten it; we layer the options on top of CastMold's
+// upsert without otherwise modifying the entry.
+func persistEffectiveOptions(manifestPath, source, subpath string, eff foundry.CastOptionsRecord) error {
+	manifest, err := foundry.ReadInstalledManifest(manifestPath)
+	if err != nil {
+		return err
+	}
+	if manifest == nil {
+		return fmt.Errorf("manifest disappeared at %s", manifestPath)
+	}
+	target := manifest.FindBySource(source, subpath)
+	if target == nil {
+		return fmt.Errorf("entry %s/%s not found after recast", source, subpath)
+	}
+	if eff.WithWorkflows || len(eff.ValueFiles) > 0 || len(eff.SetOverrides) > 0 {
+		copied := eff
+		copied.ValueFiles = append([]string(nil), eff.ValueFiles...)
+		copied.SetOverrides = append([]string(nil), eff.SetOverrides...)
+		target.CastOptions = &copied
+	} else {
+		target.CastOptions = nil
+	}
+	return foundry.WriteInstalledManifest(manifestPath, manifest)
 }

--- a/internal/commands/recast.go
+++ b/internal/commands/recast.go
@@ -18,19 +18,28 @@ var recastCmd = &cobra.Command{
 	Use:     "recast [name]",
 	Aliases: []string{"upgrade"},
 	Short:   "Re-resolve installed molds to newer versions",
-	Long: `Re-resolve installed molds to newer versions (alias: upgrade).
+	Long: `Re-resolve installed molds to newer versions and re-render their content (alias: upgrade).
 
-Reads .ailloy/installed.yaml and refreshes each mold to its latest matching
-version. If ailloy.lock exists, also updates lock entries in lockstep.
+Reads .ailloy/installed.yaml, refreshes each mold to its latest matching
+version, and re-runs the cast pipeline so files on disk reflect the new
+version. If ailloy.lock exists, it is updated in lockstep.
 
-Use --dry-run to preview changes without applying them.`,
+Flags supplied here layer on top of the options the original cast recorded
+in installed.yaml. --set and --values overrides are persisted back; the
+recovery flag --force-replace-on-parse-error is not.
+
+Use --dry-run to preview which molds will move, without re-rendering.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runRecast,
 }
 
 var (
-	recastDryRun bool
-	recastGlobal bool
+	recastDryRun        bool
+	recastGlobal        bool
+	recastSetFlags      []string
+	recastValFiles      []string
+	recastWithWorkflows bool
+	recastForceReplace  bool
 	// recastFrozen mirrors --frozen on cast: fail (do not auto-install) on
 	// any declared ingot/ore dep that's missing from .ailloy/.
 	recastFrozen bool
@@ -115,6 +124,10 @@ func init() {
 	rootCmd.AddCommand(recastCmd)
 	recastCmd.Flags().BoolVar(&recastDryRun, "dry-run", false, "preview changes without applying")
 	recastCmd.Flags().BoolVarP(&recastGlobal, "global", "g", false, "operate on the global manifest/lock under ~/")
+	recastCmd.Flags().BoolVar(&recastWithWorkflows, "with-workflows", false, "include GitHub Actions workflow blanks (OR'd with the recorded value)")
+	recastCmd.Flags().StringArrayVar(&recastSetFlags, "set", nil, "override flux variable (key=value, repeatable; supports dotted keys)")
+	recastCmd.Flags().StringArrayVarP(&recastValFiles, "values", "f", nil, "flux value file (repeatable; later files override earlier)")
+	recastCmd.Flags().BoolVar(&recastForceReplace, "force-replace-on-parse-error", false, "replace unparseable merge-strategy destinations instead of erroring")
 	recastCmd.Flags().BoolVar(&recastFrozen, "frozen", false, "fail (do not auto-install) when a declared ingot/ore dep is missing from .ailloy/; intended for CI")
 }
 

--- a/internal/commands/recast.go
+++ b/internal/commands/recast.go
@@ -27,7 +27,8 @@ Flags supplied here layer on top of the options the original cast recorded
 in installed.yaml. --set and --values overrides are persisted back; the
 recovery flag --force-replace-on-parse-error is not.
 
-Use --dry-run to preview which molds will move, without re-rendering.`,
+Use --global/-g to operate on the manifest under ~/ instead of the current
+project. Use --dry-run to preview which molds will move, without re-rendering.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runRecast,
 }
@@ -137,8 +138,7 @@ type recastChange struct {
 	OldCommit      string
 	NewVersion     string
 	NewCommit      string
-	Effective      foundry.CastOptionsRecord // applied options for this run
-	OptionsChanged bool                      // true when CLI overrode recorded options
+	OptionsChanged bool // true when CLI overrode recorded options
 }
 
 func runRecast(cmd *cobra.Command, args []string) error {
@@ -210,7 +210,6 @@ func runRecast(cmd *cobra.Command, args []string) error {
 			OldCommit:      entry.Commit,
 			NewVersion:     resolved.Tag,
 			NewCommit:      resolved.Commit,
-			Effective:      effective,
 			OptionsChanged: cli.hasOverrides(),
 		}
 

--- a/internal/commands/recast.go
+++ b/internal/commands/recast.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"log"
+	"slices"
 	"strings"
 	"time"
 
@@ -75,7 +76,7 @@ func mergeRecastOptions(recorded *foundry.CastOptionsRecord, cli recastCLIOption
 	rec.WithWorkflows = rec.WithWorkflows || cli.WithWorkflows
 
 	for _, f := range cli.ValueFiles {
-		if !containsString(rec.ValueFiles, f) {
+		if !slices.Contains(rec.ValueFiles, f) {
 			rec.ValueFiles = append(rec.ValueFiles, f)
 		}
 	}
@@ -85,6 +86,8 @@ func mergeRecastOptions(recorded *foundry.CastOptionsRecord, cli recastCLIOption
 		replaced := false
 		for i, existing := range rec.SetOverrides {
 			if setOverrideKey(existing) == key {
+				// Safe: rec.SetOverrides was cloned above, so this does not
+				// alias the caller's recorded slice.
 				rec.SetOverrides[i] = kv
 				replaced = true
 				break
@@ -99,25 +102,13 @@ func mergeRecastOptions(recorded *foundry.CastOptionsRecord, cli recastCLIOption
 }
 
 // setOverrideKey returns the LHS of a `key=value` --set string, trimmed of
-// whitespace. Mirrors the parsing in mold.ApplySetOverrides so dedupe matches
-// what the renderer ultimately sees. Inputs without an "=" return the entire
-// string (treated as a single-key entry).
+// whitespace. Mirrors the trim behavior in mold.ApplySetOverrides
+// (pkg/mold/flux.go) so dedupe matches what the renderer ultimately sees.
+// Inputs without "=" return the entire string trimmed (treated as a single-
+// key entry).
 func setOverrideKey(kv string) string {
-	for i := 0; i < len(kv); i++ {
-		if kv[i] == '=' {
-			return strings.TrimSpace(kv[:i])
-		}
-	}
-	return strings.TrimSpace(kv)
-}
-
-func containsString(haystack []string, needle string) bool {
-	for _, s := range haystack {
-		if s == needle {
-			return true
-		}
-	}
-	return false
+	parts := strings.SplitN(kv, "=", 2)
+	return strings.TrimSpace(parts[0])
 }
 
 func init() {

--- a/internal/commands/recast.go
+++ b/internal/commands/recast.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/nimble-giant/ailloy/internal/tui/ceremony"
@@ -33,6 +34,91 @@ var (
 	// any declared ingot/ore dep that's missing from .ailloy/.
 	recastFrozen bool
 )
+
+// recastCLIOptions holds the option-shaped flags supplied for THIS recast run.
+// Distinct from foundry.CastOptionsRecord (which is the persisted form) so the
+// merge algorithm has explicit "recorded" and "this-run" inputs.
+type recastCLIOptions struct {
+	WithWorkflows            bool
+	ValueFiles               []string
+	SetOverrides             []string
+	ForceReplaceOnParseError bool // run-time only, never persisted
+}
+
+// hasOverrides reports whether any persistable CLI flag was supplied. Used by
+// the loop to decide whether a same-version mold should still be re-rendered.
+// ForceReplaceOnParseError is intentionally excluded — a recovery flag alone
+// should not force a re-render of an already-up-to-date mold.
+func (o recastCLIOptions) hasOverrides() bool {
+	return o.WithWorkflows || len(o.ValueFiles) > 0 || len(o.SetOverrides) > 0
+}
+
+// mergeRecastOptions composes the persisted (recorded) options with this run's
+// CLI flags. CLI flags layer on top of recorded options:
+//
+//   - WithWorkflows is OR'd (CLI cannot turn off a recorded true).
+//   - ValueFiles: recorded first, CLI appended; dedupe on exact path.
+//   - SetOverrides: recorded first, CLI appended; if a CLI override has the
+//     same dotted key as a recorded entry, the recorded entry is replaced
+//     in place rather than duplicated.
+//
+// The returned record is what we persist back to the manifest after a
+// successful recast. ForceReplaceOnParseError is not part of the result.
+func mergeRecastOptions(recorded *foundry.CastOptionsRecord, cli recastCLIOptions) foundry.CastOptionsRecord {
+	var rec foundry.CastOptionsRecord
+	if recorded != nil {
+		rec = *recorded
+		rec.ValueFiles = append([]string(nil), recorded.ValueFiles...)
+		rec.SetOverrides = append([]string(nil), recorded.SetOverrides...)
+	}
+
+	rec.WithWorkflows = rec.WithWorkflows || cli.WithWorkflows
+
+	for _, f := range cli.ValueFiles {
+		if !containsString(rec.ValueFiles, f) {
+			rec.ValueFiles = append(rec.ValueFiles, f)
+		}
+	}
+
+	for _, kv := range cli.SetOverrides {
+		key := setOverrideKey(kv)
+		replaced := false
+		for i, existing := range rec.SetOverrides {
+			if setOverrideKey(existing) == key {
+				rec.SetOverrides[i] = kv
+				replaced = true
+				break
+			}
+		}
+		if !replaced {
+			rec.SetOverrides = append(rec.SetOverrides, kv)
+		}
+	}
+
+	return rec
+}
+
+// setOverrideKey returns the LHS of a `key=value` --set string, trimmed of
+// whitespace. Mirrors the parsing in mold.ApplySetOverrides so dedupe matches
+// what the renderer ultimately sees. Inputs without an "=" return the entire
+// string (treated as a single-key entry).
+func setOverrideKey(kv string) string {
+	for i := 0; i < len(kv); i++ {
+		if kv[i] == '=' {
+			return strings.TrimSpace(kv[:i])
+		}
+	}
+	return strings.TrimSpace(kv)
+}
+
+func containsString(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
 
 func init() {
 	rootCmd.AddCommand(recastCmd)

--- a/internal/commands/recast_e2e_test.go
+++ b/internal/commands/recast_e2e_test.go
@@ -1,0 +1,327 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nimble-giant/ailloy/pkg/foundry"
+)
+
+// recastE2EEnv wires a synthetic remote into a self-contained sandbox so the
+// e2e tests can exercise `cast` and `recast` without ever touching the user's
+// real ~/.ailloy cache or hitting the network.
+//
+// The sandbox is built on two git mechanisms:
+//
+//  1. A bare git repository created on disk plays the role of the "remote".
+//     Tags pushed to it (v1.0.0, v2.0.0, ...) become the versions ailloy will
+//     resolve against.
+//  2. A scratch HOME directory + GIT_CONFIG_GLOBAL pointing at a temp gitconfig
+//     with `url.<file://...>.insteadOf = https://<host>/<owner>/<repo>` makes
+//     every `git ls-remote` / `git clone` / `git fetch` ailloy issues against
+//     the synthetic CloneURL transparently redirect to the local bare repo.
+//
+// Why this shape: the foundry package only treats `host/owner/repo`-style refs
+// as remote (see foundry.IsRemoteReference), and ParseReference + CloneURL
+// hardcode `https://<host>/<owner>/<repo>.git`. There is no `file://` shortcut
+// in the parser, and recast specifically requires entry.Source to be in
+// `host/owner/repo` form (referenceFromInstalledEntry in quench.go). The
+// insteadOf trick is the cleanest way to satisfy both constraints without
+// patching the parser or pre-populating the cache by hand.
+type recastE2EEnv struct {
+	bin       string // ailloy binary path
+	repoDir   string // working tree of the synthetic remote
+	bareDir   string // bare git repo ailloy will clone from (via insteadOf)
+	homeDir   string // sandboxed HOME so ~/.ailloy/cache stays out of $HOME
+	gitConfig string // path to the temp gitconfig with insteadOf
+	host      string // synthetic host segment, e.g. "localhost.test"
+	owner     string // synthetic owner segment, e.g. "ailloy-test"
+	repo      string // synthetic repo segment, e.g. "recast-fixture"
+}
+
+// refString returns the canonical ailloy ref for the synthetic repo.
+func (e *recastE2EEnv) refString() string {
+	return fmt.Sprintf("%s/%s/%s", e.host, e.owner, e.repo)
+}
+
+// extraEnv returns the env additions every spawned ailloy process needs so
+// HOME points at the sandbox and git applies the insteadOf substitution.
+func (e *recastE2EEnv) extraEnv() []string {
+	return []string{
+		"HOME=" + e.homeDir,
+		"GIT_CONFIG_GLOBAL=" + e.gitConfig,
+		// Defang any user/system gitconfig that might inject conflicting
+		// insteadOf rules or credential helpers.
+		"GIT_CONFIG_NOSYSTEM=1",
+	}
+}
+
+// run invokes the ailloy binary with the sandbox env applied. dir is the
+// working directory (typically the project under test).
+func (e *recastE2EEnv) run(t *testing.T, dir string, args ...string) ([]byte, error) {
+	t.Helper()
+	cmd := exec.Command(e.bin, args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), e.extraEnv()...)
+	return cmd.CombinedOutput()
+}
+
+// gitInRepo runs a git command inside the synthetic remote's working tree
+// (e.repoDir) with the sandbox gitconfig applied. Used to add commits and
+// tags that ailloy will later resolve.
+func (e *recastE2EEnv) gitInRepo(t *testing.T, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = e.repoDir
+	cmd.Env = append(os.Environ(), e.extraEnv()...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+// writeMoldFiles populates the synthetic remote's working tree with a minimal
+// mold whose rendered README echoes the value of flux variable `foo`.
+// versionMarker is appended to the template so v1 vs v2 renders are
+// distinguishable.
+func (e *recastE2EEnv) writeMoldFiles(t *testing.T, version, versionMarker string) {
+	t.Helper()
+
+	moldYAML := fmt.Sprintf("apiVersion: v1\nkind: Mold\nname: e2e-recast\nversion: %s\n", version)
+	if err := os.WriteFile(filepath.Join(e.repoDir, "mold.yaml"), []byte(moldYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// flux.yaml maps the README template as an output. Note: keys under
+	// `output:` are SOURCE files in the mold; they are processed as Go
+	// templates by default.
+	fluxYAML := "output:\n  README.md: README.md\n"
+	if err := os.WriteFile(filepath.Join(e.repoDir, "flux.yaml"), []byte(fluxYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+	tmpl := fmt.Sprintf("foo={{ .foo }}%s\n", versionMarker)
+	if err := os.WriteFile(filepath.Join(e.repoDir, "README.md"), []byte(tmpl), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// commitAndTag stages all changes in the synthetic remote, commits them with
+// the given message, tags the commit, and pushes the commit + tag to the bare
+// repo so ailloy's `git ls-remote --tags` against the synthetic CloneURL
+// (redirected via insteadOf) sees the new version.
+func (e *recastE2EEnv) commitAndTag(t *testing.T, message, tag string) {
+	t.Helper()
+	e.gitInRepo(t, "add", ".")
+	e.gitInRepo(t, "commit", "-m", message)
+	e.gitInRepo(t, "tag", tag)
+	// Push to the bare repo so future ls-remote/fetch calls against the
+	// synthetic remote URL find the new tag.
+	e.gitInRepo(t, "push", "origin", "HEAD:refs/heads/main", "--tags", "--force")
+}
+
+// setupRecastE2EEnv builds the ailloy binary, prepares the synthetic remote
+// with an initial v1.0.0 mold, and returns an env ready for cast/recast.
+func setupRecastE2EEnv(t *testing.T) *recastE2EEnv {
+	t.Helper()
+
+	bin := buildAilloyBinary(t)
+
+	root := t.TempDir()
+	env := &recastE2EEnv{
+		bin:       bin,
+		repoDir:   filepath.Join(root, "remote-worktree"),
+		bareDir:   filepath.Join(root, "remote.git"),
+		homeDir:   filepath.Join(root, "home"),
+		gitConfig: filepath.Join(root, "gitconfig"),
+		host:      "localhost.test",
+		owner:     "ailloy-test",
+		repo:      "recast-fixture",
+	}
+
+	for _, dir := range []string{env.repoDir, env.bareDir, env.homeDir} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Write the gitconfig that makes git redirect the synthetic CloneURL
+	// (https://localhost.test/ailloy-test/recast-fixture[.git]) to the local
+	// bare repo. Two insteadOf entries handle both the with-.git and
+	// without-.git URL shapes that ailloy may construct.
+	cloneURL := fmt.Sprintf("https://%s/%s/%s", env.host, env.owner, env.repo)
+	gitconfigContents := fmt.Sprintf(
+		"[url \"file://%s\"]\n\tinsteadOf = %s.git\n[url \"file://%s\"]\n\tinsteadOf = %s\n",
+		env.bareDir, cloneURL,
+		env.bareDir, cloneURL,
+	)
+	if err := os.WriteFile(env.gitConfig, []byte(gitconfigContents), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Initialize the bare "remote" repo (where tags will live).
+	bareInit := exec.Command("git", "init", "--bare", "--initial-branch=main", env.bareDir)
+	bareInit.Env = append(os.Environ(), env.extraEnv()...)
+	if out, err := bareInit.CombinedOutput(); err != nil {
+		t.Fatalf("git init --bare: %v\n%s", err, out)
+	}
+
+	// Initialize the working tree, point its origin at the bare repo, and
+	// configure a committer identity scoped to this repo (so the test does
+	// not depend on the developer's global git identity).
+	wtInit := exec.Command("git", "init", "--initial-branch=main", env.repoDir)
+	wtInit.Env = append(os.Environ(), env.extraEnv()...)
+	if out, err := wtInit.CombinedOutput(); err != nil {
+		t.Fatalf("git init worktree: %v\n%s", err, out)
+	}
+	env.gitInRepo(t, "config", "user.email", "test@example.com")
+	env.gitInRepo(t, "config", "user.name", "ailloy-test")
+	env.gitInRepo(t, "config", "commit.gpgsign", "false")
+	env.gitInRepo(t, "remote", "add", "origin", env.bareDir)
+
+	// Seed the v1 mold and publish it.
+	env.writeMoldFiles(t, "1.0.0", "")
+	env.commitAndTag(t, "initial", "v1.0.0")
+
+	return env
+}
+
+// TestE2E_Recast_RerenderWithRecordedOptions is the happy-path test: cast
+// with --set, bump the synthetic remote to v2, run `recast` with no flags and
+// assert files reflect the new version while the recorded --set value is
+// still applied. Then `recast --set foo=updated` to confirm CLI overrides
+// replace the recorded entry rather than appending.
+func TestE2E_Recast_RerenderWithRecordedOptions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("e2e binary build is slow; skipping in -short mode")
+	}
+
+	env := setupRecastE2EEnv(t)
+	project := t.TempDir()
+
+	// Initial cast pinned to v1.0.0 with a recorded --set override.
+	refV1 := env.refString() + "@v1.0.0"
+	if out, err := env.run(t, project, "cast", refV1, "--set", "foo=cli-value"); err != nil {
+		t.Fatalf("cast failed: %v\n%s", err, out)
+	}
+
+	got, _ := os.ReadFile(filepath.Join(project, "README.md"))
+	if !strings.Contains(string(got), "foo=cli-value") {
+		t.Fatalf("after initial cast README.md did not reflect --set value:\n%s", got)
+	}
+
+	// Manifest must record the --set override so a no-flag recast can replay it.
+	manifest, err := foundry.ReadInstalledManifest(filepath.Join(project, ".ailloy", "installed.yaml"))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	if len(manifest.Molds) != 1 || manifest.Molds[0].CastOptions == nil {
+		t.Fatalf("expected manifest to record cast options, got %+v", manifest)
+	}
+	if got := manifest.Molds[0].CastOptions.SetOverrides; len(got) != 1 || got[0] != "foo=cli-value" {
+		t.Errorf("recorded SetOverrides = %v, want [foo=cli-value]", got)
+	}
+
+	// Publish a v2 commit that materially changes the rendered README so we
+	// can detect that recast actually re-rendered against the new tag.
+	env.writeMoldFiles(t, "2.0.0", " (v2)")
+	env.commitAndTag(t, "v2", "v2.0.0")
+
+	// Recast with no flags. Because the manifest entry is unversioned (Latest)
+	// recast should resolve to v2.0.0, re-render, and replay the recorded
+	// --set foo=cli-value.
+	if out, err := env.run(t, project, "recast"); err != nil {
+		t.Fatalf("recast failed: %v\n%s", err, out)
+	}
+
+	got, _ = os.ReadFile(filepath.Join(project, "README.md"))
+	gs := string(got)
+	if !strings.Contains(gs, "foo=cli-value") {
+		t.Errorf("expected recorded --set foo=cli-value to still apply, got:\n%s", gs)
+	}
+	if !strings.Contains(gs, "(v2)") {
+		t.Errorf("expected recast to bump the rendered template to v2, got:\n%s", gs)
+	}
+
+	// recast --set foo=updated should replace the recorded entry (same key),
+	// not append a duplicate.
+	if out, err := env.run(t, project, "recast", "--set", "foo=updated"); err != nil {
+		t.Fatalf("recast --set failed: %v\n%s", err, out)
+	}
+	got, _ = os.ReadFile(filepath.Join(project, "README.md"))
+	if !strings.Contains(string(got), "foo=updated") {
+		t.Errorf("expected recast --set to update render, got:\n%s", got)
+	}
+
+	manifest, err = foundry.ReadInstalledManifest(filepath.Join(project, ".ailloy", "installed.yaml"))
+	if err != nil {
+		t.Fatalf("re-read manifest: %v", err)
+	}
+	if got := manifest.Molds[0].CastOptions.SetOverrides; len(got) != 1 || got[0] != "foo=updated" {
+		t.Errorf("expected SetOverrides=[foo=updated] (replaced, not appended), got %v", got)
+	}
+}
+
+// TestE2E_Recast_DryRunWritesNothing proves --dry-run is non-mutating: even
+// with CLI overrides supplied that would otherwise change the render, neither
+// the rendered files nor the installed manifest may change.
+func TestE2E_Recast_DryRunWritesNothing(t *testing.T) {
+	if testing.Short() {
+		t.Skip("e2e binary build is slow; skipping in -short mode")
+	}
+
+	env := setupRecastE2EEnv(t)
+	project := t.TempDir()
+
+	refV1 := env.refString() + "@v1.0.0"
+	if out, err := env.run(t, project, "cast", refV1); err != nil {
+		t.Fatalf("cast failed: %v\n%s", err, out)
+	}
+
+	// Snapshot README and manifest contents so we can assert byte-for-byte
+	// equality after the dry run.
+	readmeBefore, err := os.ReadFile(filepath.Join(project, "README.md"))
+	if err != nil {
+		t.Fatalf("read README before: %v", err)
+	}
+	manifestPath := filepath.Join(project, ".ailloy", "installed.yaml")
+	manBefore, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read manifest before: %v", err)
+	}
+
+	// Publish v2 so a real recast WOULD pick it up; --dry-run must still not
+	// mutate disk even though the version moved AND a CLI override was given.
+	env.writeMoldFiles(t, "2.0.0", " (v2)")
+	env.commitAndTag(t, "v2", "v2.0.0")
+
+	if out, err := env.run(t, project, "recast", "--dry-run", "--set", "foo=updated"); err != nil {
+		t.Fatalf("recast --dry-run failed: %v\n%s", err, out)
+	}
+
+	readmeAfter, _ := os.ReadFile(filepath.Join(project, "README.md"))
+	manAfter, _ := os.ReadFile(manifestPath)
+	if string(readmeBefore) != string(readmeAfter) {
+		t.Errorf("README.md changed under --dry-run\nbefore:\n%s\nafter:\n%s", readmeBefore, readmeAfter)
+	}
+	if string(manBefore) != string(manAfter) {
+		t.Errorf("installed.yaml changed under --dry-run\nbefore:\n%s\nafter:\n%s", manBefore, manAfter)
+	}
+}
+
+// TestE2E_Recast_PartialFailureExitsNonZero is intentionally stubbed.
+//
+// The happy-path harness above uses a single synthetic remote per test; to
+// prove "one mold fails, others still re-render, exit code is non-zero" we
+// need either two remotes (one healthy, one whose ls-remote/clone is wired to
+// fail deterministically) or a way to inject a transient failure mid-loop.
+// Both are bigger than a single test-file change and orthogonal to the ref-
+// scheme question this task was scoped around — so leaving as a marker for a
+// follow-up rather than smuggling a flaky network failure into CI.
+func TestE2E_Recast_PartialFailureExitsNonZero(t *testing.T) {
+	if testing.Short() {
+		t.Skip("e2e binary build is slow; skipping in -short mode")
+	}
+	t.Skip("TODO: requires multi-remote sandbox; tracked as follow-up to the recast e2e harness")
+}

--- a/internal/commands/recast_e2e_test.go
+++ b/internal/commands/recast_e2e_test.go
@@ -60,13 +60,31 @@ func (e *recastE2EEnv) extraEnv() []string {
 	}
 }
 
+// sandboxEnv returns os.Environ() with all GIT_* variables stripped, then the
+// sandbox additions appended. This matters when the test runs inside a git
+// hook (e.g. lefthook's pre-push) because git sets GIT_DIR / GIT_INDEX_FILE /
+// GIT_WORK_TREE in the hook environment, and any subprocess that inherits
+// those would operate on the OUTER repo regardless of cmd.Dir — causing the
+// test's git operations to mutate the developer's repo instead of the
+// per-test sandbox.
+func (e *recastE2EEnv) sandboxEnv() []string {
+	out := make([]string, 0, len(os.Environ()))
+	for _, kv := range os.Environ() {
+		if strings.HasPrefix(kv, "GIT_") {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return append(out, e.extraEnv()...)
+}
+
 // run invokes the ailloy binary with the sandbox env applied. dir is the
 // working directory (typically the project under test).
 func (e *recastE2EEnv) run(t *testing.T, dir string, args ...string) ([]byte, error) {
 	t.Helper()
 	cmd := exec.Command(e.bin, args...)
 	cmd.Dir = dir
-	cmd.Env = append(os.Environ(), e.extraEnv()...)
+	cmd.Env = e.sandboxEnv()
 	return cmd.CombinedOutput()
 }
 
@@ -77,7 +95,7 @@ func (e *recastE2EEnv) gitInRepo(t *testing.T, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", args...)
 	cmd.Dir = e.repoDir
-	cmd.Env = append(os.Environ(), e.extraEnv()...)
+	cmd.Env = e.sandboxEnv()
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git %v: %v\n%s", args, err, out)
 	}
@@ -162,7 +180,7 @@ func setupRecastE2EEnv(t *testing.T) *recastE2EEnv {
 
 	// Initialize the bare "remote" repo (where tags will live).
 	bareInit := exec.Command("git", "init", "--bare", "--initial-branch=main", env.bareDir)
-	bareInit.Env = append(os.Environ(), env.extraEnv()...)
+	bareInit.Env = env.sandboxEnv()
 	if out, err := bareInit.CombinedOutput(); err != nil {
 		t.Fatalf("git init --bare: %v\n%s", err, out)
 	}
@@ -171,7 +189,7 @@ func setupRecastE2EEnv(t *testing.T) *recastE2EEnv {
 	// configure a committer identity scoped to this repo (so the test does
 	// not depend on the developer's global git identity).
 	wtInit := exec.Command("git", "init", "--initial-branch=main", env.repoDir)
-	wtInit.Env = append(os.Environ(), env.extraEnv()...)
+	wtInit.Env = env.sandboxEnv()
 	if out, err := wtInit.CombinedOutput(); err != nil {
 		t.Fatalf("git init worktree: %v\n%s", err, out)
 	}

--- a/internal/commands/recast_test.go
+++ b/internal/commands/recast_test.go
@@ -84,6 +84,12 @@ func TestMergeRecastOptions(t *testing.T) {
 			cli:      recastCLIOptions{SetOverrides: []string{"agent.target=bar"}},
 			want:     foundry.CastOptionsRecord{SetOverrides: []string{"agent.target=bar"}},
 		},
+		{
+			name:     "set: combined same-key replace and distinct-key append",
+			recorded: &foundry.CastOptionsRecord{SetOverrides: []string{"a=1", "b=2"}},
+			cli:      recastCLIOptions{SetOverrides: []string{"a=99", "c=3"}},
+			want:     foundry.CastOptionsRecord{SetOverrides: []string{"a=99", "b=2", "c=3"}},
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/commands/recast_test.go
+++ b/internal/commands/recast_test.go
@@ -1,0 +1,97 @@
+package commands
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/nimble-giant/ailloy/pkg/foundry"
+)
+
+func TestMergeRecastOptions(t *testing.T) {
+	cases := []struct {
+		name     string
+		recorded *foundry.CastOptionsRecord
+		cli      recastCLIOptions
+		want     foundry.CastOptionsRecord
+	}{
+		{
+			name:     "empty recorded + empty CLI",
+			recorded: nil,
+			cli:      recastCLIOptions{},
+			want:     foundry.CastOptionsRecord{},
+		},
+		{
+			name:     "empty recorded + CLI flags",
+			recorded: nil,
+			cli: recastCLIOptions{
+				WithWorkflows: true,
+				ValueFiles:    []string{"./a.yaml"},
+				SetOverrides:  []string{"k=v"},
+			},
+			want: foundry.CastOptionsRecord{
+				WithWorkflows: true,
+				ValueFiles:    []string{"./a.yaml"},
+				SetOverrides:  []string{"k=v"},
+			},
+		},
+		{
+			name: "recorded + no CLI replays recorded",
+			recorded: &foundry.CastOptionsRecord{
+				WithWorkflows: true,
+				ValueFiles:    []string{"./a.yaml"},
+				SetOverrides:  []string{"k=v"},
+			},
+			cli: recastCLIOptions{},
+			want: foundry.CastOptionsRecord{
+				WithWorkflows: true,
+				ValueFiles:    []string{"./a.yaml"},
+				SetOverrides:  []string{"k=v"},
+			},
+		},
+		{
+			name:     "with-workflows is OR'd",
+			recorded: &foundry.CastOptionsRecord{WithWorkflows: false},
+			cli:      recastCLIOptions{WithWorkflows: true},
+			want:     foundry.CastOptionsRecord{WithWorkflows: true},
+		},
+		{
+			name:     "value files: recorded first, CLI appended",
+			recorded: &foundry.CastOptionsRecord{ValueFiles: []string{"./a.yaml"}},
+			cli:      recastCLIOptions{ValueFiles: []string{"./b.yaml"}},
+			want:     foundry.CastOptionsRecord{ValueFiles: []string{"./a.yaml", "./b.yaml"}},
+		},
+		{
+			name:     "value files: dedupe exact path",
+			recorded: &foundry.CastOptionsRecord{ValueFiles: []string{"./a.yaml", "./b.yaml"}},
+			cli:      recastCLIOptions{ValueFiles: []string{"./a.yaml", "./c.yaml"}},
+			want:     foundry.CastOptionsRecord{ValueFiles: []string{"./a.yaml", "./b.yaml", "./c.yaml"}},
+		},
+		{
+			name:     "set: distinct keys append",
+			recorded: &foundry.CastOptionsRecord{SetOverrides: []string{"a=1"}},
+			cli:      recastCLIOptions{SetOverrides: []string{"b=2"}},
+			want:     foundry.CastOptionsRecord{SetOverrides: []string{"a=1", "b=2"}},
+		},
+		{
+			name:     "set: same-key collision replaces recorded",
+			recorded: &foundry.CastOptionsRecord{SetOverrides: []string{"a=1", "b=2"}},
+			cli:      recastCLIOptions{SetOverrides: []string{"a=99"}},
+			want:     foundry.CastOptionsRecord{SetOverrides: []string{"a=99", "b=2"}},
+		},
+		{
+			name:     "set: nested-key collision uses dotted prefix",
+			recorded: &foundry.CastOptionsRecord{SetOverrides: []string{"agent.target=foo"}},
+			cli:      recastCLIOptions{SetOverrides: []string{"agent.target=bar"}},
+			want:     foundry.CastOptionsRecord{SetOverrides: []string{"agent.target=bar"}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mergeRecastOptions(tc.recorded, tc.cli)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("got %+v\nwant %+v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/foundry/manifest.go
+++ b/pkg/foundry/manifest.go
@@ -23,7 +23,10 @@ const InstalledManifestPath = ".ailloy/installed.yaml"
 type CastOptionsRecord struct {
 	WithWorkflows bool     `yaml:"withWorkflows,omitempty"`
 	ValueFiles    []string `yaml:"valueFiles,omitempty"`
-	SetOverrides  []string `yaml:"setOverrides,omitempty"`
+	// SetOverrides stores raw `key=value` strings so consumers can re-parse
+	// them through the same --set parser. Do not convert to a map: that
+	// would silently collapse duplicate keys.
+	SetOverrides []string `yaml:"setOverrides,omitempty"`
 }
 
 // InstalledEntry records a mold that was cast into the project.

--- a/pkg/foundry/manifest.go
+++ b/pkg/foundry/manifest.go
@@ -12,20 +12,35 @@ import (
 // InstalledManifestPath is the default project manifest path.
 const InstalledManifestPath = ".ailloy/installed.yaml"
 
+// CastOptionsRecord captures the option-shaped flags that drove a `cast`
+// invocation. Persisted on the installed entry so `recast` can replay them
+// against newer versions without the user having to remember which flags
+// they originally used.
+//
+// Run-time-only flags (e.g. --force-replace-on-parse-error, --global) are
+// intentionally NOT recorded — they are recovery / context-selection flags,
+// not stable preferences.
+type CastOptionsRecord struct {
+	WithWorkflows bool     `yaml:"withWorkflows,omitempty"`
+	ValueFiles    []string `yaml:"valueFiles,omitempty"`
+	SetOverrides  []string `yaml:"setOverrides,omitempty"`
+}
+
 // InstalledEntry records a mold that was cast into the project.
 // Files / FileHashes are populated by RecordInstalledFiles and consumed by
 // UninstallMold so the uninstall flow knows what to remove and can detect
 // post-cast modifications. They are intentionally on the manifest (not the
 // lock) so uninstall keeps working when ailloy.lock has not been opted into.
 type InstalledEntry struct {
-	Name       string            `yaml:"name"`
-	Source     string            `yaml:"source"`
-	Subpath    string            `yaml:"subpath,omitempty"`
-	Version    string            `yaml:"version"`
-	Commit     string            `yaml:"commit"`
-	CastAt     time.Time         `yaml:"castAt"`
-	Files      []string          `yaml:"files,omitempty"`
-	FileHashes map[string]string `yaml:"fileHashes,omitempty"`
+	Name        string             `yaml:"name"`
+	Source      string             `yaml:"source"`
+	Subpath     string             `yaml:"subpath,omitempty"`
+	Version     string             `yaml:"version"`
+	Commit      string             `yaml:"commit"`
+	CastAt      time.Time          `yaml:"castAt"`
+	Files       []string           `yaml:"files,omitempty"`
+	FileHashes  map[string]string  `yaml:"fileHashes,omitempty"`
+	CastOptions *CastOptionsRecord `yaml:"castOptions,omitempty"`
 }
 
 // ArtifactEntry records an installed ingot or ore. Mirrors InstalledEntry

--- a/pkg/foundry/manifest_test.go
+++ b/pkg/foundry/manifest_test.go
@@ -129,12 +129,13 @@ func TestInstalledManifest_RoundTrip_CastOptions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(string(raw), "name: without-options") {
-		idx := strings.Index(string(raw), "name: without-options")
-		tail := string(raw)[idx:]
-		if strings.Contains(tail, "castOptions") {
-			t.Errorf("entry without options should not emit castOptions yaml; got:\n%s", tail)
-		}
+	idx := strings.Index(string(raw), "name: without-options")
+	if idx == -1 {
+		t.Fatalf("expected to find 'name: without-options' in:\n%s", raw)
+	}
+	tail := string(raw)[idx:]
+	if strings.Contains(tail, "castOptions") {
+		t.Errorf("entry without options should not emit castOptions yaml; got:\n%s", tail)
 	}
 }
 

--- a/pkg/foundry/manifest_test.go
+++ b/pkg/foundry/manifest_test.go
@@ -3,6 +3,7 @@ package foundry
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -59,6 +60,81 @@ func TestInstalledManifest_RoundTrip(t *testing.T) {
 	}
 	if loaded.Molds[1].Subpath != "sub/path" {
 		t.Errorf("Subpath = %q", loaded.Molds[1].Subpath)
+	}
+}
+
+func TestInstalledManifest_RoundTrip_CastOptions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".ailloy", "installed.yaml")
+
+	ts := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	original := &InstalledManifest{
+		APIVersion: "v1",
+		Molds: []InstalledEntry{
+			{
+				Name:    "with-options",
+				Source:  "github.com/x/y",
+				Version: "v1.0.0",
+				Commit:  "abc123",
+				CastAt:  ts,
+				CastOptions: &CastOptionsRecord{
+					WithWorkflows: true,
+					ValueFiles:    []string{"./flux/prod.yaml"},
+					SetOverrides:  []string{"agent.targets=foo,bar"},
+				},
+			},
+			{
+				Name:    "without-options",
+				Source:  "github.com/x/z",
+				Version: "v1.0.0",
+				Commit:  "def456",
+				CastAt:  ts,
+			},
+		},
+	}
+
+	if err := WriteInstalledManifest(path, original); err != nil {
+		t.Fatalf("WriteInstalledManifest: %v", err)
+	}
+
+	loaded, err := ReadInstalledManifest(path)
+	if err != nil {
+		t.Fatalf("ReadInstalledManifest: %v", err)
+	}
+	if len(loaded.Molds) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(loaded.Molds))
+	}
+
+	withOpts := loaded.Molds[0]
+	if withOpts.CastOptions == nil {
+		t.Fatalf("expected CastOptions to round-trip, got nil")
+	}
+	if !withOpts.CastOptions.WithWorkflows {
+		t.Errorf("WithWorkflows = false, want true")
+	}
+	if got, want := withOpts.CastOptions.ValueFiles, []string{"./flux/prod.yaml"}; len(got) != 1 || got[0] != want[0] {
+		t.Errorf("ValueFiles = %v, want %v", got, want)
+	}
+	if got, want := withOpts.CastOptions.SetOverrides, []string{"agent.targets=foo,bar"}; len(got) != 1 || got[0] != want[0] {
+		t.Errorf("SetOverrides = %v, want %v", got, want)
+	}
+
+	without := loaded.Molds[1]
+	if without.CastOptions != nil {
+		t.Errorf("expected CastOptions to be nil for entry without options, got %+v", without.CastOptions)
+	}
+
+	// Verify the on-disk yaml omits the castOptions block when absent.
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "name: without-options") {
+		idx := strings.Index(string(raw), "name: without-options")
+		tail := string(raw)[idx:]
+		if strings.Contains(tail, "castOptions") {
+			t.Errorf("entry without options should not emit castOptions yaml; got:\n%s", tail)
+		}
 	}
 }
 


### PR DESCRIPTION
## Description

Makes `ailloy recast` actually re-render mold content (not just bump `installed.yaml`/`ailloy.lock` metadata) and accept the same option-shaped flags as `cast`: `--set`, `--values`/`-f`, `--with-workflows`, `--force-replace-on-parse-error`. Cast now records those options in a new `castOptions` block on each `installed.yaml` entry, and recast replays them — CLI overrides layer on top (`--set` dedupes by key, `--values` by exact path, `--with-workflows` is OR'd) and the merged result is persisted back. `recast` now delegates to `CastMold` per entry, surfaces partial failures as a non-zero exit, and continues to honor `--dry-run` (preview only, no writes).

## Related Issue

N/A

## Testing

- New schema round-trip in `pkg/foundry/manifest_test.go` covers `castOptions` with and without options, including the omitted-yaml case.
- 10-case table-driven `TestMergeRecastOptions` covers all merge rules (OR, dedupe by path, same-key replace, dotted-key collisions, combined append+replace).
- E2E in `internal/commands/recast_e2e_test.go`: cast with `--set`, bump tag upstream, `recast` re-renders with recorded value still applied; `recast --set` overrides and replaces in the manifest; `--dry-run` is byte-for-byte non-mutating. Failure-isolation case is a documented `t.Skip` stub pending a multi-remote sandbox.
- Full `go test -race ./...` clean. Lefthook pre-commit/pre-push hooks pass.

## UAT

In a project with at least one cast mold:
1. `ailloy cast <ref> --set foo=bar --with-workflows` and confirm `.ailloy/installed.yaml` records a `castOptions:` block.
2. Bump the upstream tag, then run `ailloy recast` — the rendered files should reflect the new version with the recorded `--set` still applied.
3. `ailloy recast --set foo=baz` should re-render with the new value and replace (not duplicate) the `foo` entry in the manifest.
4. `ailloy recast --dry-run --set anything=yes` should print a preview with `(would override options)` suffix and leave files/manifest untouched.

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [x] I have updated documentation (if applicable)
- [ ] My commits have DCO sign-off (`git commit -s`)