### PR TITLE
feat(cli): multi-ingot package layout (parity with ore) #200

### DIFF
--- a/docs/ingots.md
+++ b/docs/ingots.md
@@ -53,6 +53,35 @@ ingots/
 
 Bare files are simpler but limited to a single file. The resolver tries the manifest-based form first, then falls back to bare files.
 
+## Multi-Ingot Repository Layout
+
+A single git repository can ship multiple ingots side-by-side. Place each one under `ingots/<name>/` with its own `ingot.yaml`:
+
+```
+my-ingots/
+├── ingots/
+│   ├── pr-helpers/
+│   │   ├── ingot.yaml
+│   │   └── content.md
+│   └── issue-helpers/
+│       ├── ingot.yaml
+│       └── content.md
+```
+
+A repo with a top-level `ingot.yaml` is still treated as a single ingot at root — that remains the default and is unaffected. The two layouts are mutually exclusive: if a top-level `ingot.yaml` exists, the `ingots/` directory is ignored.
+
+`ailloy ingot add github.com/org/repo` against a multi-ingot repo (no `//subpath`) installs every ingot in the repo. To install just one, append the subpath: `ailloy ingot add github.com/org/repo//ingots/pr-helpers`.
+
+Mold `mold.yaml` dependency entries follow the same rule. A bare ref pulls in every ingot in the repo at cast time; a `//subpath` ref pins one:
+
+```yaml
+dependencies:
+  - ingot: github.com/org/repo                       # all ingots
+  - ingot: github.com/org/repo//ingots/pr-helpers    # just one
+```
+
+`ailloy temper github.com/org/repo` validates each ingot in the repo independently and aggregates the diagnostics — one bad ingot does not mask the others.
+
 ## Creating an Ingot
 
 ### 1. Create the ingot directory

--- a/internal/commands/ingot.go
+++ b/internal/commands/ingot.go
@@ -34,9 +34,7 @@ After download, the cache path is printed.`,
 	RunE: runIngotGet,
 }
 
-var (
-	ingotAddGlobal bool
-)
+var ingotAddGlobal bool
 
 var ingotAddCmd = &cobra.Command{
 	Use:   "add <reference>",
@@ -130,11 +128,11 @@ func runIngotAdd(_ *cobra.Command, args []string) error {
 	return installIngotsFromFS(fsys, result, ingotAddGlobal)
 }
 
-// runIngotAddFromLocal is a test-only seam that drives the multi-package install
-// pipeline against a local fs.FS without going through the foundry resolver.
-// We synthesize a ResolveResult that recordInstalledArtifact / lock writes will
-// accept; the source string uses the local path so identity is stable across
-// re-installs from the same source.
+// runIngotAddFromLocal is a test-only seam (not part of the CLI surface) that
+// drives the multi-package install pipeline against a local fs.FS without
+// going through the foundry resolver. We synthesize a ResolveResult so the
+// manifest + lock writes carry a stable source identity ("local/fs/<base>")
+// across re-installs from the same source.
 func runIngotAddFromLocal(localDir string, global bool) error {
 	fsys := os.DirFS(localDir)
 	result := &foundry.ResolveResult{
@@ -167,9 +165,51 @@ func installIngotsFromFS(fsys fs.FS, result *foundry.ResolveResult, global bool)
 		return fmt.Errorf("no ingot.yaml found at root or under ingots/<name>/")
 	}
 
+	// Read manifest once; we'll batch all package upserts before writing.
+	manifestPath := manifestPathFor(global)
+	var manifest *foundry.InstalledManifest
+	if manifestPath != "" {
+		manifest, _ = foundry.ReadInstalledManifest(manifestPath)
+		if manifest == nil {
+			manifest = &foundry.InstalledManifest{APIVersion: "v1"}
+		}
+	}
+
+	// Read lock once; project-scope only. ailloy.lock is project-only today.
+	var lock *foundry.LockFile
+	if !global {
+		lock, _ = foundry.ReadLockFile(foundry.LockFileName)
+	}
+
 	for _, p := range pkgs {
-		if err := installSingleIngot(fsys, p, result, global); err != nil {
-			return err
+		entry, lerr := installSingleIngot(fsys, p, result, global)
+		if lerr != nil {
+			return lerr
+		}
+		if manifest != nil {
+			manifest.UpsertArtifact("ingot", entry)
+		}
+		if lock != nil {
+			lock.UpsertArtifactLock("ingot", foundry.LockEntry{
+				Name:      entry.Name,
+				Source:    entry.Source,
+				Subpath:   entry.Subpath,
+				Version:   entry.Version,
+				Commit:    entry.Commit,
+				Timestamp: entry.InstalledAt,
+			})
+		}
+	}
+
+	if manifest != nil && manifestPath != "" {
+		if err := foundry.WriteInstalledManifest(manifestPath, manifest); err != nil {
+			log.Printf("warning: failed to update installed manifest: %v", err)
+		}
+	}
+	// Update ailloy.lock if present (project scope only).
+	if lock != nil {
+		if err := foundry.WriteLockFile(foundry.LockFileName, lock); err != nil {
+			log.Printf("warning: failed to update lock file: %v", err)
 		}
 	}
 
@@ -182,7 +222,10 @@ func installIngotsFromFS(fsys fs.FS, result *foundry.ResolveResult, global bool)
 	return nil
 }
 
-func installSingleIngot(fsys fs.FS, pkg mold.IngotPackage, result *foundry.ResolveResult, global bool) error {
+// installSingleIngot copies one package onto disk and returns the ArtifactEntry
+// the caller should upsert into the installed manifest. The caller batches the
+// manifest + lock writes; this function only owns disk-side install of files.
+func installSingleIngot(fsys fs.FS, pkg mold.IngotPackage, result *foundry.ResolveResult, global bool) (foundry.ArtifactEntry, error) {
 	// Effective subpath: the resolver may already have rooted fsys at a //subpath
 	// (in which case result.Ref.Subpath is set and pkg.Subpath is "" because pkg
 	// was discovered at the root of that already-narrowed fsys). When we fan out
@@ -197,20 +240,20 @@ func installSingleIngot(fsys fs.FS, pkg mold.IngotPackage, result *foundry.Resol
 	if global {
 		home, herr := os.UserHomeDir()
 		if herr != nil {
-			return fmt.Errorf("determining home directory: %w", herr)
+			return foundry.ArtifactEntry{}, fmt.Errorf("determining home directory: %w", herr)
 		}
 		baseRoot = filepath.Join(home, ".ailloy", "ingots")
 	}
 	destDir := filepath.Join(baseRoot, pkg.Name)
 	if err := os.MkdirAll(destDir, 0o750); err != nil {
-		return fmt.Errorf("creating ingot directory: %w", err)
+		return foundry.ArtifactEntry{}, fmt.Errorf("creating ingot directory: %w", err)
 	}
 
 	pkgFS := fsys
 	if pkg.Root != "." {
 		sub, serr := fs.Sub(fsys, pkg.Root)
 		if serr != nil {
-			return fmt.Errorf("scoping fs to %s: %w", pkg.Root, serr)
+			return foundry.ArtifactEntry{}, fmt.Errorf("scoping fs to %s: %w", pkg.Root, serr)
 		}
 		pkgFS = sub
 	}
@@ -227,43 +270,22 @@ func installSingleIngot(fsys fs.FS, pkg mold.IngotPackage, result *foundry.Resol
 		if rerr != nil {
 			return fmt.Errorf("reading %s: %w", p, rerr)
 		}
-		if err := os.WriteFile(destPath, content, 0o644); err != nil { //#nosec G306
+		if err := os.WriteFile(destPath, content, 0o644); err != nil { // #nosec G306 -- ingot files need to be readable
 			return fmt.Errorf("writing %s: %w", destPath, err)
 		}
 		fmt.Println(styles.SuccessStyle.Render("  + ") + styles.CodeStyle.Render(destPath))
 		return nil
 	}); err != nil {
-		return fmt.Errorf("copying ingot files: %w", err)
+		return foundry.ArtifactEntry{}, fmt.Errorf("copying ingot files: %w", err)
 	}
 
-	// Synthesize a per-package ResolveResult so the recordInstalledArtifact +
-	// lock writes carry the correct (Source, Subpath) identity. Ref is a
-	// pointer, so we deep-copy it before mutating to avoid clobbering shared
-	// state across pkgs in the same fan-out.
-	perPkgResult := *result
-	refCopy := *result.Ref
-	refCopy.Subpath = effectiveSubpath
-	refCopy.Repo = pkg.Name
-	perPkgResult.Ref = &refCopy
-
-	if err := recordInstalledArtifact("ingot", &perPkgResult, "", global); err != nil {
-		log.Printf("warning: failed to update installed manifest: %v", err)
-	}
-
-	if !global {
-		if lock, _ := foundry.ReadLockFile(foundry.LockFileName); lock != nil {
-			lock.UpsertArtifactLock("ingot", foundry.LockEntry{
-				Name:      pkg.Name,
-				Source:    result.Ref.CacheKey(),
-				Subpath:   effectiveSubpath,
-				Version:   result.Resolved.Tag,
-				Commit:    result.Resolved.Commit,
-				Timestamp: time.Now().UTC(),
-			})
-			if werr := foundry.WriteLockFile(foundry.LockFileName, lock); werr != nil {
-				log.Printf("warning: failed to update lock file: %v", werr)
-			}
-		}
-	}
-	return nil
+	return foundry.ArtifactEntry{
+		Name:        pkg.Name,
+		Source:      result.Ref.CacheKey(),
+		Subpath:     effectiveSubpath,
+		Version:     result.Resolved.Tag,
+		Commit:      result.Resolved.Commit,
+		InstalledAt: time.Now().UTC(),
+		Dependents:  []string{"user"},
+	}, nil
 }

--- a/internal/commands/ingot.go
+++ b/internal/commands/ingot.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/nimble-giant/ailloy/pkg/foundry"
 	"github.com/nimble-giant/ailloy/pkg/mold"
@@ -33,10 +34,18 @@ After download, the cache path is printed.`,
 	RunE: runIngotGet,
 }
 
+var (
+	ingotAddGlobal bool
+)
+
 var ingotAddCmd = &cobra.Command{
 	Use:   "add <reference>",
 	Short: "Download and register an ingot",
 	Long: `Download an ingot and register it in the project's .ailloy/ingots/ directory.
+
+If the reference points to a multi-ingot repo (containing ingots/<name>/ingot.yaml
+entries) and no //subpath is given, every ingot in the repo is installed. To install
+just one, use the //ingots/<name> subpath suffix.
 
 The ingot files are copied into .ailloy/ingots/<name>/ for use by the template engine.`,
 	Args: cobra.ExactArgs(1),
@@ -47,6 +56,8 @@ func init() {
 	rootCmd.AddCommand(ingotCmd)
 	ingotCmd.AddCommand(ingotGetCmd)
 	ingotCmd.AddCommand(ingotAddCmd)
+
+	ingotAddCmd.Flags().BoolVar(&ingotAddGlobal, "global", false, "install under ~/.ailloy/ingots/ instead of ./.ailloy/ingots/")
 }
 
 func runIngotGet(_ *cobra.Command, args []string) error {
@@ -116,52 +127,143 @@ func runIngotAdd(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("resolving ingot: %w", err)
 	}
 
-	// Validate ingot.yaml exists.
-	ingot, err := mold.LoadIngotFromFS(fsys, "ingot.yaml")
+	return installIngotsFromFS(fsys, result, ingotAddGlobal)
+}
+
+// runIngotAddFromLocal is a test-only seam that drives the multi-package install
+// pipeline against a local fs.FS without going through the foundry resolver.
+// We synthesize a ResolveResult that recordInstalledArtifact / lock writes will
+// accept; the source string uses the local path so identity is stable across
+// re-installs from the same source.
+func runIngotAddFromLocal(localDir string, global bool) error {
+	fsys := os.DirFS(localDir)
+	result := &foundry.ResolveResult{
+		Ref: &foundry.Reference{
+			Host:  "local",
+			Owner: "fs",
+			Repo:  filepath.Base(localDir),
+		},
+		Resolved: foundry.ResolvedVersion{
+			Tag:    "local",
+			Commit: "local",
+		},
+	}
+	return installIngotsFromFS(fsys, result, global)
+}
+
+// installIngotsFromFS handles single-ingot and multi-ingot layouts. Per
+// issue #200:
+//   - Bare ref into multi-layout: install every ingot.
+//   - //subpath ref: foundry.Resolve already roots fsys at the subpath, so
+//     this looks like single-at-root and installs just that one.
+//   - Root manifest in fsys: install the single ingot.
+//   - No manifests anywhere: error.
+func installIngotsFromFS(fsys fs.FS, result *foundry.ResolveResult, global bool) error {
+	pkgs, err := mold.DiscoverIngotPackages(fsys)
 	if err != nil {
-		return fmt.Errorf("invalid ingot manifest: %w", err)
+		return fmt.Errorf("discovering ingots: %w", err)
+	}
+	if len(pkgs) == 0 {
+		return fmt.Errorf("no ingot.yaml found at root or under ingots/<name>/")
 	}
 
-	// Copy ingot into project .ailloy/ingots/<name>/
-	destDir := filepath.Join(".ailloy", "ingots", ingot.Name)
-	if err := os.MkdirAll(destDir, 0750); err != nil {
-		return fmt.Errorf("creating ingot directory: %w", err)
-	}
-
-	err = fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
+	for _, p := range pkgs {
+		if err := installSingleIngot(fsys, p, result, global); err != nil {
 			return err
 		}
-
-		destPath := filepath.Join(destDir, path)
-
-		if d.IsDir() {
-			return os.MkdirAll(destPath, 0750)
-		}
-
-		content, err := fs.ReadFile(fsys, path)
-		if err != nil {
-			return fmt.Errorf("reading %s: %w", path, err)
-		}
-
-		if err := os.WriteFile(destPath, content, 0644); err != nil { // #nosec G306 -- ingot files need to be readable
-			return fmt.Errorf("writing %s: %w", destPath, err)
-		}
-
-		fmt.Println(styles.SuccessStyle.Render("  + ") + styles.CodeStyle.Render(destPath))
-		return nil
-	})
-	if err != nil {
-		return fmt.Errorf("copying ingot files: %w", err)
 	}
 
 	fmt.Println()
-	fmt.Println(styles.SuccessStyle.Render("Ingot added: ") + styles.AccentStyle.Render(ingot.Name+" "+ingot.Version))
-	fmt.Println(styles.InfoStyle.Render("Installed to: ") + styles.CodeStyle.Render(destDir))
+	if len(pkgs) == 1 {
+		fmt.Println(styles.SuccessStyle.Render("Ingot added: ") + styles.AccentStyle.Render(pkgs[0].Name+" "+pkgs[0].Version))
+	} else {
+		fmt.Println(styles.SuccessStyle.Render(fmt.Sprintf("Installed %d ingots from %s", len(pkgs), result.Ref.CacheKey())))
+	}
+	return nil
+}
 
-	if err := recordInstalled(result, false, nil, "direct", nil, nil); err != nil {
+func installSingleIngot(fsys fs.FS, pkg mold.IngotPackage, result *foundry.ResolveResult, global bool) error {
+	// Effective subpath: the resolver may already have rooted fsys at a //subpath
+	// (in which case result.Ref.Subpath is set and pkg.Subpath is "" because pkg
+	// was discovered at the root of that already-narrowed fsys). When we fan out
+	// over a multi-package fsys, pkg.Subpath carries "ingots/<name>" and joins
+	// with result.Ref.Subpath which is "". We pick whichever is non-empty.
+	effectiveSubpath := result.Ref.Subpath
+	if effectiveSubpath == "" {
+		effectiveSubpath = pkg.Subpath
+	}
+
+	baseRoot := filepath.Join(".ailloy", "ingots")
+	if global {
+		home, herr := os.UserHomeDir()
+		if herr != nil {
+			return fmt.Errorf("determining home directory: %w", herr)
+		}
+		baseRoot = filepath.Join(home, ".ailloy", "ingots")
+	}
+	destDir := filepath.Join(baseRoot, pkg.Name)
+	if err := os.MkdirAll(destDir, 0o750); err != nil {
+		return fmt.Errorf("creating ingot directory: %w", err)
+	}
+
+	pkgFS := fsys
+	if pkg.Root != "." {
+		sub, serr := fs.Sub(fsys, pkg.Root)
+		if serr != nil {
+			return fmt.Errorf("scoping fs to %s: %w", pkg.Root, serr)
+		}
+		pkgFS = sub
+	}
+
+	if err := fs.WalkDir(pkgFS, ".", func(p string, d fs.DirEntry, werr error) error {
+		if werr != nil {
+			return werr
+		}
+		destPath := filepath.Join(destDir, p)
+		if d.IsDir() {
+			return os.MkdirAll(destPath, 0o750)
+		}
+		content, rerr := fs.ReadFile(pkgFS, p)
+		if rerr != nil {
+			return fmt.Errorf("reading %s: %w", p, rerr)
+		}
+		if err := os.WriteFile(destPath, content, 0o644); err != nil { //#nosec G306
+			return fmt.Errorf("writing %s: %w", destPath, err)
+		}
+		fmt.Println(styles.SuccessStyle.Render("  + ") + styles.CodeStyle.Render(destPath))
+		return nil
+	}); err != nil {
+		return fmt.Errorf("copying ingot files: %w", err)
+	}
+
+	// Synthesize a per-package ResolveResult so the recordInstalledArtifact +
+	// lock writes carry the correct (Source, Subpath) identity. Ref is a
+	// pointer, so we deep-copy it before mutating to avoid clobbering shared
+	// state across pkgs in the same fan-out.
+	perPkgResult := *result
+	refCopy := *result.Ref
+	refCopy.Subpath = effectiveSubpath
+	refCopy.Repo = pkg.Name
+	perPkgResult.Ref = &refCopy
+
+	if err := recordInstalledArtifact("ingot", &perPkgResult, "", global); err != nil {
 		log.Printf("warning: failed to update installed manifest: %v", err)
 	}
 
+	if !global {
+		if lock, _ := foundry.ReadLockFile(foundry.LockFileName); lock != nil {
+			lock.UpsertArtifactLock("ingot", foundry.LockEntry{
+				Name:      pkg.Name,
+				Source:    result.Ref.CacheKey(),
+				Subpath:   effectiveSubpath,
+				Version:   result.Resolved.Tag,
+				Commit:    result.Resolved.Commit,
+				Timestamp: time.Now().UTC(),
+			})
+			if werr := foundry.WriteLockFile(foundry.LockFileName, lock); werr != nil {
+				log.Printf("warning: failed to update lock file: %v", werr)
+			}
+		}
+	}
 	return nil
 }

--- a/internal/commands/ingot_multi_test.go
+++ b/internal/commands/ingot_multi_test.go
@@ -65,6 +65,9 @@ func TestRunIngotAdd_SingleIngot_RecordsArtifactAndLock(t *testing.T) {
 	if im.Ingots[0].Subpath != "" {
 		t.Errorf("expected empty subpath for root layout, got %q", im.Ingots[0].Subpath)
 	}
+	if im.Ingots[0].Source != "local/fs/src" {
+		t.Errorf("expected Source=local/fs/src, got %q", im.Ingots[0].Source)
+	}
 	if len(im.Ingots[0].Dependents) != 1 || im.Ingots[0].Dependents[0] != "user" {
 		t.Errorf("expected dependents=[user], got %v", im.Ingots[0].Dependents)
 	}
@@ -75,6 +78,9 @@ func TestRunIngotAdd_SingleIngot_RecordsArtifactAndLock(t *testing.T) {
 	}
 	if len(lf.Ingots) != 1 || lf.Ingots[0].Name != "solo" {
 		t.Fatalf("expected 1 ingot in lock named solo, got %+v", lf.Ingots)
+	}
+	if lf.Ingots[0].Source != "local/fs/src" {
+		t.Errorf("expected lock Source=local/fs/src, got %q", lf.Ingots[0].Source)
 	}
 }
 
@@ -117,6 +123,11 @@ func TestRunIngotAdd_MultiIngot_InstallsAll(t *testing.T) {
 	if bySubpath["ingots/footer"] != "footer" || bySubpath["ingots/header"] != "header" {
 		t.Errorf("expected per-package subpaths, got %v", bySubpath)
 	}
+	for _, e := range im.Ingots {
+		if e.Source != "local/fs/src" {
+			t.Errorf("expected all ingots to share Source=local/fs/src, got %q", e.Source)
+		}
+	}
 
 	lf, err := foundry.ReadLockFile(lockPath)
 	if err != nil || lf == nil {
@@ -124,6 +135,11 @@ func TestRunIngotAdd_MultiIngot_InstallsAll(t *testing.T) {
 	}
 	if len(lf.Ingots) != 2 {
 		t.Fatalf("expected 2 ingots in lock, got %d (%+v)", len(lf.Ingots), lf.Ingots)
+	}
+	for _, e := range lf.Ingots {
+		if e.Source != "local/fs/src" {
+			t.Errorf("expected lock entries to share Source=local/fs/src, got %q", e.Source)
+		}
 	}
 }
 

--- a/internal/commands/ingot_multi_test.go
+++ b/internal/commands/ingot_multi_test.go
@@ -1,0 +1,150 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nimble-giant/ailloy/pkg/foundry"
+)
+
+// writeIngotFixture writes a minimal single-ingot repo at dir.
+func writeIngotFixture(t *testing.T, dir, name, version string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	manifest := "apiVersion: v1\nkind: ingot\nname: " + name + "\nversion: " + version + "\nfiles: [content.md]\n"
+	if err := os.WriteFile(filepath.Join(dir, "ingot.yaml"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("write ingot.yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "content.md"), []byte("# "+name+"\n"), 0o644); err != nil {
+		t.Fatalf("write content.md: %v", err)
+	}
+}
+
+// writeMultiIngotFixture writes a multi-ingot repo with N named ingots under ingots/<name>/.
+func writeMultiIngotFixture(t *testing.T, dir string, names ...string) {
+	t.Helper()
+	for _, n := range names {
+		sub := filepath.Join(dir, "ingots", n)
+		writeIngotFixture(t, sub, n, "1.0.0")
+	}
+}
+
+func TestRunIngotAdd_SingleIngot_RecordsArtifactAndLock(t *testing.T) {
+	tmp := t.TempDir()
+	srcDir := filepath.Join(tmp, "src")
+	writeIngotFixture(t, srcDir, "solo", "0.1.0")
+
+	projectDir := filepath.Join(tmp, "proj")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	lockPath := filepath.Join(projectDir, foundry.LockFileName)
+	if err := os.WriteFile(lockPath, []byte("apiVersion: v1\nmolds: []\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	chdir(t, projectDir)
+	if err := runIngotAddFromLocal(srcDir, false); err != nil {
+		t.Fatalf("runIngotAddFromLocal: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(projectDir, ".ailloy", "ingots", "solo", "ingot.yaml")); err != nil {
+		t.Fatalf("expected ingot.yaml under .ailloy/ingots/solo/, got: %v", err)
+	}
+
+	im, err := foundry.ReadInstalledManifest(filepath.Join(projectDir, ".ailloy", "installed.yaml"))
+	if err != nil || im == nil {
+		t.Fatalf("read installed manifest: im=%v err=%v", im, err)
+	}
+	if len(im.Ingots) != 1 || im.Ingots[0].Name != "solo" {
+		t.Fatalf("expected 1 ingot entry named solo, got %+v", im.Ingots)
+	}
+	if im.Ingots[0].Subpath != "" {
+		t.Errorf("expected empty subpath for root layout, got %q", im.Ingots[0].Subpath)
+	}
+	if len(im.Ingots[0].Dependents) != 1 || im.Ingots[0].Dependents[0] != "user" {
+		t.Errorf("expected dependents=[user], got %v", im.Ingots[0].Dependents)
+	}
+
+	lf, err := foundry.ReadLockFile(lockPath)
+	if err != nil || lf == nil {
+		t.Fatalf("read lock: lf=%v err=%v", lf, err)
+	}
+	if len(lf.Ingots) != 1 || lf.Ingots[0].Name != "solo" {
+		t.Fatalf("expected 1 ingot in lock named solo, got %+v", lf.Ingots)
+	}
+}
+
+func TestRunIngotAdd_MultiIngot_InstallsAll(t *testing.T) {
+	tmp := t.TempDir()
+	srcDir := filepath.Join(tmp, "src")
+	writeMultiIngotFixture(t, srcDir, "header", "footer")
+
+	projectDir := filepath.Join(tmp, "proj")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	lockPath := filepath.Join(projectDir, foundry.LockFileName)
+	if err := os.WriteFile(lockPath, []byte("apiVersion: v1\nmolds: []\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	chdir(t, projectDir)
+	if err := runIngotAddFromLocal(srcDir, false); err != nil {
+		t.Fatalf("runIngotAddFromLocal: %v", err)
+	}
+
+	for _, name := range []string{"header", "footer"} {
+		if _, err := os.Stat(filepath.Join(projectDir, ".ailloy", "ingots", name, "ingot.yaml")); err != nil {
+			t.Errorf("missing %s: %v", name, err)
+		}
+	}
+
+	im, err := foundry.ReadInstalledManifest(filepath.Join(projectDir, ".ailloy", "installed.yaml"))
+	if err != nil || im == nil {
+		t.Fatalf("read installed manifest: im=%v err=%v", im, err)
+	}
+	if len(im.Ingots) != 2 {
+		t.Fatalf("expected 2 ingots, got %d (%+v)", len(im.Ingots), im.Ingots)
+	}
+	bySubpath := map[string]string{}
+	for _, e := range im.Ingots {
+		bySubpath[e.Subpath] = e.Name
+	}
+	if bySubpath["ingots/footer"] != "footer" || bySubpath["ingots/header"] != "header" {
+		t.Errorf("expected per-package subpaths, got %v", bySubpath)
+	}
+
+	lf, err := foundry.ReadLockFile(lockPath)
+	if err != nil || lf == nil {
+		t.Fatalf("read lock: lf=%v err=%v", lf, err)
+	}
+	if len(lf.Ingots) != 2 {
+		t.Fatalf("expected 2 ingots in lock, got %d (%+v)", len(lf.Ingots), lf.Ingots)
+	}
+}
+
+func TestRunIngotAdd_NoManifest_Errors(t *testing.T) {
+	tmp := t.TempDir()
+	srcDir := filepath.Join(tmp, "src")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "README.md"), []byte("not an ingot"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	projectDir := filepath.Join(tmp, "proj")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	chdir(t, projectDir)
+
+	err := runIngotAddFromLocal(srcDir, false)
+	if err == nil {
+		t.Fatal("expected error for repo with no ingot manifests, got nil")
+	}
+}

--- a/internal/commands/install_deps.go
+++ b/internal/commands/install_deps.go
@@ -125,6 +125,7 @@ func installDeclaredDeps(manifest *mold.Mold, moldKey string, global, allowLocal
 		// always single-package today (PR #192 requires explicit subpath for
 		// multi-ore selection).
 		if kind == "ingot" {
+			// d.As is ore-only; ingots have no alias support today (per issue #200 scope).
 			pkgs, derr := mold.DiscoverIngotPackages(fsys)
 			if derr != nil {
 				return fmt.Errorf("discovering ingots at %s: %w", ref, derr)
@@ -133,6 +134,23 @@ func installDeclaredDeps(manifest *mold.Mold, moldKey string, global, allowLocal
 				return fmt.Errorf("no ingot.yaml found at %s", ref)
 			}
 			for _, pkg := range pkgs {
+				pkgSubpath := subpath
+				if pkgSubpath == "" {
+					pkgSubpath = pkg.Subpath
+				}
+
+				// Per-package skip: identical contract to the dep-level skip-check above,
+				// but keyed on the per-package (sourceID, pkgSubpath) identity so multi-ingot
+				// entries match correctly. Without this, every cast re-copies every package
+				// and refreshes InstalledAt, producing spurious lock drift under
+				// `quench --verify`.
+				if existing := findArtifactBySource(im, "ingot", sourceID, pkgSubpath, ""); existing != nil {
+					if moldKey != "" && !containsString(existing.Dependents, moldKey) {
+						existing.Dependents = append(existing.Dependents, moldKey)
+					}
+					continue
+				}
+
 				pkgFS := fsys
 				if pkg.Root != "." {
 					sub, serr := fs.Sub(fsys, pkg.Root)
@@ -140,10 +158,6 @@ func installDeclaredDeps(manifest *mold.Mold, moldKey string, global, allowLocal
 						return fmt.Errorf("scoping fs to %s: %w", pkg.Root, serr)
 					}
 					pkgFS = sub
-				}
-				pkgSubpath := subpath
-				if pkgSubpath == "" {
-					pkgSubpath = pkg.Subpath
 				}
 				baseDir, derr2 := artifactInstallDir("ingot", pkg.Name, global)
 				if derr2 != nil {

--- a/internal/commands/install_deps.go
+++ b/internal/commands/install_deps.go
@@ -121,25 +121,66 @@ func installDeclaredDeps(manifest *mold.Mold, moldKey string, global, allowLocal
 		sourceID = resolvedSource
 		subpath = resolvedSubpath
 
-		// Validate manifest matches kind.
-		manifestName := ""
-		switch kind {
-		case "ingot":
-			ingot, ierr := mold.LoadIngotFromFS(fsys, "ingot.yaml")
-			if ierr != nil {
-				return fmt.Errorf("invalid ingot manifest at %s: %w", ref, ierr)
+		// Validate manifest matches kind. Ingots may be multi-package; ore is
+		// always single-package today (PR #192 requires explicit subpath for
+		// multi-ore selection).
+		if kind == "ingot" {
+			pkgs, derr := mold.DiscoverIngotPackages(fsys)
+			if derr != nil {
+				return fmt.Errorf("discovering ingots at %s: %w", ref, derr)
 			}
-			manifestName = ingot.Name
-		case "ore":
-			ore, oerr := mold.LoadOreFromFS(fsys, "ore.yaml")
-			if oerr != nil {
-				return fmt.Errorf("invalid ore manifest at %s: %w", ref, oerr)
+			if len(pkgs) == 0 {
+				return fmt.Errorf("no ingot.yaml found at %s", ref)
 			}
-			if ore.Kind != "ore" {
-				return fmt.Errorf("manifest at %s has kind=%q, expected 'ore'", ref, ore.Kind)
+			for _, pkg := range pkgs {
+				pkgFS := fsys
+				if pkg.Root != "." {
+					sub, serr := fs.Sub(fsys, pkg.Root)
+					if serr != nil {
+						return fmt.Errorf("scoping fs to %s: %w", pkg.Root, serr)
+					}
+					pkgFS = sub
+				}
+				pkgSubpath := subpath
+				if pkgSubpath == "" {
+					pkgSubpath = pkg.Subpath
+				}
+				baseDir, derr2 := artifactInstallDir("ingot", pkg.Name, global)
+				if derr2 != nil {
+					return fmt.Errorf("determining install dir for ingot %s: %w", pkg.Name, derr2)
+				}
+				if err := copyFromFS(pkgFS, baseDir); err != nil {
+					return fmt.Errorf("copying ingot to %s: %w", baseDir, err)
+				}
+				entry := foundry.ArtifactEntry{
+					Name:        pkg.Name,
+					Source:      sourceID,
+					Subpath:     pkgSubpath,
+					Version:     version,
+					Commit:      commit,
+					InstalledAt: time.Now().UTC(),
+				}
+				if moldKey != "" {
+					entry.Dependents = []string{moldKey}
+				}
+				im.UpsertArtifact("ingot", entry)
+				if !silent {
+					fmt.Println(styles.SuccessStyle.Render("  Installed: ") + styles.AccentStyle.Render(pkg.Name+" "+version))
+				}
 			}
-			manifestName = ore.Name
+			continue
 		}
+
+		// Ores: single-package, optional alias.
+		manifestName := ""
+		ore, oerr := mold.LoadOreFromFS(fsys, "ore.yaml")
+		if oerr != nil {
+			return fmt.Errorf("invalid ore manifest at %s: %w", ref, oerr)
+		}
+		if ore.Kind != "ore" {
+			return fmt.Errorf("manifest at %s has kind=%q, expected 'ore'", ref, ore.Kind)
+		}
+		manifestName = ore.Name
 
 		// Install-dir name resolution (alias if set, else manifest name).
 		installName := manifestName

--- a/internal/commands/install_deps_ingot_test.go
+++ b/internal/commands/install_deps_ingot_test.go
@@ -3,7 +3,9 @@ package commands
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
+	"time"
 
 	"github.com/nimble-giant/ailloy/pkg/foundry"
 	"github.com/nimble-giant/ailloy/pkg/mold"
@@ -42,7 +44,7 @@ func TestInstallDeclaredDeps_BareIngotRef_MultiLayout_InstallsAll(t *testing.T) 
 		t.Fatalf("expected 2 ingot entries, got %d (%+v)", len(im.Ingots), im.Ingots)
 	}
 	for _, e := range im.Ingots {
-		if want := []string{"test/consumer"}; !equalStrings(e.Dependents, want) {
+		if want := []string{"test/consumer"}; !slices.Equal(e.Dependents, want) {
 			t.Errorf("ingot %q: dependents=%v, want %v", e.Name, e.Dependents, want)
 		}
 	}
@@ -85,14 +87,62 @@ func TestInstallDeclaredDeps_SubpathIngotRef_InstallsOne(t *testing.T) {
 	}
 }
 
-func equalStrings(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
+func TestInstallDeclaredDeps_BareIngotRef_DoubleInvoke_NoReInstall(t *testing.T) {
+	tmp := t.TempDir()
+	srcDir := filepath.Join(tmp, "src")
+	writeMultiIngotFixture(t, srcDir, "header", "footer")
+
+	projectDir := filepath.Join(tmp, "proj")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
 	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
+	chdir(t, projectDir)
+
+	manifest := &mold.Mold{
+		APIVersion: "v1",
+		Kind:       "mold",
+		Name:       "consumer",
+		Version:    "0.1.0",
+		Dependencies: []mold.Dependency{
+			{Ingot: srcDir, Version: "local"},
+		},
+	}
+
+	if err := installDeclaredDeps(manifest, "test/consumer", false, true, false, true, nil); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+
+	im, err := foundry.ReadInstalledManifest(filepath.Join(projectDir, ".ailloy", "installed.yaml"))
+	if err != nil || im == nil {
+		t.Fatalf("read manifest: im=%v err=%v", im, err)
+	}
+	if len(im.Ingots) != 2 {
+		t.Fatalf("expected 2 ingots after first install, got %d", len(im.Ingots))
+	}
+	firstStamps := map[string]time.Time{}
+	for _, e := range im.Ingots {
+		firstStamps[e.Subpath] = e.InstalledAt
+	}
+
+	// Second invocation should be a no-op for the install paths.
+	if err := installDeclaredDeps(manifest, "test/consumer", false, true, false, true, nil); err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+
+	im2, err := foundry.ReadInstalledManifest(filepath.Join(projectDir, ".ailloy", "installed.yaml"))
+	if err != nil || im2 == nil {
+		t.Fatalf("read manifest after 2nd: im=%v err=%v", im2, err)
+	}
+	if len(im2.Ingots) != 2 {
+		t.Fatalf("expected 2 ingots after second install, got %d", len(im2.Ingots))
+	}
+	for _, e := range im2.Ingots {
+		if !e.InstalledAt.Equal(firstStamps[e.Subpath]) {
+			t.Errorf("ingot %q (subpath %q): InstalledAt changed from %v to %v — re-install happened",
+				e.Name, e.Subpath, firstStamps[e.Subpath], e.InstalledAt)
+		}
+		if !slices.Equal(e.Dependents, []string{"test/consumer"}) {
+			t.Errorf("ingot %q: dependents=%v, expected [test/consumer]", e.Name, e.Dependents)
 		}
 	}
-	return true
 }

--- a/internal/commands/install_deps_ingot_test.go
+++ b/internal/commands/install_deps_ingot_test.go
@@ -1,0 +1,98 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nimble-giant/ailloy/pkg/foundry"
+	"github.com/nimble-giant/ailloy/pkg/mold"
+)
+
+func TestInstallDeclaredDeps_BareIngotRef_MultiLayout_InstallsAll(t *testing.T) {
+	tmp := t.TempDir()
+	srcDir := filepath.Join(tmp, "src")
+	writeMultiIngotFixture(t, srcDir, "header", "footer")
+
+	projectDir := filepath.Join(tmp, "proj")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	chdir(t, projectDir)
+
+	manifest := &mold.Mold{
+		APIVersion: "v1",
+		Kind:       "mold",
+		Name:       "consumer",
+		Version:    "0.1.0",
+		Dependencies: []mold.Dependency{
+			{Ingot: srcDir, Version: "local"},
+		},
+	}
+
+	if err := installDeclaredDeps(manifest, "test/consumer", false, true, false, true, nil); err != nil {
+		t.Fatalf("installDeclaredDeps: %v", err)
+	}
+
+	im, err := foundry.ReadInstalledManifest(filepath.Join(projectDir, ".ailloy", "installed.yaml"))
+	if err != nil || im == nil {
+		t.Fatalf("read installed manifest: im=%v err=%v", im, err)
+	}
+	if len(im.Ingots) != 2 {
+		t.Fatalf("expected 2 ingot entries, got %d (%+v)", len(im.Ingots), im.Ingots)
+	}
+	for _, e := range im.Ingots {
+		if want := []string{"test/consumer"}; !equalStrings(e.Dependents, want) {
+			t.Errorf("ingot %q: dependents=%v, want %v", e.Name, e.Dependents, want)
+		}
+	}
+}
+
+func TestInstallDeclaredDeps_SubpathIngotRef_InstallsOne(t *testing.T) {
+	tmp := t.TempDir()
+	srcDir := filepath.Join(tmp, "src")
+	writeMultiIngotFixture(t, srcDir, "header", "footer")
+
+	projectDir := filepath.Join(tmp, "proj")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	chdir(t, projectDir)
+
+	// Local refs don't natively support //subpath, so point directly at the
+	// header subdir. The pipeline treats this the same as a resolver-narrowed
+	// remote ref: a single ingot at root.
+	manifest := &mold.Mold{
+		APIVersion: "v1",
+		Kind:       "mold",
+		Name:       "consumer",
+		Version:    "0.1.0",
+		Dependencies: []mold.Dependency{
+			{Ingot: filepath.Join(srcDir, "ingots", "header"), Version: "local"},
+		},
+	}
+
+	if err := installDeclaredDeps(manifest, "test/consumer", false, true, false, true, nil); err != nil {
+		t.Fatalf("installDeclaredDeps: %v", err)
+	}
+
+	im, err := foundry.ReadInstalledManifest(filepath.Join(projectDir, ".ailloy", "installed.yaml"))
+	if err != nil || im == nil {
+		t.Fatalf("read installed manifest: im=%v err=%v", im, err)
+	}
+	if len(im.Ingots) != 1 || im.Ingots[0].Name != "header" {
+		t.Fatalf("expected 1 ingot named header, got %+v", im.Ingots)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/mold/ingot_packages.go
+++ b/pkg/mold/ingot_packages.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"path"
 	"sort"
+	"strings"
 )
 
 // IngotPackage describes one ingot package discovered inside an fs.FS. Root is
@@ -60,9 +61,13 @@ func DiscoverIngotPackages(fsys fs.FS) ([]IngotPackage, error) {
 
 	var names []string
 	for _, e := range entries {
-		if e.IsDir() {
-			names = append(names, e.Name())
+		if !e.IsDir() {
+			continue
 		}
+		if strings.HasPrefix(e.Name(), ".") {
+			continue
+		}
+		names = append(names, e.Name())
 	}
 	sort.Strings(names)
 
@@ -70,15 +75,12 @@ func DiscoverIngotPackages(fsys fs.FS) ([]IngotPackage, error) {
 	for _, name := range names {
 		root := path.Join("ingots", name)
 		manifestPath := path.Join(root, "ingot.yaml")
-		if _, serr := fs.Stat(fsys, manifestPath); serr != nil {
-			if errors.Is(serr, fs.ErrNotExist) {
-				continue
-			}
-			return nil, fmt.Errorf("stat %s: %w", manifestPath, serr)
-		}
 		ingot, perr := LoadIngotFromFS(fsys, manifestPath)
 		if perr != nil {
-			return nil, fmt.Errorf("loading ingot at %s: %w", root, perr)
+			if errors.Is(perr, fs.ErrNotExist) {
+				continue
+			}
+			return nil, fmt.Errorf("loading ingot at %s: %w", manifestPath, perr)
 		}
 		pkgs = append(pkgs, IngotPackage{
 			Name:    ingot.Name,

--- a/pkg/mold/ingot_packages.go
+++ b/pkg/mold/ingot_packages.go
@@ -1,0 +1,92 @@
+package mold
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"path"
+	"sort"
+)
+
+// IngotPackage describes one ingot package discovered inside an fs.FS. Root is
+// the package's path within the FS (".", or "ingots/<name>"). Subpath is the
+// "//subpath" component used for refs and lock identity — empty for the
+// single-at-root layout, "ingots/<name>" for multi-package layout.
+type IngotPackage struct {
+	Name    string
+	Version string
+	Root    string
+	Subpath string
+	Ingot   *Ingot
+}
+
+// DiscoverIngotPackages returns every ingot package present in fsys. Layout
+// rules (mirrors ore PR #192):
+//
+//   - If a top-level ingot.yaml exists, return a single package rooted at "."
+//     with empty Subpath. (Single-at-root layout.)
+//   - Else if "ingots/" exists, scan each subdirectory <name> for
+//     <name>/ingot.yaml. Return one package per subdir; Root="ingots/<name>",
+//     Subpath="ingots/<name>". Subdirectories without an ingot.yaml are skipped.
+//   - Else: empty result, no error. The caller decides whether emptiness is
+//     fatal (e.g. `ailloy ingot add` should reject; temper does too).
+//
+// Manifest parse errors are returned as errors — a partially-valid multi-ingot
+// repo should not silently succeed.
+func DiscoverIngotPackages(fsys fs.FS) ([]IngotPackage, error) {
+	if _, err := fs.Stat(fsys, "ingot.yaml"); err == nil {
+		ingot, perr := LoadIngotFromFS(fsys, "ingot.yaml")
+		if perr != nil {
+			return nil, fmt.Errorf("loading root ingot manifest: %w", perr)
+		}
+		return []IngotPackage{{
+			Name:    ingot.Name,
+			Version: ingot.Version,
+			Root:    ".",
+			Subpath: "",
+			Ingot:   ingot,
+		}}, nil
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return nil, fmt.Errorf("stat ingot.yaml: %w", err)
+	}
+
+	entries, err := fs.ReadDir(fsys, "ingots")
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading ingots/: %w", err)
+	}
+
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+
+	var pkgs []IngotPackage
+	for _, name := range names {
+		root := path.Join("ingots", name)
+		manifestPath := path.Join(root, "ingot.yaml")
+		if _, serr := fs.Stat(fsys, manifestPath); serr != nil {
+			if errors.Is(serr, fs.ErrNotExist) {
+				continue
+			}
+			return nil, fmt.Errorf("stat %s: %w", manifestPath, serr)
+		}
+		ingot, perr := LoadIngotFromFS(fsys, manifestPath)
+		if perr != nil {
+			return nil, fmt.Errorf("loading ingot at %s: %w", root, perr)
+		}
+		pkgs = append(pkgs, IngotPackage{
+			Name:    ingot.Name,
+			Version: ingot.Version,
+			Root:    root,
+			Subpath: root,
+			Ingot:   ingot,
+		})
+	}
+	return pkgs, nil
+}

--- a/pkg/mold/ingot_packages_test.go
+++ b/pkg/mold/ingot_packages_test.go
@@ -1,0 +1,89 @@
+package mold
+
+import (
+	"testing"
+	"testing/fstest"
+)
+
+func TestDiscoverIngotPackages_RootLayout(t *testing.T) {
+	fsys := fstest.MapFS{
+		"ingot.yaml": &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: ingot\nname: solo\nversion: 0.1.0\n")},
+	}
+	pkgs, err := DiscoverIngotPackages(fsys)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pkgs) != 1 {
+		t.Fatalf("expected 1 package, got %d", len(pkgs))
+	}
+	if pkgs[0].Name != "solo" {
+		t.Errorf("expected name %q, got %q", "solo", pkgs[0].Name)
+	}
+	if pkgs[0].Subpath != "" {
+		t.Errorf("expected empty subpath for root layout, got %q", pkgs[0].Subpath)
+	}
+	if pkgs[0].Root != "." {
+		t.Errorf("expected root %q, got %q", ".", pkgs[0].Root)
+	}
+}
+
+func TestDiscoverIngotPackages_MultiLayout(t *testing.T) {
+	fsys := fstest.MapFS{
+		"ingots/header/ingot.yaml":   &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: ingot\nname: header\nversion: 1.0.0\n")},
+		"ingots/footer/ingot.yaml":   &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: ingot\nname: footer\nversion: 1.0.0\n")},
+		"ingots/empty-dir/README.md": &fstest.MapFile{Data: []byte("not an ingot")},
+	}
+	pkgs, err := DiscoverIngotPackages(fsys)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pkgs) != 2 {
+		t.Fatalf("expected 2 packages, got %d", len(pkgs))
+	}
+	if pkgs[0].Name != "footer" || pkgs[0].Subpath != "ingots/footer" {
+		t.Errorf("pkgs[0]: got name=%q subpath=%q, want name=%q subpath=%q",
+			pkgs[0].Name, pkgs[0].Subpath, "footer", "ingots/footer")
+	}
+	if pkgs[1].Name != "header" || pkgs[1].Subpath != "ingots/header" {
+		t.Errorf("pkgs[1]: got name=%q subpath=%q, want name=%q subpath=%q",
+			pkgs[1].Name, pkgs[1].Subpath, "header", "ingots/header")
+	}
+}
+
+func TestDiscoverIngotPackages_NoIngot(t *testing.T) {
+	fsys := fstest.MapFS{"README.md": &fstest.MapFile{Data: []byte("not an ingot repo")}}
+	pkgs, err := DiscoverIngotPackages(fsys)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pkgs) != 0 {
+		t.Fatalf("expected 0 packages, got %d", len(pkgs))
+	}
+}
+
+func TestDiscoverIngotPackages_RootShadowsMulti(t *testing.T) {
+	fsys := fstest.MapFS{
+		"ingot.yaml":               &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: ingot\nname: root\nversion: 0.1.0\n")},
+		"ingots/header/ingot.yaml": &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: ingot\nname: header\nversion: 1.0.0\n")},
+	}
+	pkgs, err := DiscoverIngotPackages(fsys)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pkgs) != 1 {
+		t.Fatalf("expected 1 package (root shadows multi), got %d", len(pkgs))
+	}
+	if pkgs[0].Name != "root" {
+		t.Errorf("expected root layout to win, got %q", pkgs[0].Name)
+	}
+}
+
+func TestDiscoverIngotPackages_BadManifest(t *testing.T) {
+	fsys := fstest.MapFS{
+		"ingots/broken/ingot.yaml": &fstest.MapFile{Data: []byte(":- not yaml")},
+	}
+	_, err := DiscoverIngotPackages(fsys)
+	if err == nil {
+		t.Fatal("expected error for malformed multi-ingot manifest, got nil")
+	}
+}

--- a/pkg/mold/ingot_packages_test.go
+++ b/pkg/mold/ingot_packages_test.go
@@ -61,6 +61,36 @@ func TestDiscoverIngotPackages_NoIngot(t *testing.T) {
 	}
 }
 
+func TestDiscoverIngotPackages_IngotsDirOnlyFiles(t *testing.T) {
+	fsys := fstest.MapFS{
+		"ingots/README.md": &fstest.MapFile{Data: []byte("loose file, no subdirs")},
+	}
+	pkgs, err := DiscoverIngotPackages(fsys)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pkgs) != 0 {
+		t.Fatalf("expected 0 packages when ingots/ has no subdirs, got %d", len(pkgs))
+	}
+}
+
+func TestDiscoverIngotPackages_SkipsHiddenDirs(t *testing.T) {
+	fsys := fstest.MapFS{
+		"ingots/.git/ingot.yaml":   &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: ingot\nname: bogus\nversion: 0.0.0\n")},
+		"ingots/header/ingot.yaml": &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: ingot\nname: header\nversion: 1.0.0\n")},
+	}
+	pkgs, err := DiscoverIngotPackages(fsys)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pkgs) != 1 {
+		t.Fatalf("expected 1 package (hidden .git skipped), got %d", len(pkgs))
+	}
+	if pkgs[0].Name != "header" {
+		t.Errorf("expected header, got %q", pkgs[0].Name)
+	}
+}
+
 func TestDiscoverIngotPackages_RootShadowsMulti(t *testing.T) {
 	fsys := fstest.MapFS{
 		"ingot.yaml":               &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: ingot\nname: root\nversion: 0.1.0\n")},

--- a/pkg/mold/temper_multi_ingot_test.go
+++ b/pkg/mold/temper_multi_ingot_test.go
@@ -1,0 +1,52 @@
+package mold
+
+import (
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+func TestTemper_MultiIngot_ValidatesEach(t *testing.T) {
+	fsys := fstest.MapFS{
+		"ingots/header/ingot.yaml": &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: ingot\nname: header\nversion: 1.0.0\nfiles: [content.md]\n")},
+		"ingots/header/content.md": &fstest.MapFile{Data: []byte("# header\n")},
+		"ingots/footer/ingot.yaml": &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: ingot\nname: footer\nversion: 1.0.0\nfiles: [missing.md]\n")},
+	}
+	result := Temper(fsys)
+
+	if result.ManifestKind != "ingot" {
+		t.Fatalf("expected ManifestKind=ingot, got %q", result.ManifestKind)
+	}
+	errs := result.Errors()
+	if len(errs) == 0 {
+		t.Fatalf("expected at least one error from footer's missing file, got %d (diags=%+v)", len(errs), result.Diagnostics)
+	}
+	found := false
+	for _, e := range errs {
+		if e.File == "ingots/footer/ingot.yaml" || (e.File == "ingot.yaml" && contains(e.Message, "missing.md")) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected error tied to footer's missing.md, got %+v", errs)
+	}
+}
+
+func TestTemper_MultiIngot_AllValid(t *testing.T) {
+	fsys := fstest.MapFS{
+		"ingots/a/ingot.yaml": &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: ingot\nname: a\nversion: 1.0.0\n")},
+		"ingots/b/ingot.yaml": &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: ingot\nname: b\nversion: 1.0.0\n")},
+	}
+	result := Temper(fsys)
+	if result.HasErrors() {
+		t.Fatalf("expected no errors, got %+v", result.Errors())
+	}
+	if result.ManifestKind != "ingot" {
+		t.Fatalf("expected ManifestKind=ingot, got %q", result.ManifestKind)
+	}
+}
+
+func contains(s, sub string) bool {
+	return strings.Contains(s, sub)
+}

--- a/pkg/mold/temper_multi_ingot_test.go
+++ b/pkg/mold/temper_multi_ingot_test.go
@@ -23,7 +23,7 @@ func TestTemper_MultiIngot_ValidatesEach(t *testing.T) {
 	}
 	found := false
 	for _, e := range errs {
-		if e.File == "ingots/footer/ingot.yaml" || (e.File == "ingot.yaml" && contains(e.Message, "missing.md")) {
+		if e.File == "ingots/footer/ingot.yaml" {
 			found = true
 			break
 		}
@@ -47,6 +47,22 @@ func TestTemper_MultiIngot_AllValid(t *testing.T) {
 	}
 }
 
-func contains(s, sub string) bool {
-	return strings.Contains(s, sub)
+func TestTemper_MultiIngot_ParseError(t *testing.T) {
+	fsys := fstest.MapFS{
+		"ingots/broken/ingot.yaml": &fstest.MapFile{Data: []byte(":- not yaml")},
+	}
+	result := Temper(fsys)
+	if !result.HasErrors() {
+		t.Fatalf("expected errors for malformed multi-ingot manifest, got %+v", result.Diagnostics)
+	}
+	found := false
+	for _, e := range result.Errors() {
+		if strings.Contains(e.Message, "scanning ingots/") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected diagnostic mentioning 'scanning ingots/', got %+v", result.Errors())
+	}
 }

--- a/pkg/mold/validate.go
+++ b/pkg/mold/validate.go
@@ -3,6 +3,7 @@ package mold
 import (
 	"fmt"
 	"io/fs"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -422,12 +423,35 @@ func (r *TemperResult) Suggestions() []Diagnostic {
 func Temper(fsys fs.FS) *TemperResult {
 	result := &TemperResult{}
 
-	// Detect manifest type
 	hasMold := fileExists(fsys, "mold.yaml")
 	hasIngot := fileExists(fsys, "ingot.yaml")
 	hasOre := fileExists(fsys, "ore.yaml")
 
-	if !hasMold && !hasIngot && !hasOre {
+	switch {
+	case hasMold:
+		result.ManifestKind = "mold"
+		temperMold(fsys, result)
+		return result
+	case hasIngot:
+		result.ManifestKind = "ingot"
+		temperIngotAt(fsys, "ingot.yaml", result)
+		return result
+	case hasOre:
+		result.ManifestKind = "ore"
+		temperOre(fsys, result)
+		return result
+	}
+
+	// No top-level manifest. Look for multi-ingot layout.
+	pkgs, err := DiscoverIngotPackages(fsys)
+	if err != nil {
+		result.Diagnostics = append(result.Diagnostics, Diagnostic{
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("scanning ingots/: %v", err),
+		})
+		return result
+	}
+	if len(pkgs) == 0 {
 		result.Diagnostics = append(result.Diagnostics, Diagnostic{
 			Severity: SeverityError,
 			Message:  "no mold.yaml, ingot.yaml, or ore.yaml found",
@@ -435,18 +459,33 @@ func Temper(fsys fs.FS) *TemperResult {
 		return result
 	}
 
-	switch {
-	case hasMold:
-		result.ManifestKind = "mold"
-		temperMold(fsys, result)
-	case hasIngot:
-		result.ManifestKind = "ingot"
-		temperIngot(fsys, result)
-	case hasOre:
-		result.ManifestKind = "ore"
-		temperOre(fsys, result)
+	result.ManifestKind = "ingot"
+	for _, p := range pkgs {
+		sub, serr := fs.Sub(fsys, p.Root)
+		if serr != nil {
+			result.Diagnostics = append(result.Diagnostics, Diagnostic{
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("scoping fs to %s: %v", p.Root, serr),
+			})
+			continue
+		}
+		// Validate the package against its own scoped FS, but tag any diagnostics
+		// with the package-relative file path so the user can navigate to it.
+		pre := len(result.Diagnostics)
+		temperIngotAt(sub, "ingot.yaml", result)
+		for i := pre; i < len(result.Diagnostics); i++ {
+			if result.Diagnostics[i].File != "" {
+				result.Diagnostics[i].File = path.Join(p.Root, result.Diagnostics[i].File)
+			}
+		}
 	}
-
+	// Surface a stable Name/Version for the result header. With N packages we
+	// pick the first lexicographic package; that mirrors how `cast` reports the
+	// repo's headline package for monorepos.
+	if len(pkgs) > 0 {
+		result.Name = pkgs[0].Name
+		result.Version = pkgs[0].Version
+	}
 	return result
 }
 
@@ -494,46 +533,55 @@ func temperMold(fsys fs.FS, result *TemperResult) {
 	validateTemplates(fsys, outputFiles, result)
 }
 
-// temperIngot validates an ingot package.
+// temperIngot validates an ingot package at the FS root.
 func temperIngot(fsys fs.FS, result *TemperResult) {
-	i, err := LoadIngotFromFS(fsys, "ingot.yaml")
+	temperIngotAt(fsys, "ingot.yaml", result)
+}
+
+// temperIngotAt validates an ingot package whose manifest is at manifestPath,
+// resolving file references relative to the manifest's directory. Used by both
+// single-at-root temper and multi-ingot fan-out.
+func temperIngotAt(fsys fs.FS, manifestPath string, result *TemperResult) {
+	i, err := LoadIngotFromFS(fsys, manifestPath)
 	if err != nil {
 		result.Diagnostics = append(result.Diagnostics, Diagnostic{
 			Severity: SeverityError,
-			Message:  fmt.Sprintf("failed to parse ingot.yaml: %v", err),
-			File:     "ingot.yaml",
+			Message:  fmt.Sprintf("failed to parse %s: %v", manifestPath, err),
+			File:     manifestPath,
 		})
 		return
 	}
 
-	result.Name = i.Name
-	result.Version = i.Version
+	// Single-at-root path sets these once. Multi-ingot leaves them set to the
+	// last package processed; the wrapper in Temper picks a stable headline
+	// from the discovered packages list.
+	if result.Name == "" {
+		result.Name = i.Name
+		result.Version = i.Version
+	}
 
-	// Validate manifest fields
 	if err := ValidateIngot(i); err != nil {
 		for _, line := range extractValidationErrors(err) {
 			result.Diagnostics = append(result.Diagnostics, Diagnostic{
 				Severity: SeverityError,
 				Message:  line,
-				File:     "ingot.yaml",
+				File:     manifestPath,
 			})
 		}
 	}
 
-	// Validate file references
 	if len(i.Files) > 0 {
 		for _, f := range i.Files {
 			if !fileExists(fsys, f) {
 				result.Diagnostics = append(result.Diagnostics, Diagnostic{
 					Severity: SeverityError,
 					Message:  fmt.Sprintf("referenced file not found: %s", f),
-					File:     "ingot.yaml",
+					File:     manifestPath,
 				})
 			}
 		}
 	}
 
-	// Validate template syntax only for ingot files
 	ingotPaths := make(map[string]bool, len(i.Files))
 	for _, f := range i.Files {
 		ingotPaths[f] = true

--- a/pkg/mold/validate.go
+++ b/pkg/mold/validate.go
@@ -533,11 +533,6 @@ func temperMold(fsys fs.FS, result *TemperResult) {
 	validateTemplates(fsys, outputFiles, result)
 }
 
-// temperIngot validates an ingot package at the FS root.
-func temperIngot(fsys fs.FS, result *TemperResult) {
-	temperIngotAt(fsys, "ingot.yaml", result)
-}
-
 // temperIngotAt validates an ingot package whose manifest is at manifestPath,
 // resolving file references relative to the manifest's directory. Used by both
 // single-at-root temper and multi-ingot fan-out.

--- a/pkg/mold/validate.go
+++ b/pkg/mold/validate.go
@@ -547,9 +547,10 @@ func temperIngotAt(fsys fs.FS, manifestPath string, result *TemperResult) {
 		return
 	}
 
-	// Single-at-root path sets these once. Multi-ingot leaves them set to the
-	// last package processed; the wrapper in Temper picks a stable headline
-	// from the discovered packages list.
+	// In the single-at-root path, result.Name is empty on entry, so this
+	// always fires. In multi-ingot fan-out, the wrapper in Temper overwrites
+	// Name/Version from pkgs[0] after the loop, so this guard's value is
+	// moot there — kept only to avoid surprising single-call callers.
 	if result.Name == "" {
 		result.Name = i.Name
 		result.Version = i.Version


### PR DESCRIPTION
## Description

Brings ingots to parity with PR #192's multi-ore-per-repo support: a single git repo can ship N ingots under `ingots/<name>/`, addressable via the `//<subpath>` ref convention. Single-ingot-at-root layout remains the default and works unchanged. Adds a `DiscoverIngotPackages` primitive, fans out `ailloy ingot add` and declared dependencies over multi-package repos, makes `ailloy temper` validate each ingot independently, and switches the CLI's `ingot add` onto the per-artifact `(Source, Subpath, Alias)` lock/manifest identity that ore already uses.

## Related Issue

Fixes #200

## Testing

- Unit tests for `DiscoverIngotPackages` (root, multi, shadow, hidden-dir, bad-manifest)
- CLI tests for `ingot add` (single, multi, no-manifest, Source assertions in manifest + lock)
- Declared-dep fan-out tests (bare-ref multi, subpath-ref single, double-invoke no re-install)
- Temper tests for multi-ingot (per-package diagnostics, ParseError path)
- Full `go test ./... -race`, `go vet ./...`, `golangci-lint run ./...` — all green
- Pre-push hooks (lint + build + test) passed on this push

## UAT

1. Create a repo with `ingots/header/ingot.yaml` and `ingots/footer/ingot.yaml`. Run `ailloy ingot add <repo>` — both ingots install under `.ailloy/ingots/`, both pin in `ailloy.lock` with distinct subpaths.
2. Same repo with `//ingots/header` suffix installs only header.
3. Declare `- ingot: <repo>` in a `mold.yaml`; running `ailloy cast` installs both, and re-running does not refresh `InstalledAt`.
4. Run `ailloy temper` at the repo root — diagnostics for each package are tagged with `ingots/<name>/ingot.yaml`.

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [x] I have updated documentation (if applicable)
- [ ] My commits have DCO sign-off (\`git commit -s\`)