### PR TITLE
feat(assay): lint hand-rolled ore entries when packaged ore exists

### DIFF
--- a/docs/assay.md
+++ b/docs/assay.md
@@ -57,6 +57,14 @@ ailloy lint
 | `skill-token-budget` | Warning | Skill body exceeds [~5000 tokens](https://agentskills.io/specification#progressive-disclosure) (configurable); move reference material to separate files |
 | `description-imperative` | Suggestion | Description uses [declarative phrasing](https://agentskills.io/skill-creation/optimizing-descriptions#writing-effective-descriptions) ("This skill does...") instead of imperative ("Analyzes...") |
 
+### Mold-tree rules
+
+These rules lint a mold's source tree (rather than rendered AI instruction files) and are invoked automatically by [`ailloy temper`](temper.md):
+
+| Rule | Severity | Description |
+|------|----------|-------------|
+| `ore-shadowing` | Warning | A mold has both a packaged ore at `./ores/<n>/` and hand-rolled `ore.<n>.*` entries in `flux.schema.yaml`; the hand-rolled entries silently shadow the package and almost always indicate a missed cleanup after migrating from the in-tree convention |
+
 ## Claude Plugin Directory Support
 
 Assay automatically detects and lints **Claude plugin directories** — any directory containing a `.claude-plugin/plugin.json` manifest. This includes marketplace repositories that bundle multiple plugins at arbitrary nesting depths.

--- a/internal/commands/temper.go
+++ b/internal/commands/temper.go
@@ -71,6 +71,7 @@ func runTemper(_ *cobra.Command, args []string) error {
 	// allowed because temper only operates on local trees.
 	if result.ManifestKind == "mold" {
 		appendOreDiagnostics(fsys, result)
+		appendMoldAssayDiagnostics(moldDir, result)
 	}
 
 	if result.Name != "" {
@@ -364,6 +365,39 @@ func isWellKnownDefault(dotted string) bool {
 	}
 	switch root {
 	case "output":
+		return true
+	}
+	return false
+}
+
+// appendMoldAssayDiagnostics runs assay rules whose Check function operates on
+// a mold tree (rather than rendered AI instruction files), and appends their
+// findings to the temper result. Suppression follows the standard assay
+// convention: rules can be disabled via .ailloyrc.yaml at the mold root.
+func appendMoldAssayDiagnostics(moldDir string, result *mold.TemperResult) {
+	cfg, err := assay.LoadConfig(moldDir)
+	if err != nil {
+		cfg = assay.DefaultConfig()
+	}
+	ctx := &assay.RuleContext{RootDir: moldDir, Config: cfg}
+	for _, rule := range assay.AllRules() {
+		if !isMoldTreeRule(rule.Name()) {
+			continue
+		}
+		if !cfg.IsRuleEnabled(rule.Name()) {
+			continue
+		}
+		result.Diagnostics = append(result.Diagnostics, rule.Check(ctx)...)
+	}
+}
+
+// isMoldTreeRule names assay rules that lint a mold's source tree (not
+// rendered AI instruction files). They have no DetectedFile inputs and read
+// straight from ctx.RootDir, so they're invoked by temper rather than the
+// assay command's file-driven scan.
+func isMoldTreeRule(name string) bool {
+	switch name {
+	case "ore-shadowing":
 		return true
 	}
 	return false

--- a/internal/commands/temper_ore_test.go
+++ b/internal/commands/temper_ore_test.go
@@ -56,6 +56,62 @@ dependencies:
 	}
 }
 
+// TestTemper_OnMold_OreShadowingRule_Fires verifies that running temper on a
+// mold with both a packaged mold-local ore and stale hand-rolled
+// `ore.<name>.*` entries in flux.schema.yaml surfaces the ore-shadowing
+// warning.
+func TestTemper_OnMold_OreShadowingRule_Fires(t *testing.T) {
+	moldDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(moldDir, "mold.yaml"), []byte("apiVersion: v1\nkind: mold\nname: test-mold\nversion: 1.0.0\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeOreFiles(t, filepath.Join(moldDir, "ores", "status"), "status")
+	schema := "- name: ore.status.enabled\n  type: bool\n"
+	if err := os.WriteFile(filepath.Join(moldDir, "flux.schema.yaml"), []byte(schema), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := &mold.TemperResult{ManifestKind: "mold"}
+	appendMoldAssayDiagnostics(moldDir, result)
+
+	var saw bool
+	for _, d := range result.Warnings() {
+		if d.Rule == "ore-shadowing" && strings.Contains(d.Message, "ore.status.") {
+			saw = true
+		}
+	}
+	if !saw {
+		t.Errorf("expected ore-shadowing warning, got %+v", result.Diagnostics)
+	}
+}
+
+// TestTemper_OnMold_OreShadowingRule_SuppressedByConfig verifies that
+// disabling the rule via .ailloyrc.yaml prevents the warning.
+func TestTemper_OnMold_OreShadowingRule_SuppressedByConfig(t *testing.T) {
+	moldDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(moldDir, "mold.yaml"), []byte("apiVersion: v1\nkind: mold\nname: test-mold\nversion: 1.0.0\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeOreFiles(t, filepath.Join(moldDir, "ores", "status"), "status")
+	schema := "- name: ore.status.enabled\n  type: bool\n"
+	if err := os.WriteFile(filepath.Join(moldDir, "flux.schema.yaml"), []byte(schema), 0644); err != nil {
+		t.Fatal(err)
+	}
+	rcYAML := "assay:\n  rules:\n    ore-shadowing:\n      enabled: false\n"
+	if err := os.WriteFile(filepath.Join(moldDir, ".ailloyrc.yaml"), []byte(rcYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := &mold.TemperResult{ManifestKind: "mold"}
+	appendMoldAssayDiagnostics(moldDir, result)
+
+	for _, d := range result.Diagnostics {
+		if d.Rule == "ore-shadowing" {
+			t.Errorf("ore-shadowing should be suppressed, but fired: %+v", d)
+		}
+	}
+}
+
 // TestTemper_OnOreDir_PrefixedEntry_Errors verifies that an ore directory
 // whose flux.schema.yaml contains a pre-prefixed entry name (`ore.x` or
 // `<oreName>.x`) is reported as an error — entries must be unprefixed.

--- a/pkg/assay/config.go
+++ b/pkg/assay/config.go
@@ -236,6 +236,8 @@ assay:
         error-pct: 25             # error when instructions exceed this % of effective context window
         # warn-tokens: 18400     # optional: override with absolute token count
         # error-tokens: 46000    # optional: override with absolute token count
+    ore-shadowing:
+      enabled: true              # warn when a mold has both ./ores/<n>/ and ore.<n>.* entries in flux.schema.yaml
   ignore: []
     # - "vendor/**"
     # - ".claude/rules/generated-*.md"

--- a/pkg/assay/rationales.go
+++ b/pkg/assay/rationales.go
@@ -30,6 +30,7 @@ var ruleRationales = map[string]string{
 	"skill-token-budget":          "Skills should keep their SKILL.md body under 5000 tokens to avoid consuming excessive context. Move reference material to separate files. See: https://agentskills.io/specification#progressive-disclosure",
 	"description-imperative":      "Descriptions using declarative phrasing ('This skill does...') trigger less reliably than imperative phrasing ('Use this skill when...'). See: https://agentskills.io/skill-creation/optimizing-descriptions#writing-effective-descriptions",
 	"context-usage":               "Every @import expands inline, consuming context window budget that could be used for code, conversation, and tool results. Progressive context disclosure — loading instructions on-demand via skills and reference files — keeps overhead low and improves model performance. See: https://agentskills.io/specification#progressive-disclosure",
+	"ore-shadowing":               "Mold-local flux.schema.yaml entries silently win over packaged ore overlays of the same namespace. Carrying both is almost always a leftover from migrating an in-tree ore to a packaged one — the package contributes nothing until the hand-rolled entries are removed.",
 }
 
 // RuleRationale returns the educational rationale for a rule, or empty string if none is defined.

--- a/pkg/assay/rules_ore.go
+++ b/pkg/assay/rules_ore.go
@@ -1,0 +1,107 @@
+package assay
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/nimble-giant/ailloy/pkg/mold"
+)
+
+func init() {
+	Register(&oreShadowingRule{})
+}
+
+// oreShadowingRule warns when a mold ships a packaged ore at ./ores/<name>/
+// while also carrying hand-rolled `ore.<name>.*` entries in flux.schema.yaml.
+// The mold-local entries silently win (per the mold-wins precedence rule),
+// which almost always indicates the author forgot to clean up after migrating
+// from the in-tree convention to the packaged-ore convention.
+type oreShadowingRule struct{}
+
+func (r *oreShadowingRule) Name() string                       { return "ore-shadowing" }
+func (r *oreShadowingRule) DefaultSeverity() mold.DiagSeverity { return mold.SeverityWarning }
+func (r *oreShadowingRule) Platforms() []Platform              { return nil }
+
+func (r *oreShadowingRule) Check(ctx *RuleContext) []mold.Diagnostic {
+	if ctx == nil || ctx.RootDir == "" {
+		return nil
+	}
+
+	// Only applicable inside a mold tree.
+	if _, err := os.Stat(filepath.Join(ctx.RootDir, "mold.yaml")); err != nil {
+		return nil
+	}
+
+	oresDir := filepath.Join(ctx.RootDir, "ores")
+	entries, err := os.ReadDir(oresDir)
+	if err != nil {
+		return nil
+	}
+
+	type oreInfo struct {
+		installDir string
+		namespace  string
+	}
+	var packaged []oreInfo
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		manifestPath := filepath.Join(oresDir, e.Name(), "ore.yaml")
+		if _, err := os.Stat(manifestPath); err != nil {
+			continue
+		}
+		ore, err := mold.LoadOre(manifestPath)
+		if err != nil || ore == nil {
+			continue
+		}
+		ns := e.Name()
+		if e.Name() == ore.Name {
+			ns = ore.EffectiveNamespace()
+		}
+		if ns == "" {
+			continue
+		}
+		packaged = append(packaged, oreInfo{installDir: e.Name(), namespace: ns})
+	}
+	if len(packaged) == 0 {
+		return nil
+	}
+
+	schema, err := mold.LoadFluxSchema(os.DirFS(ctx.RootDir), "flux.schema.yaml")
+	if err != nil || len(schema) == 0 {
+		return nil
+	}
+
+	sort.Slice(packaged, func(i, j int) bool {
+		return packaged[i].installDir < packaged[j].installDir
+	})
+
+	var diags []mold.Diagnostic
+	for _, oi := range packaged {
+		prefix := "ore." + oi.namespace + "."
+		hasMatch := false
+		for _, fv := range schema {
+			if strings.HasPrefix(fv.Name, prefix) {
+				hasMatch = true
+				break
+			}
+		}
+		if !hasMatch {
+			continue
+		}
+		diags = append(diags, mold.Diagnostic{
+			Severity: r.DefaultSeverity(),
+			Message: fmt.Sprintf(
+				"flux.schema.yaml contains entries with prefix %q while a packaged ore exists at ./ores/%s/. Either remove the in-tree entries (they're shadowing the packaged ore) or remove the package.",
+				prefix, oi.installDir,
+			),
+			File: "flux.schema.yaml",
+			Rule: r.Name(),
+		})
+	}
+	return diags
+}

--- a/pkg/assay/rules_ore_test.go
+++ b/pkg/assay/rules_ore_test.go
@@ -1,0 +1,214 @@
+package assay
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeMoldWithOre lays out a minimal mold tree with an optional packaged ore
+// at ores/<oreName>/ and an optional flux.schema.yaml. Both args may be empty
+// to skip writing them.
+func writeMoldWithOre(t *testing.T, root, oreName, fluxSchema string) {
+	t.Helper()
+	if err := os.MkdirAll(root, 0750); err != nil {
+		t.Fatal(err)
+	}
+	moldYAML := "apiVersion: v1\nkind: mold\nname: test-mold\nversion: 1.0.0\n"
+	if err := os.WriteFile(filepath.Join(root, "mold.yaml"), []byte(moldYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if oreName != "" {
+		oreDir := filepath.Join(root, "ores", oreName)
+		if err := os.MkdirAll(oreDir, 0750); err != nil {
+			t.Fatal(err)
+		}
+		oreYAML := "apiVersion: v1\nkind: ore\nname: " + oreName + "\nversion: 1.0.0\n"
+		if err := os.WriteFile(filepath.Join(oreDir, "ore.yaml"), []byte(oreYAML), 0644); err != nil {
+			t.Fatal(err)
+		}
+		schema := "- name: enabled\n  type: bool\n  default: \"false\"\n"
+		if err := os.WriteFile(filepath.Join(oreDir, "flux.schema.yaml"), []byte(schema), 0644); err != nil {
+			t.Fatal(err)
+		}
+		defaults := "enabled: false\n"
+		if err := os.WriteFile(filepath.Join(oreDir, "flux.yaml"), []byte(defaults), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if fluxSchema != "" {
+		if err := os.WriteFile(filepath.Join(root, "flux.schema.yaml"), []byte(fluxSchema), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestOreShadowingRule_FiresOnCollision(t *testing.T) {
+	root := t.TempDir()
+	schema := "- name: ore.status.enabled\n  type: bool\n- name: ore.status.field_id\n  type: string\n"
+	writeMoldWithOre(t, root, "status", schema)
+
+	rule := &oreShadowingRule{}
+	ctx := &RuleContext{RootDir: root, Config: DefaultConfig()}
+	diags := rule.Check(ctx)
+
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic, got %d: %+v", len(diags), diags)
+	}
+	d := diags[0]
+	if d.Rule != "ore-shadowing" {
+		t.Errorf("Rule = %q, want ore-shadowing", d.Rule)
+	}
+	if d.File != "flux.schema.yaml" {
+		t.Errorf("File = %q, want flux.schema.yaml", d.File)
+	}
+	if !strings.Contains(d.Message, "ore.status.") {
+		t.Errorf("Message missing prefix: %q", d.Message)
+	}
+	if !strings.Contains(d.Message, "./ores/status/") {
+		t.Errorf("Message missing ore path: %q", d.Message)
+	}
+}
+
+func TestOreShadowingRule_QuietWhenOnlyOneSide(t *testing.T) {
+	t.Run("only packaged ore", func(t *testing.T) {
+		root := t.TempDir()
+		writeMoldWithOre(t, root, "status", "- name: project.name\n  type: string\n")
+
+		diags := (&oreShadowingRule{}).Check(&RuleContext{RootDir: root, Config: DefaultConfig()})
+		if len(diags) != 0 {
+			t.Fatalf("expected no diagnostics, got %+v", diags)
+		}
+	})
+
+	t.Run("only hand-rolled entries", func(t *testing.T) {
+		root := t.TempDir()
+		schema := "- name: ore.status.enabled\n  type: bool\n"
+		writeMoldWithOre(t, root, "", schema)
+
+		diags := (&oreShadowingRule{}).Check(&RuleContext{RootDir: root, Config: DefaultConfig()})
+		if len(diags) != 0 {
+			t.Fatalf("expected no diagnostics, got %+v", diags)
+		}
+	})
+
+	t.Run("packaged ore for unrelated namespace", func(t *testing.T) {
+		root := t.TempDir()
+		// status is packaged, but flux.schema.yaml only has ore.priority entries.
+		schema := "- name: ore.priority.enabled\n  type: bool\n"
+		writeMoldWithOre(t, root, "status", schema)
+
+		diags := (&oreShadowingRule{}).Check(&RuleContext{RootDir: root, Config: DefaultConfig()})
+		if len(diags) != 0 {
+			t.Fatalf("expected no diagnostics, got %+v", diags)
+		}
+	})
+}
+
+func TestOreShadowingRule_OnlyFiresInsideMoldTree(t *testing.T) {
+	root := t.TempDir()
+	// Build the tree but omit mold.yaml so the rule should bail out.
+	oreDir := filepath.Join(root, "ores", "status")
+	if err := os.MkdirAll(oreDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(oreDir, "ore.yaml"), []byte("apiVersion: v1\nkind: ore\nname: status\nversion: 1.0.0\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "flux.schema.yaml"), []byte("- name: ore.status.enabled\n  type: bool\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	diags := (&oreShadowingRule{}).Check(&RuleContext{RootDir: root, Config: DefaultConfig()})
+	if len(diags) != 0 {
+		t.Fatalf("expected no diagnostics outside a mold tree, got %+v", diags)
+	}
+}
+
+func TestOreShadowingRule_MultipleNamespaces(t *testing.T) {
+	root := t.TempDir()
+	writeMoldWithOre(t, root, "status", "")
+	// Add a second packaged ore at ores/priority/
+	priorityDir := filepath.Join(root, "ores", "priority")
+	if err := os.MkdirAll(priorityDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(priorityDir, "ore.yaml"), []byte("apiVersion: v1\nkind: ore\nname: priority\nversion: 1.0.0\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	schema := "- name: ore.status.enabled\n  type: bool\n- name: ore.priority.enabled\n  type: bool\n"
+	if err := os.WriteFile(filepath.Join(root, "flux.schema.yaml"), []byte(schema), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	diags := (&oreShadowingRule{}).Check(&RuleContext{RootDir: root, Config: DefaultConfig()})
+	if len(diags) != 2 {
+		t.Fatalf("expected 2 diagnostics, got %d: %+v", len(diags), diags)
+	}
+	// Sorted by install dir: priority comes before status.
+	if !strings.Contains(diags[0].Message, "ore.priority.") {
+		t.Errorf("first diagnostic should mention priority, got %q", diags[0].Message)
+	}
+	if !strings.Contains(diags[1].Message, "ore.status.") {
+		t.Errorf("second diagnostic should mention status, got %q", diags[1].Message)
+	}
+}
+
+func TestOreShadowingRule_HonorsAlias(t *testing.T) {
+	// When the install-dir name differs from ore.Name (alias case), the
+	// install-dir name wins as the namespace.
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "mold.yaml"), []byte("apiVersion: v1\nkind: mold\nname: test-mold\nversion: 1.0.0\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Install dir is "github_status" but the underlying ore.Name is "status".
+	oreDir := filepath.Join(root, "ores", "github_status")
+	if err := os.MkdirAll(oreDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(oreDir, "ore.yaml"), []byte("apiVersion: v1\nkind: ore\nname: status\nversion: 1.0.0\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// flux.schema.yaml carries ore.github_status.* — should fire.
+	schema := "- name: ore.github_status.enabled\n  type: bool\n- name: ore.status.enabled\n  type: bool\n"
+	if err := os.WriteFile(filepath.Join(root, "flux.schema.yaml"), []byte(schema), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	diags := (&oreShadowingRule{}).Check(&RuleContext{RootDir: root, Config: DefaultConfig()})
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic for alias, got %d: %+v", len(diags), diags)
+	}
+	if !strings.Contains(diags[0].Message, "ore.github_status.") {
+		t.Errorf("expected diagnostic to use alias namespace, got %q", diags[0].Message)
+	}
+	if !strings.Contains(diags[0].Message, "./ores/github_status/") {
+		t.Errorf("expected diagnostic to reference install dir, got %q", diags[0].Message)
+	}
+}
+
+func TestOreShadowingRule_RegisteredAndSuppressible(t *testing.T) {
+	// The rule must be registered so .ailloyrc.yaml can disable it by name.
+	var found *oreShadowingRule
+	for _, r := range AllRules() {
+		if r.Name() == "ore-shadowing" {
+			if cast, ok := r.(*oreShadowingRule); ok {
+				found = cast
+			}
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("ore-shadowing rule not registered in global registry")
+	}
+
+	// Verify Config.IsRuleEnabled honors disabled config.
+	disabled := false
+	cfg := &Config{Rules: map[string]RuleConfig{
+		"ore-shadowing": {Enabled: &disabled},
+	}}
+	if cfg.IsRuleEnabled("ore-shadowing") {
+		t.Error("expected ore-shadowing to be disabled by config")
+	}
+}


### PR DESCRIPTION
## Description

Adds a new `ore-shadowing` assay rule that warns when a mold ships both a packaged ore at `./ores/<n>/` and stale `ore.<n>.*` entries in `flux.schema.yaml` — the in-tree entries silently shadow the package per the mold-wins precedence rule, almost always indicating the author forgot to clean up after migrating to the packaged convention. The rule is registered in the assay registry, suppressible via `assay.rules.ore-shadowing.enabled: false` in `.ailloyrc.yaml`, and wired into `ailloy temper` so it fires whenever an author validates a mold.

## Related Issue

Fixes #186

## Testing

`go test -race ./pkg/assay/... ./internal/commands/...` — direct rule tests cover collision firing, single-side quiet cases (only package, only hand-rolled, unrelated namespace), outside-mold no-op, multiple namespaces, and the alias case where install-dir name differs from `ore.Name`. Integration tests in `temper_ore_test.go` verify the rule fires through `appendMoldAssayDiagnostics` and is suppressed by `.ailloyrc.yaml`. `gofmt`, `go vet`, and lefthook pre-push (build + lint + test) all pass.

## UAT

In a mold with `./ores/status/` and a stale `ore.status.enabled` entry in `flux.schema.yaml`, run `ailloy temper ./my-mold` and confirm the warning fires. Add `.ailloyrc.yaml` with `assay.rules.ore-shadowing.enabled: false` and re-run to confirm suppression.

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [x] I have updated documentation (if applicable)
- [x] My commits have DCO sign-off (`git commit -s`)