### PR TITLE
feat: transitive mold dependencies (refs #193)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ These guides teach you how to create, package, and share your own AI workflow pa
 - [Flux Variables](flux.md) — Configure blanks with variables, schemas, and value layering
 - [Ingots](ingots.md) — Create and use reusable template components
 - [Ore](ore.md) — Reusable flux partials for opt-in business-logic data structures
+- [Mold Dependencies](mold-dependencies.md) — Compose molds; transitive resolution, conflict handling, lockfile, uninstall cascade
 - [Packaging Molds](smelt.md) — Package molds into distributable tarballs or binaries
 
 ## Operations

--- a/docs/mold-dependencies.md
+++ b/docs/mold-dependencies.md
@@ -1,0 +1,142 @@
+# Mold Dependencies
+
+A mold may declare other molds it depends on. When the parent mold is cast,
+Ailloy resolves the full dependency graph and installs all transitive
+dependencies alongside the parent. Authors can publish small, focused molds
+and compose them into larger workflows without forcing consumers to cast each
+one manually.
+
+## Declaring a mold dependency
+
+Mold-on-mold dependencies live in the same `dependencies:` list that already
+holds ingot/ore dependencies. Use a `mold:` field to identify the dependency:
+
+```yaml
+# mold.yaml
+apiVersion: v1
+kind: mold
+name: team-workflow
+version: 1.0.0
+dependencies:
+  - mold: github.com/my-org/issue-helpers
+    version: "^1.0.0"
+  - mold: github.com/my-org/release-helpers
+    version: "^2.0.0"
+    as: release
+    with:
+      release_channel: "stable"
+```
+
+A dependency entry must set exactly one of `mold:`, `ingot:`, or `ore:`. The
+`mold:` reference accepts the same syntax as top-level `ailloy cast` — a
+foundry-resolvable name, a git URL, or a local path.
+
+| Field      | Meaning                                                                |
+|------------|------------------------------------------------------------------------|
+| `mold:`    | The dependency's source reference (host/owner/repo, git URL, or path). |
+| `version:` | A semver constraint (`^1.0.0`, `~1.2`, `>=1.0,<2.0`) or exact tag.     |
+| `as:`      | Optional alias used to scope flux overrides (`--set <as>.<key>=…`).    |
+| `with:`    | Helm-style sub-flux values seeded into the dep's flux at cast time.    |
+
+## Resolution policy
+
+Ailloy uses **highest-compatible** semver resolution (npm/cargo style):
+
+1. The graph is built by DFS from the parent. Cycles are detected and
+   reported with the offending path.
+2. Constraints from every parent that references the same `(source, subpath)`
+   are intersected. The highest available tag satisfying every constraint
+   wins.
+3. If no version satisfies every constraint, the cast fails with a list of
+   the conflicting constraints.
+4. Non-semver pins (branch names, exact SHAs) must agree across every
+   reference — any disagreement is reported.
+
+**Example.** With `parent → A@^1.0.0` and `parent → B@^1.0.0`, where both A
+and B depend on `D`, A pins `D@^1.0.0` and B pins `D@^1.2.0`, Ailloy will
+install the highest published `D` in `>=1.2.0,<2.0.0`. If A pinned `D@^1.0.0`
+and B pinned `D@^2.0.0`, the cast fails with a conflict error.
+
+## How dependencies are installed
+
+After the parent mold is cast, transitive dependencies are cast in
+leaves-first topological order. Each transitive uses the same destination as
+the parent (project root, or `~/` when `--global` is set) and its files are
+recorded in `.ailloy/installed.yaml`:
+
+```yaml
+molds:
+  - name: parent
+    source: github.com/my-org/team-workflow
+    version: v1.0.0
+    installedAs: direct
+  - name: issue-helpers
+    source: github.com/my-org/issue-helpers
+    version: v1.4.2
+    installedAs: transitive
+    installedBy:
+      - github.com/my-org/team-workflow
+```
+
+`installedAs` distinguishes user-cast molds (`direct`) from molds Ailloy
+pulled in transitively. `installedBy` records the parents that pulled the
+mold in — when the last parent goes away, the transitive is
+garbage-collected on `ailloy uninstall`.
+
+### Flux propagation (Helm-style)
+
+Each transitive mold renders with its own flux defaults, but parents may
+override them via the `with:` block on the dep declaration. From most-default
+to highest-precedence:
+
+1. The transitive's own `flux.yaml` defaults / inline `flux:` schema.
+2. The parent's `with:` block on the dep entry.
+3. Root cast `--set <alias>.<key>=<value>` overrides where `<alias>` is the
+   dep's `as:` value (defaults to the dep's mold name).
+
+### `--with-workflows` cascades
+
+When the parent is cast with `--with-workflows`, every transitive in the
+graph also contributes its `.github/` files. Without the flag, no `.github/`
+files are emitted for parent or transitives.
+
+## Lock & recast
+
+`ailloy.lock` (created by `ailloy quench`) pins every node in the dependency
+graph — direct casts and transitives both. `ailloy recast` re-resolves the
+full graph: transitives that are no longer required after a constraint
+change are pruned; new transitives that newly appear are installed.
+
+> **Note.** As of this release, `quench` and `recast` track the directly-
+> cast molds; full graph-aware behavior across constraint changes is
+> rolling out in follow-up work — see issue #193.
+
+## Uninstall cascade
+
+`ailloy uninstall <parent>` removes the parent and walks its transitives.
+For each transitive whose `installedBy` becomes empty after the parent is
+stripped, the transitive's files are removed and the manifest entry is
+dropped — mirroring how Ailloy already handles ingots/ores via `Dependents`.
+
+Direct casts (`installedAs: direct`) are never garbage-collected even if a
+transitive parent edge happens to be stripped from their `installedBy`.
+
+## Inspecting the graph
+
+Authors can preview the resolved graph before casting:
+
+```bash
+ailloy temper           # validates the manifest, including dep declarations
+ailloy forge <mold>     # dry-run renders without writing to disk
+```
+
+`temper` errors on conflicting `dependencies:` entries (e.g., setting both
+`mold:` and `ingot:`). The `forge --show-graph` flag (where available)
+prints the resolved tree with the chosen versions.
+
+## See also
+
+- [`docs/foundry.md`](foundry.md) — publishing molds, monorepos, version
+  tagging.
+- [`docs/ingots.md`](ingots.md) — non-mold (ingot) dependencies.
+- [`docs/ore.md`](ore.md) — flux-overlay (ore) dependencies.

--- a/internal/commands/cast.go
+++ b/internal/commands/cast.go
@@ -394,6 +394,15 @@ func castProject(reader *blanks.MoldReader, source string) error {
 		}
 	}
 
+	// Cast transitive mold deps (mold-on-mold dependencies). No-op when the
+	// root has no mold-kind deps. Runs after the root is recorded so cycles
+	// or conflicts surface alongside the root cast result.
+	if resolvedRemote != nil {
+		if err := castTransitiveDeps(resolvedRemote, manifest, flux, destPrefix); err != nil {
+			return fmt.Errorf("casting transitive dependencies: %w", err)
+		}
+	}
+
 	// Success celebration
 	fmt.Println()
 	successMessage := "Project casting complete!"
@@ -783,7 +792,12 @@ func copyResolvedFilesWithSchema(reader *blanks.MoldReader, manifest *mold.Mold,
 // `recast` can replay them. logger receives the "corrupt manifest, resetting"
 // warning; pass a discarding logger from TUI callers to keep the alt-screen
 // clean.
-func recordInstalled(result *foundry.ResolveResult, global bool, opts *foundry.CastOptionsRecord, logger *log.Logger) error {
+//
+// installedAs is "direct" for top-level casts (the user typed `ailloy cast
+// <ref>`) and "transitive" for molds pulled in by another mold's
+// dependencies. installedBy is the list of parent source[@subpath] strings
+// for transitives — empty/ignored for direct casts.
+func recordInstalled(result *foundry.ResolveResult, global bool, opts *foundry.CastOptionsRecord, installedAs string, installedBy []string, logger *log.Logger) error {
 	if logger == nil {
 		logger = log.Default()
 	}
@@ -799,13 +813,31 @@ func recordInstalled(result *foundry.ResolveResult, global bool, opts *foundry.C
 	if manifest == nil {
 		manifest = &foundry.InstalledManifest{APIVersion: "v1"}
 	}
+	// Preserve any pre-existing InstalledBy entries when a transitive is also
+	// reached via additional parents, so multi-parent reverse edges accumulate
+	// like ArtifactEntry.Dependents already does.
+	mergedBy := append([]string(nil), installedBy...)
+	if existing := manifest.FindBySource(result.Ref.CacheKey(), result.Ref.Subpath); existing != nil {
+		for _, p := range existing.InstalledBy {
+			if !containsString(mergedBy, p) {
+				mergedBy = append(mergedBy, p)
+			}
+		}
+		// A mold cast directly stays direct even if it was previously seen as
+		// transitive; the user explicitly asked for it now.
+		if installedAs == "" {
+			installedAs = existing.InstalledAs
+		}
+	}
 	entry := foundry.InstalledEntry{
-		Name:    result.Ref.Repo,
-		Source:  result.Ref.CacheKey(),
-		Subpath: result.Ref.Subpath,
-		Version: result.Resolved.Tag,
-		Commit:  result.Resolved.Commit,
-		CastAt:  time.Now().UTC(),
+		Name:        result.Ref.Repo,
+		Source:      result.Ref.CacheKey(),
+		Subpath:     result.Ref.Subpath,
+		Version:     result.Resolved.Tag,
+		Commit:      result.Resolved.Commit,
+		CastAt:      time.Now().UTC(),
+		InstalledAs: installedAs,
+		InstalledBy: mergedBy,
 	}
 	if opts != nil && (opts.WithWorkflows || len(opts.ValueFiles) > 0 || len(opts.SetOverrides) > 0) {
 		// Copy to detach from caller's slice ownership.
@@ -826,7 +858,14 @@ func recordInstalled(result *foundry.ResolveResult, global bool, opts *foundry.C
 // arguments for `recast`; logger is forwarded so TUI callers can keep the
 // alt-screen clean.
 func recordCastedFiles(result *foundry.ResolveResult, files []foundry.InstalledFile, global bool, opts *foundry.CastOptionsRecord, logger *log.Logger) error {
-	if err := recordInstalled(result, global, opts, logger); err != nil {
+	return recordCastedFilesWithProvenance(result, files, global, opts, "direct", nil, logger)
+}
+
+// recordCastedFilesWithProvenance is recordCastedFiles with explicit
+// InstalledAs / InstalledBy plumbing for transitive mold deps. The default
+// recordCastedFiles call sets installedAs="direct" and no installedBy.
+func recordCastedFilesWithProvenance(result *foundry.ResolveResult, files []foundry.InstalledFile, global bool, opts *foundry.CastOptionsRecord, installedAs string, installedBy []string, logger *log.Logger) error {
+	if err := recordInstalled(result, global, opts, installedAs, installedBy, logger); err != nil {
 		return err
 	}
 	path := manifestPathFor(global)

--- a/internal/commands/cast_deps.go
+++ b/internal/commands/cast_deps.go
@@ -1,0 +1,285 @@
+package commands
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/nimble-giant/ailloy/pkg/blanks"
+	"github.com/nimble-giant/ailloy/pkg/foundry"
+	"github.com/nimble-giant/ailloy/pkg/foundry/depgraph"
+	"github.com/nimble-giant/ailloy/pkg/mold"
+	"github.com/nimble-giant/ailloy/pkg/styles"
+)
+
+// hasMoldDeps reports whether the given mold declares any kind=="mold"
+// dependencies (i.e. transitive mold-on-mold edges). Used to short-circuit
+// the depgraph build for the common case of leaf-only molds.
+func hasMoldDeps(m *mold.Mold) bool {
+	if m == nil {
+		return false
+	}
+	for _, d := range m.Dependencies {
+		if k, _ := d.Kind(); k == "mold" {
+			return true
+		}
+	}
+	return false
+}
+
+// depFetcher is the subset of depgraph behaviors castTransitiveDeps needs:
+// graph construction + per-node fs.FS retrieval. The production wiring uses
+// depgraph.ProdFetcher; tests inject a fake.
+type depFetcher interface {
+	depgraph.Fetcher
+	CacheEntry(depgraph.NodeKey) *depgraph.ProdFetchCacheEntry
+}
+
+// castTransitiveDeps resolves and casts the transitive mold dependencies of
+// `root`. It is a no-op if root has no mold-kind deps.
+//
+// Each transitive node renders into the same project (or global) destination
+// as the root, with Helm-style flux propagation: dep defaults <- the parent's
+// `with:` block <- the root cast's `--set <depAlias>.*` and `-f` overrides.
+//
+// `--with-workflows` cascades to transitives; transitives' .github/ files are
+// emitted only when the user passed --with-workflows for the root.
+//
+// Failures during dep resolution or per-dep casting bubble up unchanged so
+// the cast as a whole is reported as failed (rather than silently leaving a
+// half-installed graph).
+func castTransitiveDeps(rootResult *foundry.ResolveResult, root *mold.Mold, rootFlux map[string]any, destPrefix string) error {
+	if rootResult == nil || root == nil || !hasMoldDeps(root) {
+		return nil
+	}
+
+	fetcher := depgraph.NewProdFetcher()
+	if castGlobal {
+		fetcher.LockPath = globalLockPath()
+	}
+	return castTransitiveDepsWith(fetcher, rootResult, root, rootFlux, destPrefix)
+}
+
+// castTransitiveDepsWith is the testable core: it accepts an injected fetcher
+// so unit tests can drive the cast pipeline without touching git.
+func castTransitiveDepsWith(fetcher depFetcher, rootResult *foundry.ResolveResult, root *mold.Mold, rootFlux map[string]any, destPrefix string) error {
+	if rootResult == nil || root == nil || !hasMoldDeps(root) {
+		return nil
+	}
+	graph, err := depgraph.New(fetcher).Build(root, rootResult.Ref)
+	if err != nil {
+		return fmt.Errorf("resolving dependency graph: %w", err)
+	}
+
+	rootKey := depgraph.NodeKey{Source: rootResult.Ref.CacheKey(), Subpath: rootResult.Ref.Subpath}
+	parentLabel := rootKey.String()
+
+	for _, node := range graph.Nodes {
+		if node.Key == rootKey {
+			continue
+		}
+
+		fmt.Println(styles.InfoStyle.Render("📦 Casting dependency: ") + styles.CodeStyle.Render(node.Key.String()) + " " + styles.CodeStyle.Render(node.Version))
+
+		entry := fetcher.CacheEntry(node.Key)
+		if entry == nil || entry.FS == nil {
+			return fmt.Errorf("internal error: dep graph node %s missing cached fs", node.Key)
+		}
+
+		// foundry.Fetch already returns a per-mold fs rooted at the mold dir
+		// (subpath included), and entry.Root points at that dir on disk —
+		// mirror what runCast does for the root mold.
+		reader := blanks.NewMoldReaderFromFS(entry.FS, entry.Root)
+
+		manifest, err := reader.LoadManifest()
+		if err != nil {
+			return fmt.Errorf("loading mold.yaml for %s: %w", node.Key, err)
+		}
+
+		// Recurse the ingot/ore install pass for this transitive's own
+		// non-mold deps. Mold-kind deps are handled by the depgraph walk.
+		moldKey := node.Key.Source
+		if node.Key.Subpath != "" {
+			moldKey += "@" + node.Key.Subpath
+		}
+		if err := installDeclaredDeps(manifest, moldKey, castGlobal, false, castFrozen, false, nil); err != nil {
+			return fmt.Errorf("installing declared deps of %s: %w", node.Key, err)
+		}
+
+		// Compute effective flux: dep defaults < parent's `with:` block <
+		// root's --set/-f overrides scoped to <depAlias>.*. The dep's alias
+		// defaults to its mold name when no `as:` was set.
+		flux, schema, err := loadDepFlux(reader, manifest, &node, rootFlux)
+		if err != nil {
+			return fmt.Errorf("loading flux for %s: %w", node.Key, err)
+		}
+
+		ignorePatterns := mold.LoadIgnorePatterns(reader.FS(), manifest)
+		var resolveOpts []mold.ResolveOption
+		if len(ignorePatterns) > 0 {
+			resolveOpts = append(resolveOpts, mold.WithIgnorePatterns(ignorePatterns))
+		}
+
+		resolved, err := mold.ResolveFiles(flux["output"], reader.FS(), resolveOpts...)
+		if err != nil {
+			return fmt.Errorf("resolving output files for %s: %w", node.Key, err)
+		}
+
+		var filesToCast []mold.ResolvedFile
+		for _, rf := range resolved {
+			if !withWorkflows && strings.HasPrefix(rf.DestPath, ".github/") {
+				continue
+			}
+			if destPrefix != "" {
+				rf.DestPath = filepath.Join(destPrefix, rf.DestPath)
+			}
+			filesToCast = append(filesToCast, rf)
+		}
+
+		// Create destination directories for this dep's outputs.
+		dirSet := make(map[string]bool)
+		for _, rf := range filesToCast {
+			dirSet[filepath.Dir(rf.DestPath)] = true
+		}
+		for d := range dirSet {
+			if err := os.MkdirAll(d, 0750); err != nil { // #nosec G301
+				return fmt.Errorf("creating directory %s for dep %s: %w", d, node.Key, err)
+			}
+		}
+
+		if err := copyResolvedFilesWithSchema(reader, manifest, schema, flux, filesToCast, copyOpts{
+			ForceReplaceOnParseError: castForceReplaceOnParseError,
+		}); err != nil {
+			return fmt.Errorf("copying files for %s: %w", node.Key, err)
+		}
+
+		// Record the transitive entry. Use the same destPrefix-stripping that
+		// the root cast uses so .Files paths are project-relative.
+		installedFiles := make([]foundry.InstalledFile, 0, len(filesToCast))
+		for _, f := range filesToCast {
+			sum, _ := hashFileForDeps(f.DestPath)
+			rel := f.DestPath
+			if destPrefix != "" {
+				if r, rerr := filepath.Rel(destPrefix, f.DestPath); rerr == nil {
+					rel = r
+				}
+			}
+			installedFiles = append(installedFiles, foundry.InstalledFile{RelPath: rel, SHA256: sum})
+		}
+
+		// Synthesize a ResolveResult-shaped record from the cached fetch. The
+		// cached Reference already has the post-resolution version baked in.
+		depResult := &foundry.ResolveResult{
+			Ref: entry.Reference,
+			Resolved: foundry.ResolvedVersion{
+				Tag:    node.Version,
+				Commit: node.Commit,
+			},
+			Root: entry.Root,
+		}
+		// Build the parents list. For now we record the immediate parents
+		// captured during graph construction.
+		var parents []string
+		seen := map[string]struct{}{}
+		for _, e := range node.Parents {
+			lbl := e.Source
+			if e.Subpath != "" {
+				lbl += "@" + e.Subpath
+			}
+			if _, dup := seen[lbl]; dup {
+				continue
+			}
+			seen[lbl] = struct{}{}
+			parents = append(parents, lbl)
+		}
+		if len(parents) == 0 {
+			parents = []string{parentLabel}
+		}
+
+		if err := recordCastedFilesWithProvenance(depResult, installedFiles, castGlobal, nil, "transitive", parents, nil); err != nil {
+			log.Printf("warning: failed to record transitive dep %s: %v", node.Key, err)
+		}
+	}
+	return nil
+}
+
+// loadDepFlux computes the effective flux map for a transitive dep, mirroring
+// loadCastFlux's ordering but rooted in the dep's own defaults and seeded by
+// the parent's `with:` block + root --set/-f scoped to <depAlias>.*.
+func loadDepFlux(reader *blanks.MoldReader, manifest *mold.Mold, node *depgraph.Node, rootFlux map[string]any) (map[string]any, []mold.FluxVar, error) {
+	defaults, err := reader.LoadFluxDefaults()
+	if err != nil {
+		defaults = map[string]any{}
+	}
+	if manifest != nil && len(manifest.Flux) > 0 {
+		defaults = mold.ApplyFluxDefaults(manifest.Flux, defaults)
+	}
+
+	flux := make(map[string]any, len(defaults))
+	for k, v := range defaults {
+		flux[k] = v
+	}
+
+	// Layer parent-supplied `with:` values.
+	for k, v := range node.With {
+		flux[k] = v
+	}
+
+	// Layer root --set scoped to this dep's alias. Treat <alias>.<key>=value
+	// as setting <key> on the dep's flux. A child mold may also explicitly
+	// reference root flux via direct keys — we don't try to do that magic
+	// here; users opt-in by listing the keys in `with:` on the parent.
+	alias := depAlias(node, manifest)
+	if alias != "" {
+		prefix := alias + "."
+		for _, raw := range castSetFlags {
+			parts := strings.SplitN(raw, "=", 2)
+			if len(parts) != 2 || !strings.HasPrefix(parts[0], prefix) {
+				continue
+			}
+			scoped := strings.TrimPrefix(parts[0], prefix) + "=" + parts[1]
+			if err := mold.ApplySetOverrides(flux, []string{scoped}); err != nil {
+				return nil, nil, fmt.Errorf("applying scoped --set %q: %w", raw, err)
+			}
+		}
+	}
+
+	schema := manifest.Flux
+	if s, _ := reader.LoadFluxSchema(); len(s) > 0 {
+		schema = s
+	}
+	return flux, schema, nil
+}
+
+// depAlias returns the alias the parent declared for this node, falling back
+// to the mold's own name when the dep entry didn't set `as:`.
+func depAlias(node *depgraph.Node, manifest *mold.Mold) string {
+	for _, e := range node.Parents {
+		if e.As != "" {
+			return e.As
+		}
+	}
+	if manifest != nil && manifest.Name != "" {
+		return manifest.Name
+	}
+	return ""
+}
+
+// hashFileForDeps duplicates cast.go's hashFile to avoid an import cycle on
+// shared helpers; we only need a sha256 hex of the file contents.
+func hashFileForDeps(path string) (string, error) {
+	f, err := os.Open(path) // #nosec G304 -- path under user control by design
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}

--- a/internal/commands/cast_deps_test.go
+++ b/internal/commands/cast_deps_test.go
@@ -1,0 +1,259 @@
+package commands
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/nimble-giant/ailloy/pkg/foundry"
+	"github.com/nimble-giant/ailloy/pkg/foundry/depgraph"
+	"github.com/nimble-giant/ailloy/pkg/mold"
+)
+
+func TestHasMoldDeps(t *testing.T) {
+	t.Run("nil mold", func(t *testing.T) {
+		if hasMoldDeps(nil) {
+			t.Error("nil mold must return false")
+		}
+	})
+	t.Run("no deps", func(t *testing.T) {
+		m := &mold.Mold{Dependencies: nil}
+		if hasMoldDeps(m) {
+			t.Error("no-deps mold must return false")
+		}
+	})
+	t.Run("only ingot/ore deps", func(t *testing.T) {
+		m := &mold.Mold{Dependencies: []mold.Dependency{
+			{Ingot: "x", Version: "^1.0.0"},
+			{Ore: "y", Version: "^1.0.0"},
+		}}
+		if hasMoldDeps(m) {
+			t.Error("ingot/ore-only mold must return false")
+		}
+	})
+	t.Run("with mold dep", func(t *testing.T) {
+		m := &mold.Mold{Dependencies: []mold.Dependency{
+			{Ingot: "x", Version: "^1.0.0"},
+			{Mold: "github.com/x/y", Version: "^1.0.0"},
+		}}
+		if !hasMoldDeps(m) {
+			t.Error("mold with kind=mold dep must return true")
+		}
+	})
+}
+
+func TestDepAlias(t *testing.T) {
+	t.Run("from parent As", func(t *testing.T) {
+		node := &depgraph.Node{
+			Parents: []depgraph.ParentEdge{{As: "parent-alias"}},
+		}
+		manifest := &mold.Mold{Name: "fallback"}
+		if got := depAlias(node, manifest); got != "parent-alias" {
+			t.Errorf("got %q; want parent-alias", got)
+		}
+	})
+	t.Run("falls back to mold name", func(t *testing.T) {
+		node := &depgraph.Node{Parents: []depgraph.ParentEdge{{As: ""}}}
+		manifest := &mold.Mold{Name: "leaf"}
+		if got := depAlias(node, manifest); got != "leaf" {
+			t.Errorf("got %q; want leaf", got)
+		}
+	})
+}
+
+// fakeDepFetcher implements depFetcher backed by an in-memory fs.FS per node.
+// It mirrors depgraph.ProdFetcher's contract: Fetch + Tags + CacheEntry.
+type fakeDepFetcher struct {
+	molds map[string]map[string]*moldFixture // sourceKey -> version -> fixture
+	tags  map[string]map[string]string       // sourceKey -> tag -> sha
+	cache map[depgraph.NodeKey]*depgraph.ProdFetchCacheEntry
+}
+
+type moldFixture struct {
+	mold *mold.Mold
+	fs   fs.FS
+	root string // on-disk root; empty for in-memory
+}
+
+func newFakeDepFetcher() *fakeDepFetcher {
+	return &fakeDepFetcher{
+		molds: map[string]map[string]*moldFixture{},
+		tags:  map[string]map[string]string{},
+		cache: map[depgraph.NodeKey]*depgraph.ProdFetchCacheEntry{},
+	}
+}
+
+func (f *fakeDepFetcher) addMold(source, version string, fixture *moldFixture) {
+	if f.molds[source] == nil {
+		f.molds[source] = map[string]*moldFixture{}
+	}
+	f.molds[source][version] = fixture
+	if f.tags[source] == nil {
+		f.tags[source] = map[string]string{}
+	}
+	f.tags[source]["v"+version] = "sha-" + source + "-" + version
+}
+
+func (f *fakeDepFetcher) Fetch(ref *foundry.Reference) (depgraph.FetchResult, error) {
+	key := ref.CacheKey()
+	if ref.Subpath != "" {
+		key = key + "//" + ref.Subpath
+	}
+	versions := f.molds[key]
+	if versions == nil {
+		return depgraph.FetchResult{}, &fakeNotFoundErr{key}
+	}
+	bare := strings.TrimPrefix(ref.Version, "v")
+	v, ok := versions[bare]
+	if !ok {
+		// Constraint fallback: pick any single version (test fixtures register one each).
+		for _, candidate := range versions {
+			v = candidate
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return depgraph.FetchResult{}, &fakeNotFoundErr{key + "@" + ref.Version}
+	}
+	resolved := foundry.ResolvedVersion{Tag: "v" + bare, Commit: "sha-" + key + "-" + bare}
+	if bare == "" {
+		resolved = foundry.ResolvedVersion{Tag: "v1.0.0", Commit: "sha-" + key + "-1.0.0"}
+	}
+	cached := &depgraph.ProdFetchCacheEntry{
+		FS:        v.fs,
+		Root:      v.root,
+		Mold:      v.mold,
+		Resolved:  resolved,
+		Reference: ref,
+	}
+	nodeKey := depgraph.NodeKey{Source: ref.CacheKey(), Subpath: ref.Subpath}
+	f.cache[nodeKey] = cached
+	return depgraph.FetchResult{
+		Mold:    v.mold,
+		Version: resolved.Tag,
+		Commit:  resolved.Commit,
+	}, nil
+}
+
+func (f *fakeDepFetcher) Tags(source, subpath string) (map[string]string, error) {
+	key := source
+	if subpath != "" {
+		key = source + "//" + subpath
+	}
+	tags := f.tags[key]
+	if tags == nil {
+		return nil, &fakeNotFoundErr{key}
+	}
+	out := make(map[string]string, len(tags))
+	for k, v := range tags {
+		out[k] = v
+	}
+	return out, nil
+}
+
+func (f *fakeDepFetcher) CacheEntry(k depgraph.NodeKey) *depgraph.ProdFetchCacheEntry {
+	return f.cache[k]
+}
+
+type fakeNotFoundErr struct{ key string }
+
+func (e *fakeNotFoundErr) Error() string { return "fake fetch: not found: " + e.key }
+
+// TestCastTransitiveDeps_NoOpWhenNoMoldDeps verifies the function is a true
+// no-op for molds with no kind=mold dependencies.
+func TestCastTransitiveDeps_NoOpWhenNoMoldDeps(t *testing.T) {
+	root := &mold.Mold{
+		APIVersion: "v1", Kind: "mold", Name: "root", Version: "1.0.0",
+	}
+	if err := castTransitiveDepsWith(newFakeDepFetcher(), nil, root, nil, ""); err != nil {
+		t.Fatalf("expected nil for no-mold-deps mold, got %v", err)
+	}
+}
+
+// TestCastTransitiveDeps_InstallsLeafAsTransitive runs the full helper against
+// a fake fetcher where the root depends on a single leaf mold. Verifies the
+// leaf's rendered file lands in the project and installed.yaml records it
+// with InstalledAs=transitive and InstalledBy=[root key].
+func TestCastTransitiveDeps_InstallsLeafAsTransitive(t *testing.T) {
+	// Run in a temp project dir so installed.yaml lands under .ailloy/.
+	tmp := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	leafFS := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: mold\nname: leaf\nversion: 1.0.0\n")},
+		"flux.yaml": &fstest.MapFile{Data: []byte("output:\n  hello.md: hello-out.md\n")},
+		"hello.md":  &fstest.MapFile{Data: []byte("# hi from leaf\n")},
+	}
+	leafMold := &mold.Mold{APIVersion: "v1", Kind: "mold", Name: "leaf", Version: "1.0.0"}
+
+	fetcher := newFakeDepFetcher()
+	fetcher.addMold("github.com/x/leaf", "1.0.0", &moldFixture{mold: leafMold, fs: leafFS})
+
+	root := &mold.Mold{
+		APIVersion: "v1", Kind: "mold", Name: "root", Version: "1.0.0",
+		Dependencies: []mold.Dependency{
+			{Mold: "github.com/x/leaf", Version: "^1.0.0"},
+		},
+	}
+	rootRef, err := foundry.ParseReference("github.com/x/root@1.0.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootResult := &foundry.ResolveResult{
+		Ref:      rootRef,
+		Resolved: foundry.ResolvedVersion{Tag: "v1.0.0", Commit: "sha-root"},
+		Root:     filepath.Join(tmp, "_unused"),
+	}
+
+	// Pre-create an empty installed.yaml so recordInstalled has something to
+	// upsert into (mirrors what recordCastedFiles for the root would do).
+	manifest := &foundry.InstalledManifest{
+		APIVersion: "v1",
+		Molds: []foundry.InstalledEntry{{
+			Name: "root", Source: "github.com/x/root", Version: "v1.0.0",
+			Commit: "sha-root", InstalledAs: "direct",
+		}},
+	}
+	if err := foundry.WriteInstalledManifest(filepath.Join(tmp, ".ailloy", "installed.yaml"), manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := castTransitiveDepsWith(fetcher, rootResult, root, map[string]any{}, ""); err != nil {
+		t.Fatalf("castTransitiveDepsWith: %v", err)
+	}
+
+	// Leaf's hello.md should have been rendered to hello-out.md.
+	if _, err := os.Stat(filepath.Join(tmp, "hello-out.md")); err != nil {
+		t.Errorf("leaf output missing: %v", err)
+	}
+
+	// installed.yaml should now have the leaf as transitive.
+	got, err := foundry.ReadInstalledManifest(filepath.Join(tmp, ".ailloy", "installed.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	leafEntry := got.FindBySource("github.com/x/leaf", "")
+	if leafEntry == nil {
+		t.Fatalf("leaf not in installed.yaml; entries: %+v", got.Molds)
+	}
+	if leafEntry.InstalledAs != "transitive" {
+		t.Errorf("InstalledAs = %q; want transitive", leafEntry.InstalledAs)
+	}
+	if len(leafEntry.InstalledBy) != 1 || leafEntry.InstalledBy[0] != "github.com/x/root" {
+		t.Errorf("InstalledBy = %v; want [github.com/x/root]", leafEntry.InstalledBy)
+	}
+
+	// Root entry should still be marked as direct (untouched by transitive pass).
+	rootEntry := got.FindBySource("github.com/x/root", "")
+	if rootEntry == nil || rootEntry.InstalledAs != "direct" {
+		t.Errorf("root entry: %+v", rootEntry)
+	}
+}

--- a/internal/commands/ingot.go
+++ b/internal/commands/ingot.go
@@ -159,7 +159,7 @@ func runIngotAdd(_ *cobra.Command, args []string) error {
 	fmt.Println(styles.SuccessStyle.Render("Ingot added: ") + styles.AccentStyle.Render(ingot.Name+" "+ingot.Version))
 	fmt.Println(styles.InfoStyle.Render("Installed to: ") + styles.CodeStyle.Render(destDir))
 
-	if err := recordInstalled(result, false, nil, nil); err != nil {
+	if err := recordInstalled(result, false, nil, "direct", nil, nil); err != nil {
 		log.Printf("warning: failed to update installed manifest: %v", err)
 	}
 

--- a/internal/commands/install_deps.go
+++ b/internal/commands/install_deps.go
@@ -76,6 +76,12 @@ func installDeclaredDeps(manifest *mold.Mold, moldKey string, global, allowLocal
 
 	for _, d := range manifest.Dependencies {
 		kind, _ := d.Kind() // already validated above
+		// Mold-on-mold dependencies are resolved transitively by the cast
+		// pipeline (see castTransitiveDeps), not here. This function is for
+		// ingot/ore artifacts only.
+		if kind == "mold" {
+			continue
+		}
 		ref := d.Source()
 
 		if !allowLocalDeps && !foundry.IsRemoteReference(ref) {
@@ -435,6 +441,90 @@ func artifactInstallDir(kind, name string, global bool) (string, error) {
 		return "", err
 	}
 	return filepath.Join(home, ".ailloy", kind+"s", name), nil
+}
+
+// cascadeUninstallTransitiveMolds is the mold equivalent of
+// cascadeUninstallArtifacts: when a parent mold is uninstalled, any
+// transitive mold it had pulled in (InstalledAs="transitive") loses one
+// reverse-edge in its InstalledBy list. Transitives whose InstalledBy drains
+// to empty are uninstalled (their files removed and manifest entry dropped).
+//
+// Direct casts (InstalledAs="direct") are never garbage-collected by this
+// pass — only the parent reference is stripped from their InstalledBy.
+//
+// Recursion: a removed transitive may itself have pulled in further
+// transitives; we cascade through them the same way until no orphans
+// remain. The recursion is bounded by the manifest's mold count.
+func cascadeUninstallTransitiveMolds(manifestPath, parentKey string, global, dryRun bool) error {
+	if manifestPath == "" || parentKey == "" {
+		return nil
+	}
+	for {
+		im, err := foundry.ReadInstalledManifest(manifestPath)
+		if err != nil {
+			return err
+		}
+		if im == nil {
+			return nil
+		}
+
+		// Find transitives whose InstalledBy contains only the parent key being
+		// removed. After the parent is gone, those become orphans and need a
+		// real UninstallMold call (so their files come out + lock entry drops).
+		type orphan struct {
+			source  string
+			subpath string
+			label   string
+		}
+		var orphans []orphan
+		mutated := false
+		for i := range im.Molds {
+			e := &im.Molds[i]
+			if !containsString(e.InstalledBy, parentKey) {
+				continue
+			}
+			e.InstalledBy = stripDependent(e.InstalledBy, parentKey)
+			mutated = true
+			if e.InstalledAs == "transitive" && len(e.InstalledBy) == 0 {
+				lbl := e.Source
+				if e.Subpath != "" {
+					lbl += "@" + e.Subpath
+				}
+				orphans = append(orphans, orphan{source: e.Source, subpath: e.Subpath, label: lbl})
+			}
+		}
+		if mutated {
+			if err := foundry.WriteInstalledManifest(manifestPath, im); err != nil {
+				return fmt.Errorf("writing manifest after cascading mold parent edges: %w", err)
+			}
+		}
+		if len(orphans) == 0 {
+			return nil
+		}
+
+		// Uninstall each orphan. Their files come off disk, and their entry is
+		// dropped from the manifest. After each one we re-run the cascade so
+		// the next orphan's own transitives also get cleaned up.
+		for _, o := range orphans {
+			ures, uerr := foundry.UninstallMold(manifestPath, o.source, o.subpath, foundry.UninstallOptions{
+				Force:  uninstallForce,
+				DryRun: dryRun,
+			})
+			if uerr != nil {
+				log.Printf("warning: cascade-uninstall of transitive mold %s: %v", o.label, uerr)
+				continue
+			}
+			fmt.Println(styles.SuccessStyle.Render("  Cascade-removed: ") + styles.AccentStyle.Render("mold "+o.label) +
+				styles.SubtleStyle.Render(fmt.Sprintf(" (%d file(s))", len(ures.Deleted))))
+			// Recurse: this orphan might have its own transitives.
+			if err := cascadeUninstallTransitiveMolds(manifestPath, o.label, global, dryRun); err != nil {
+				return err
+			}
+		}
+		// Loop again in case there are still orphans to process. Bounded by the
+		// finite manifest size; at minimum each iteration strips one entry.
+		return nil
+	}
 }
 
 // cascadeUninstallArtifacts strips moldKey from every ingot/ore Dependents

--- a/internal/commands/uninstall.go
+++ b/internal/commands/uninstall.go
@@ -62,8 +62,9 @@ func runUninstall(_ *cobra.Command, args []string) error {
 	if subpath != "" {
 		display = source + "//" + subpath
 	}
-	// Cascade-prune unshared ingots/ores once the mold has been removed.
-	// moldKey mirrors the cast-time key (source@subpath when subpath is set).
+	// Cascade-prune unshared ingots/ores AND orphaned transitive mold deps
+	// once the parent mold has been removed. moldKey mirrors the cast-time
+	// key (source@subpath when subpath is set).
 	if err == nil && !uninstallDryRun {
 		moldKey := source
 		if subpath != "" {
@@ -71,6 +72,9 @@ func runUninstall(_ *cobra.Command, args []string) error {
 		}
 		if cerr := cascadeUninstallArtifacts(manifestPath, moldKey, uninstallGlobal); cerr != nil {
 			fmt.Println(styles.WarningStyle.Render("⚠️  ") + "cascade cleanup: " + cerr.Error())
+		}
+		if cerr := cascadeUninstallTransitiveMolds(manifestPath, moldKey, uninstallGlobal, uninstallDryRun); cerr != nil {
+			fmt.Println(styles.WarningStyle.Render("⚠️  ") + "transitive-mold cascade: " + cerr.Error())
 		}
 	}
 	if err != nil {

--- a/internal/commands/uninstall_cascade_test.go
+++ b/internal/commands/uninstall_cascade_test.go
@@ -85,6 +85,145 @@ func TestUninstall_TwoMoldsShareOre_FirstUninstallLeavesOre(t *testing.T) {
 	}
 }
 
+func TestCascadeUninstallTransitiveMolds_OrphanRemoved(t *testing.T) {
+	tmp := t.TempDir()
+	cwd, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+
+	parentKey := "github.com/example/parent"
+	leafSrc := "github.com/example/leaf"
+	manifestPath := filepath.Join(".ailloy", "installed.yaml")
+
+	// Pre-stage a transitive entry whose only parent is the one being removed,
+	// AND lay down its installed file so UninstallMold has something to remove.
+	leafFile := "leaf-out.md"
+	if err := os.WriteFile(leafFile, []byte("# leaf\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	manifest := &foundry.InstalledManifest{
+		APIVersion: "v1",
+		Molds: []foundry.InstalledEntry{
+			{
+				Name: "leaf", Source: leafSrc, Version: "v1.0.0", Commit: "abc",
+				InstalledAs: "transitive",
+				InstalledBy: []string{parentKey},
+				Files:       []string{leafFile},
+				FileHashes:  map[string]string{leafFile: hashContent(t, leafFile)},
+			},
+		},
+	}
+	if err := foundry.WriteInstalledManifest(manifestPath, manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cascadeUninstallTransitiveMolds(manifestPath, parentKey, false, false); err != nil {
+		t.Fatalf("cascade: %v", err)
+	}
+
+	got, _ := foundry.ReadInstalledManifest(manifestPath)
+	if got != nil && len(got.Molds) != 0 {
+		t.Errorf("orphan transitive should be removed: %+v", got.Molds)
+	}
+	if _, err := os.Stat(leafFile); !os.IsNotExist(err) {
+		t.Errorf("orphan's file should be gone: %v", err)
+	}
+}
+
+func TestCascadeUninstallTransitiveMolds_DirectKeptStripsParent(t *testing.T) {
+	tmp := t.TempDir()
+	cwd, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+
+	parentKey := "github.com/example/parent"
+	manifestPath := filepath.Join(".ailloy", "installed.yaml")
+
+	// Direct cast that happens to also list parent in InstalledBy. Must NOT
+	// be removed; parent should just be stripped from InstalledBy.
+	manifest := &foundry.InstalledManifest{
+		APIVersion: "v1",
+		Molds: []foundry.InstalledEntry{
+			{
+				Name: "directly-cast", Source: "github.com/example/d", Version: "1.0.0",
+				InstalledAs: "direct",
+				InstalledBy: []string{parentKey},
+			},
+		},
+	}
+	if err := foundry.WriteInstalledManifest(manifestPath, manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cascadeUninstallTransitiveMolds(manifestPath, parentKey, false, false); err != nil {
+		t.Fatalf("cascade: %v", err)
+	}
+
+	got, _ := foundry.ReadInstalledManifest(manifestPath)
+	if got == nil || len(got.Molds) != 1 {
+		t.Fatalf("direct mold must remain: %+v", got)
+	}
+	if len(got.Molds[0].InstalledBy) != 0 {
+		t.Errorf("parent edge should be stripped: %+v", got.Molds[0].InstalledBy)
+	}
+}
+
+func TestCascadeUninstallTransitiveMolds_SharedTransitiveKept(t *testing.T) {
+	tmp := t.TempDir()
+	cwd, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+
+	parentA := "github.com/example/a"
+	parentB := "github.com/example/b"
+	manifestPath := filepath.Join(".ailloy", "installed.yaml")
+
+	manifest := &foundry.InstalledManifest{
+		APIVersion: "v1",
+		Molds: []foundry.InstalledEntry{
+			{
+				Name: "shared", Source: "github.com/example/shared", Version: "1.0.0",
+				InstalledAs: "transitive",
+				InstalledBy: []string{parentA, parentB},
+			},
+		},
+	}
+	if err := foundry.WriteInstalledManifest(manifestPath, manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	// Remove parentA; shared has parentB still — must be kept.
+	if err := cascadeUninstallTransitiveMolds(manifestPath, parentA, false, false); err != nil {
+		t.Fatalf("cascade: %v", err)
+	}
+
+	got, _ := foundry.ReadInstalledManifest(manifestPath)
+	if got == nil || len(got.Molds) != 1 {
+		t.Fatalf("shared transitive should remain: %+v", got)
+	}
+	if len(got.Molds[0].InstalledBy) != 1 || got.Molds[0].InstalledBy[0] != parentB {
+		t.Errorf("InstalledBy = %v; want [%s]", got.Molds[0].InstalledBy, parentB)
+	}
+}
+
+// hashContent computes the sha256 hex of a file's contents — used by the
+// transitive cascade tests to populate FileHashes so UninstallMold doesn't
+// flag the file as user-modified.
+func hashContent(t *testing.T, path string) string {
+	t.Helper()
+	got, err := hashFileForDeps(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return got
+}
+
 func TestUninstall_OreWithUserSentinel_NotAutoRemoved(t *testing.T) {
 	tmp := t.TempDir()
 	cwd, _ := os.Getwd()

--- a/pkg/foundry/depgraph/depgraph.go
+++ b/pkg/foundry/depgraph/depgraph.go
@@ -1,0 +1,554 @@
+// Package depgraph builds and resolves a transitive mold dependency graph.
+//
+// A mold's manifest may declare other molds it depends on (via
+// `dependencies: [{ mold: ..., version: ... }]`). When `ailloy cast` runs on
+// a root mold, the full graph of mold-on-mold dependencies must be resolved
+// and installed alongside the root. This package owns that resolution.
+//
+// Resolution policy: highest-compatible semver (npm/cargo style). For each
+// unique mold reached via the graph, all version constraints are intersected;
+// the highest version satisfying every constraint wins. Conflicts (no version
+// satisfies all constraints) and cycles are surfaced as actionable errors.
+//
+// Non-semver pins (branch names, exact SHAs) are matched by equality across
+// all encountered references — any disagreement is an error.
+package depgraph
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/nimble-giant/ailloy/pkg/foundry"
+	"github.com/nimble-giant/ailloy/pkg/mold"
+)
+
+// NodeKey is the canonical identity of a mold in the graph: its source URL
+// plus optional subpath. Aliases (`as:` on the dep declaration) do NOT change
+// the key — the same underlying mold reached via two aliases is one node.
+type NodeKey struct {
+	Source  string // host/owner/repo
+	Subpath string
+}
+
+// String returns "source//subpath" or just "source" when no subpath.
+func (k NodeKey) String() string {
+	if k.Subpath == "" {
+		return k.Source
+	}
+	return k.Source + "//" + k.Subpath
+}
+
+// ParentEdge represents one parent → child edge with the per-edge data
+// (alias, with-values) supplied by the parent's dep declaration.
+type ParentEdge struct {
+	Source  string         // parent's NodeKey.Source
+	Subpath string         // parent's NodeKey.Subpath
+	As      string         // alias the parent gave the child
+	With    map[string]any // Helm-style sub-flux values from the parent
+}
+
+// Node is a resolved mold in the graph: its mold.yaml plus the resolved
+// version + commit, plus the edges that pulled it in.
+type Node struct {
+	Key     NodeKey
+	Mold    *mold.Mold
+	Ref     *foundry.Reference // resolved with concrete version
+	Version string             // tag (or branch/sha when applicable)
+	Commit  string
+	Parents []ParentEdge   // empty = direct/root
+	With    map[string]any // merged with-values from all incoming edges
+}
+
+// Graph is the resolved dep graph in topological (leaves-first) order.
+type Graph struct {
+	Nodes []Node
+}
+
+// Find returns the node with the given (source, subpath), or nil.
+func (g *Graph) Find(source, subpath string) *Node {
+	for i := range g.Nodes {
+		if g.Nodes[i].Key.Source == source && g.Nodes[i].Key.Subpath == subpath {
+			return &g.Nodes[i]
+		}
+	}
+	return nil
+}
+
+// FetchResult is what a Fetcher returns for one (source, subpath, version).
+type FetchResult struct {
+	Mold    *mold.Mold
+	Version string // resolved tag (e.g. "v1.2.3"); empty for branch/sha
+	Commit  string // commit SHA
+}
+
+// Fetcher abstracts the I/O the builder needs: resolving + loading a mold
+// at a given reference, and listing the available semver tags for a source.
+// Tests inject a fake; production wires this to foundry.ResolveWithMetadata
+// + remote tag listing via git ls-remote.
+type Fetcher interface {
+	// Fetch resolves the reference (which may be a constraint, exact, branch,
+	// or SHA) to a concrete version and returns the parsed mold.yaml.
+	Fetch(ref *foundry.Reference) (FetchResult, error)
+	// Tags returns the available semver tags (tag → SHA) for the source. Used
+	// by the constraint solver to pick the highest version satisfying every
+	// accumulated constraint when more than one was encountered.
+	Tags(source, subpath string) (map[string]string, error)
+}
+
+// Builder builds dep graphs.
+type Builder struct {
+	Fetcher Fetcher
+}
+
+// New constructs a Builder.
+func New(f Fetcher) *Builder {
+	return &Builder{Fetcher: f}
+}
+
+// Build walks the dep graph rooted at the given mold and returns it in
+// leaves-first topological order.
+//
+// The algorithm:
+//
+//  1. DFS from root. For each visited (source, subpath) key, accumulate the
+//     version constraints that referenced it and remember the dep edges.
+//     Detect cycles via the visiting stack.
+//  2. For each unique key, intersect its accumulated constraints (semver) and
+//     pick the highest available tag satisfying all. For non-semver pins
+//     (branch / SHA), require equality across all references.
+//  3. If the chosen version differs from what was used during the discovery
+//     fetch, re-fetch the node so its declared deps are accurate. We allow
+//     up to maxResolveIterations passes — typical graphs converge in 1.
+func (b *Builder) Build(root *mold.Mold, rootRef *foundry.Reference) (*Graph, error) {
+	if b.Fetcher == nil {
+		return nil, fmt.Errorf("depgraph: nil Fetcher")
+	}
+	if root == nil {
+		return nil, fmt.Errorf("depgraph: nil root mold")
+	}
+	if rootRef == nil {
+		return nil, fmt.Errorf("depgraph: nil root reference")
+	}
+
+	state := &buildState{
+		fetcher:       b.Fetcher,
+		nodes:         map[NodeKey]*Node{},
+		constraints:   map[NodeKey][]constraintRef{},
+		order:         nil,
+		visiting:      map[NodeKey]bool{},
+		visitingOrder: nil,
+		nonSemverPins: map[NodeKey][]nonSemverRef{},
+	}
+
+	rootKey := NodeKey{Source: rootRef.CacheKey(), Subpath: rootRef.Subpath}
+	rootNode := &Node{
+		Key:     rootKey,
+		Mold:    root,
+		Ref:     rootRef,
+		Version: rootRef.Version,
+		Commit:  "",
+	}
+	state.nodes[rootKey] = rootNode
+	state.order = append(state.order, rootKey)
+
+	if err := state.walkChildren(rootKey, root); err != nil {
+		return nil, err
+	}
+
+	// Resolve each non-root node to its highest-compatible version.
+	if err := state.resolveAll(rootKey); err != nil {
+		return nil, err
+	}
+
+	// Topo-sort: leaves first. We built `order` in DFS-pre order; reverse for
+	// leaves-first because root was pushed first and leaves last.
+	graph := &Graph{Nodes: make([]Node, 0, len(state.order))}
+	// Build a children map to do a proper post-order traversal.
+	children := map[NodeKey][]NodeKey{}
+	for _, k := range state.order {
+		n := state.nodes[k]
+		seen := map[NodeKey]bool{}
+		for _, dep := range n.Mold.Dependencies {
+			if kind, _ := dep.Kind(); kind != "mold" {
+				continue
+			}
+			ref, err := foundry.ParseReference(dep.Mold)
+			if err != nil {
+				continue
+			}
+			ck := NodeKey{Source: ref.CacheKey(), Subpath: ref.Subpath}
+			if seen[ck] {
+				continue
+			}
+			seen[ck] = true
+			children[k] = append(children[k], ck)
+		}
+	}
+	visited := map[NodeKey]bool{}
+	var post func(k NodeKey)
+	post = func(k NodeKey) {
+		if visited[k] {
+			return
+		}
+		visited[k] = true
+		for _, c := range children[k] {
+			post(c)
+		}
+		if n, ok := state.nodes[k]; ok {
+			graph.Nodes = append(graph.Nodes, *n)
+		}
+	}
+	post(rootKey)
+	return graph, nil
+}
+
+// constraintRef pairs a parent's identity with the constraint it expressed.
+type constraintRef struct {
+	parent NodeKey // empty parent = direct/root edge
+	value  string  // the raw `version:` field from the dep entry
+}
+
+// nonSemverRef records a non-semver pin (branch or SHA) so we can verify
+// that all encountered references agree.
+type nonSemverRef struct {
+	parent NodeKey
+	kind   foundry.RefType
+	value  string
+}
+
+type buildState struct {
+	fetcher       Fetcher
+	nodes         map[NodeKey]*Node
+	constraints   map[NodeKey][]constraintRef
+	order         []NodeKey // pre-order discovery (root first)
+	visiting      map[NodeKey]bool
+	visitingOrder []NodeKey
+	nonSemverPins map[NodeKey][]nonSemverRef
+}
+
+func (s *buildState) walkChildren(parentKey NodeKey, parent *mold.Mold) error {
+	s.visiting[parentKey] = true
+	s.visitingOrder = append(s.visitingOrder, parentKey)
+	defer func() {
+		s.visiting[parentKey] = false
+		if len(s.visitingOrder) > 0 {
+			s.visitingOrder = s.visitingOrder[:len(s.visitingOrder)-1]
+		}
+	}()
+
+	for _, dep := range parent.Dependencies {
+		kind, kerr := dep.Kind()
+		if kerr != nil {
+			return fmt.Errorf("dependency on %s: %w", parentKey, kerr)
+		}
+		if kind != "mold" {
+			continue
+		}
+		ref, err := foundry.ParseReference(dep.Mold)
+		if err != nil {
+			return fmt.Errorf("parsing mold dep %q in %s: %w", dep.Mold, parentKey, err)
+		}
+		// `version:` field on the dep entry is the constraint; it overrides any
+		// version embedded in the `mold:` reference itself.
+		if dep.Version != "" {
+			ref.Version = dep.Version
+			ref.Type = classifyConstraint(dep.Version)
+		}
+
+		childKey := NodeKey{Source: ref.CacheKey(), Subpath: ref.Subpath}
+
+		// Cycle: child is currently in the visiting stack.
+		if s.visiting[childKey] {
+			return s.cycleError(childKey)
+		}
+
+		// Record the constraint or non-semver pin.
+		switch ref.Type {
+		case foundry.Constraint, foundry.Exact, foundry.Latest:
+			s.constraints[childKey] = append(s.constraints[childKey], constraintRef{
+				parent: parentKey,
+				value:  dep.Version,
+			})
+		case foundry.Branch, foundry.SHA:
+			s.nonSemverPins[childKey] = append(s.nonSemverPins[childKey], nonSemverRef{
+				parent: parentKey,
+				kind:   ref.Type,
+				value:  ref.Version,
+			})
+		}
+
+		// Record / merge the parent edge on the child (whether or not it's new).
+		s.recordParentEdge(childKey, parentKey, dep)
+
+		// Already discovered? Skip the recursive fetch — its subtree was
+		// already walked. Constraints/pins still accumulate via the records
+		// above. (Re-walk is unnecessary because the same mold yields the same
+		// dep declarations regardless of which path led to it.)
+		// Note: recordParentEdge may have pre-allocated a Node with nil Mold
+		// just to attach the edge, so check Mold != nil rather than presence.
+		if existing, seen := s.nodes[childKey]; seen && existing.Mold != nil {
+			continue
+		}
+
+		// Discover: fetch with the current constraint just to learn the child's
+		// transitive deps. The chosen version may be replaced during resolveAll
+		// when more constraints are intersected.
+		fr, err := s.fetcher.Fetch(ref)
+		if err != nil {
+			return fmt.Errorf("fetching %s: %w", childKey, err)
+		}
+		// If recordParentEdge pre-created the Node, fill it in; otherwise add a
+		// fresh one. Either way append to the order list once.
+		child := s.nodes[childKey]
+		if child == nil {
+			child = &Node{Key: childKey}
+			s.nodes[childKey] = child
+		}
+		child.Mold = fr.Mold
+		child.Ref = ref
+		child.Version = fr.Version
+		child.Commit = fr.Commit
+		s.order = append(s.order, childKey)
+
+		if err := s.walkChildren(childKey, fr.Mold); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *buildState) recordParentEdge(child, parent NodeKey, dep mold.Dependency) {
+	n := s.nodes[child]
+	if n == nil {
+		// Pre-create so the edge can land before we fetch (used for cycle case).
+		n = &Node{Key: child}
+		s.nodes[child] = n
+	}
+	for _, e := range n.Parents {
+		if e.Source == parent.Source && e.Subpath == parent.Subpath {
+			// Already recorded (re-encountered same edge). Merge with-values.
+			if dep.With != nil {
+				if n.With == nil {
+					n.With = map[string]any{}
+				}
+				mergeMap(n.With, dep.With)
+			}
+			return
+		}
+	}
+	n.Parents = append(n.Parents, ParentEdge{
+		Source:  parent.Source,
+		Subpath: parent.Subpath,
+		As:      dep.As,
+		With:    cloneMap(dep.With),
+	})
+	if dep.With != nil {
+		if n.With == nil {
+			n.With = map[string]any{}
+		}
+		mergeMap(n.With, dep.With)
+	}
+}
+
+func (s *buildState) cycleError(reentry NodeKey) error {
+	// visitingOrder has the path from root to the parent; reentry closes it.
+	var pathParts []string
+	for _, k := range s.visitingOrder {
+		pathParts = append(pathParts, k.String())
+	}
+	pathParts = append(pathParts, reentry.String())
+	return fmt.Errorf("dependency cycle detected: %s", strings.Join(pathParts, " → "))
+}
+
+// resolveAll pins each non-root node to a concrete version satisfying every
+// accumulated constraint. Direct cast (root) keeps its own ref as-is.
+func (s *buildState) resolveAll(rootKey NodeKey) error {
+	var errs []string
+	for _, key := range s.order {
+		if key == rootKey {
+			continue
+		}
+
+		// Non-semver pins: every reference must agree on the same value.
+		if pins := s.nonSemverPins[key]; len(pins) > 0 {
+			first := pins[0].value
+			for _, p := range pins[1:] {
+				if p.value != first {
+					errs = append(errs, fmt.Sprintf(
+						"%s: incompatible non-semver pins (%q vs %q)", key, first, p.value,
+					))
+				}
+			}
+			// If we also have semver constraints alongside non-semver pins,
+			// that's a hard conflict — we can't satisfy both at once.
+			if len(s.constraints[key]) > 0 {
+				errs = append(errs, fmt.Sprintf(
+					"%s: pinned to non-semver %q but also has semver constraints", key, first,
+				))
+			}
+			// The discovery fetch already used the pin; nothing further to do.
+			continue
+		}
+
+		// Semver constraints: intersect and pick highest matching tag.
+		raws := s.constraints[key]
+		if len(raws) == 0 {
+			continue
+		}
+		// Aggregate raw constraint strings into a slice; "" or "latest" mean
+		// no constraint for purposes of intersection.
+		var compiled []*semver.Constraints
+		var rawValues []string
+		for _, c := range raws {
+			rawValues = append(rawValues, c.value)
+			if c.value == "" || c.value == "latest" {
+				continue
+			}
+			cc, err := semver.NewConstraint(c.value)
+			if err != nil {
+				errs = append(errs, fmt.Sprintf("%s: invalid constraint %q from %s: %v", key, c.value, c.parent, err))
+				continue
+			}
+			compiled = append(compiled, cc)
+		}
+
+		tags, err := s.fetcher.Tags(key.Source, key.Subpath)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("%s: cannot list tags: %v", key, err))
+			continue
+		}
+
+		bestTag, bestSHA, ok := highestSatisfying(tags, compiled)
+		if !ok {
+			errs = append(errs, fmt.Sprintf(
+				"%s: no version satisfies all accumulated constraints (%s)", key, strings.Join(rawValues, ", "),
+			))
+			continue
+		}
+
+		// If the chosen version differs from what we fetched during discovery,
+		// re-fetch so the mold.yaml reflects the actual installed version.
+		// (Single-pass: if the new version's transitive deps differ, the user
+		// will need to recast — but for the typical case where dep declarations
+		// are stable across patch versions, this single re-fetch is enough.)
+		n := s.nodes[key]
+		if n.Version != bestTag && n.Version != strings.TrimPrefix(bestTag, "v") {
+			ref := *n.Ref
+			ref.Version = bestTag
+			ref.Type = foundry.Exact
+			fr, ferr := s.fetcher.Fetch(&ref)
+			if ferr != nil {
+				errs = append(errs, fmt.Sprintf("%s: re-fetching at %s: %v", key, bestTag, ferr))
+				continue
+			}
+			n.Mold = fr.Mold
+			n.Ref = &ref
+			n.Version = bestTag
+			n.Commit = bestSHA
+		} else {
+			// Use the SHA from the tag listing so we have an authoritative pin.
+			n.Commit = bestSHA
+			n.Version = bestTag
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("dependency resolution failed:\n  - %s", strings.Join(errs, "\n  - "))
+	}
+	return nil
+}
+
+// classifyConstraint mirrors foundry.classifyVersion (which is unexported)
+// for the depgraph's needs.
+func classifyConstraint(v string) foundry.RefType {
+	if v == "" || v == "latest" {
+		return foundry.Latest
+	}
+	// Constraint operators.
+	switch v[0] {
+	case '^', '~', '>', '<', '=', '!':
+		return foundry.Constraint
+	}
+	// SHA-ish (hex 7-40).
+	if isHex(v) && len(v) >= 7 && len(v) <= 40 {
+		return foundry.SHA
+	}
+	// Semver-ish (starts with a digit or v<digit>).
+	if (v[0] >= '0' && v[0] <= '9') || (len(v) > 1 && v[0] == 'v' && v[1] >= '0' && v[1] <= '9') {
+		return foundry.Exact
+	}
+	return foundry.Branch
+}
+
+func isHex(s string) bool {
+	for _, r := range s {
+		switch {
+		case r >= '0' && r <= '9':
+		case r >= 'a' && r <= 'f':
+		case r >= 'A' && r <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// highestSatisfying picks the highest semver tag that satisfies every supplied
+// constraint. Returns (tag, sha, true) on success.
+func highestSatisfying(tags map[string]string, constraints []*semver.Constraints) (string, string, bool) {
+	type entry struct {
+		tag string
+		sha string
+		ver *semver.Version
+	}
+	var candidates []entry
+	for tag, sha := range tags {
+		raw := strings.TrimPrefix(tag, "v")
+		// Allow prefixed tags like "wiki-v1.2.3" by trimming up to the last 'v'.
+		if i := strings.LastIndex(tag, "-v"); i >= 0 {
+			raw = tag[i+2:]
+		}
+		v, err := semver.NewVersion(raw)
+		if err != nil {
+			continue
+		}
+		ok := true
+		for _, c := range constraints {
+			if !c.Check(v) {
+				ok = false
+				break
+			}
+		}
+		if !ok {
+			continue
+		}
+		candidates = append(candidates, entry{tag: tag, sha: sha, ver: v})
+	}
+	if len(candidates) == 0 {
+		return "", "", false
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].ver.LessThan(candidates[j].ver)
+	})
+	best := candidates[len(candidates)-1]
+	return best.tag, best.sha, true
+}
+
+func cloneMap(m map[string]any) map[string]any {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+// mergeMap shallow-copies entries from src into dst, src wins on key collision.
+func mergeMap(dst, src map[string]any) {
+	for k, v := range src {
+		dst[k] = v
+	}
+}

--- a/pkg/foundry/depgraph/depgraph_test.go
+++ b/pkg/foundry/depgraph/depgraph_test.go
@@ -1,0 +1,397 @@
+package depgraph
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/nimble-giant/ailloy/pkg/foundry"
+	"github.com/nimble-giant/ailloy/pkg/mold"
+)
+
+// fakeFetcher is an in-memory Fetcher used by tests. It lets us assemble a
+// foundry of fake molds with declared tag lists without touching git.
+type fakeFetcher struct {
+	molds map[string]map[string]*mold.Mold // sourceKey -> version -> mold
+	tags  map[string]map[string]string     // sourceKey -> tag -> sha
+}
+
+func newFakeFetcher() *fakeFetcher {
+	return &fakeFetcher{
+		molds: map[string]map[string]*mold.Mold{},
+		tags:  map[string]map[string]string{},
+	}
+}
+
+func (f *fakeFetcher) addMold(source, version string, m *mold.Mold) {
+	if f.molds[source] == nil {
+		f.molds[source] = map[string]*mold.Mold{}
+	}
+	f.molds[source][version] = m
+	if f.tags[source] == nil {
+		f.tags[source] = map[string]string{}
+	}
+	f.tags[source]["v"+version] = "sha-" + source + "-" + version
+}
+
+func (f *fakeFetcher) Fetch(ref *foundry.Reference) (FetchResult, error) {
+	key := refKey(ref)
+	versions := f.molds[key]
+	if versions == nil {
+		return FetchResult{}, errNotFound(key)
+	}
+	// Exact / 'v'-stripped match wins.
+	if v, ok := versions[ref.Version]; ok {
+		return FetchResult{Mold: v, Version: ref.Version, Commit: "sha-" + key + "-" + ref.Version}, nil
+	}
+	if v, ok := versions[strings.TrimPrefix(ref.Version, "v")]; ok {
+		return FetchResult{Mold: v, Version: strings.TrimPrefix(ref.Version, "v"), Commit: "sha-" + key + "-" + ref.Version}, nil
+	}
+	// Otherwise treat as constraint and pick the highest matching version.
+	tags := f.tags[key]
+	tag, _, ok := highestSatisfyingFromRaw(tags, ref.Version)
+	if !ok {
+		return FetchResult{}, errNotFound(key + "@" + ref.Version)
+	}
+	bare := strings.TrimPrefix(tag, "v")
+	v, ok := versions[bare]
+	if !ok {
+		return FetchResult{}, errNotFound(key + "@" + tag)
+	}
+	return FetchResult{Mold: v, Version: tag, Commit: "sha-" + key + "-" + bare}, nil
+}
+
+// highestSatisfyingFromRaw picks the highest tag in `tags` that satisfies
+// the raw constraint `raw`. Used by the fake fetcher to mimic real resolution.
+func highestSatisfyingFromRaw(tags map[string]string, raw string) (string, string, bool) {
+	var c *semver.Constraints
+	if raw != "" && raw != "latest" {
+		var err error
+		c, err = semver.NewConstraint(raw)
+		if err != nil {
+			return "", "", false
+		}
+	}
+	type entry struct {
+		tag string
+		sha string
+		ver *semver.Version
+	}
+	var candidates []entry
+	for tag, sha := range tags {
+		v, err := semver.NewVersion(strings.TrimPrefix(tag, "v"))
+		if err != nil {
+			continue
+		}
+		if c != nil && !c.Check(v) {
+			continue
+		}
+		candidates = append(candidates, entry{tag, sha, v})
+	}
+	if len(candidates) == 0 {
+		return "", "", false
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].ver.LessThan(candidates[j].ver)
+	})
+	best := candidates[len(candidates)-1]
+	return best.tag, best.sha, true
+}
+
+func (f *fakeFetcher) Tags(source, subpath string) (map[string]string, error) {
+	key := source
+	if subpath != "" {
+		key = source + "//" + subpath
+	}
+	tags := f.tags[key]
+	if tags == nil {
+		return nil, errNotFound(key)
+	}
+	out := make(map[string]string, len(tags))
+	for k, v := range tags {
+		out[k] = v
+	}
+	return out, nil
+}
+
+func errNotFound(s string) error {
+	return &fakeNotFound{s}
+}
+
+type fakeNotFound struct{ key string }
+
+func (e *fakeNotFound) Error() string { return "fake fetcher: not found: " + e.key }
+
+func refKey(r *foundry.Reference) string {
+	k := r.Host + "/" + r.Owner + "/" + r.Repo
+	if r.Subpath != "" {
+		k += "//" + r.Subpath
+	}
+	return k
+}
+
+func mustRef(t *testing.T, raw string) *foundry.Reference {
+	t.Helper()
+	r, err := foundry.ParseReference(raw)
+	if err != nil {
+		t.Fatalf("parse %q: %v", raw, err)
+	}
+	return r
+}
+
+func makeMold(name string, deps ...mold.Dependency) *mold.Mold {
+	return &mold.Mold{
+		APIVersion:   "v1",
+		Kind:         "mold",
+		Name:         name,
+		Version:      "1.0.0",
+		Dependencies: deps,
+	}
+}
+
+// TestBuild_SingleNoDeps: a root with no mold deps yields just the root node.
+func TestBuild_SingleNoDeps(t *testing.T) {
+	f := newFakeFetcher()
+	root := makeMold("root")
+	f.addMold("github.com/x/root", "1.0.0", root)
+	rootRef := mustRef(t, "github.com/x/root@1.0.0")
+
+	b := New(f)
+	graph, err := b.Build(root, rootRef)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(graph.Nodes) != 1 {
+		t.Fatalf("expected 1 node, got %d: %+v", len(graph.Nodes), graph.Nodes)
+	}
+	if graph.Nodes[0].Mold.Name != "root" {
+		t.Errorf("root.Name = %q", graph.Nodes[0].Mold.Name)
+	}
+	if len(graph.Nodes[0].Parents) != 0 {
+		t.Errorf("root must have no parents, got %v", graph.Nodes[0].Parents)
+	}
+}
+
+// TestBuild_Chain: A → B. Result is leaves-first ordered.
+func TestBuild_Chain(t *testing.T) {
+	f := newFakeFetcher()
+	leaf := makeMold("leaf")
+	parent := makeMold("parent",
+		mold.Dependency{Mold: "github.com/x/leaf", Version: "^1.0.0"},
+	)
+	f.addMold("github.com/x/leaf", "1.0.0", leaf)
+	f.addMold("github.com/x/parent", "1.0.0", parent)
+
+	b := New(f)
+	graph, err := b.Build(parent, mustRef(t, "github.com/x/parent@1.0.0"))
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(graph.Nodes) != 2 {
+		t.Fatalf("expected 2 nodes, got %d", len(graph.Nodes))
+	}
+	if graph.Nodes[0].Mold.Name != "leaf" {
+		t.Errorf("expected leaf first (leaves-first order), got %q", graph.Nodes[0].Mold.Name)
+	}
+	if graph.Nodes[1].Mold.Name != "parent" {
+		t.Errorf("expected parent second, got %q", graph.Nodes[1].Mold.Name)
+	}
+}
+
+// TestBuild_DiamondCompatible: A→B,C; B→D@^1.0.0; C→D@^1.2.0.
+// D should resolve to the highest version satisfying both (>=1.2.0,<2.0.0).
+func TestBuild_DiamondCompatible(t *testing.T) {
+	f := newFakeFetcher()
+	d10 := makeMold("d")
+	d12 := makeMold("d")
+	d12.Version = "1.2.5"
+	f.addMold("github.com/x/d", "1.0.0", d10)
+	f.addMold("github.com/x/d", "1.2.5", d12)
+
+	b := makeMold("b", mold.Dependency{Mold: "github.com/x/d", Version: "^1.0.0"})
+	c := makeMold("c", mold.Dependency{Mold: "github.com/x/d", Version: "^1.2.0"})
+	f.addMold("github.com/x/b", "1.0.0", b)
+	f.addMold("github.com/x/c", "1.0.0", c)
+
+	a := makeMold("a",
+		mold.Dependency{Mold: "github.com/x/b", Version: "^1.0.0"},
+		mold.Dependency{Mold: "github.com/x/c", Version: "^1.0.0"},
+	)
+	f.addMold("github.com/x/a", "1.0.0", a)
+
+	builder := New(f)
+	graph, err := builder.Build(a, mustRef(t, "github.com/x/a@1.0.0"))
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	dNode := graph.Find("github.com/x/d", "")
+	if dNode == nil {
+		t.Fatal("d not in graph")
+	}
+	if strings.TrimPrefix(dNode.Version, "v") != "1.2.5" {
+		t.Errorf("d should resolve to 1.2.5 (highest satisfying ^1.0.0 ∩ ^1.2.0), got %q", dNode.Version)
+	}
+	// d should appear exactly once even though reached via two paths.
+	count := 0
+	for _, n := range graph.Nodes {
+		if n.Key.Source == "github.com/x/d" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("d appeared %d times; want exactly 1", count)
+	}
+}
+
+// TestBuild_DiamondConflict: B→D@^1.0.0; C→D@^2.0.0. No version satisfies both.
+func TestBuild_DiamondConflict(t *testing.T) {
+	f := newFakeFetcher()
+	d1 := makeMold("d")
+	d2 := makeMold("d")
+	d2.Version = "2.0.0"
+	f.addMold("github.com/x/d", "1.0.0", d1)
+	f.addMold("github.com/x/d", "2.0.0", d2)
+
+	b := makeMold("b", mold.Dependency{Mold: "github.com/x/d", Version: "^1.0.0"})
+	c := makeMold("c", mold.Dependency{Mold: "github.com/x/d", Version: "^2.0.0"})
+	f.addMold("github.com/x/b", "1.0.0", b)
+	f.addMold("github.com/x/c", "1.0.0", c)
+
+	a := makeMold("a",
+		mold.Dependency{Mold: "github.com/x/b", Version: "^1.0.0"},
+		mold.Dependency{Mold: "github.com/x/c", Version: "^1.0.0"},
+	)
+	f.addMold("github.com/x/a", "1.0.0", a)
+
+	_, err := New(f).Build(a, mustRef(t, "github.com/x/a@1.0.0"))
+	if err == nil {
+		t.Fatal("expected conflict error, got nil")
+	}
+	if !strings.Contains(err.Error(), "github.com/x/d") {
+		t.Errorf("error should name the conflicting mold, got: %v", err)
+	}
+}
+
+// TestBuild_Cycle: A→B→A. Must error with the cycle path.
+func TestBuild_Cycle(t *testing.T) {
+	f := newFakeFetcher()
+	a := makeMold("a", mold.Dependency{Mold: "github.com/x/b", Version: "^1.0.0"})
+	b := makeMold("b", mold.Dependency{Mold: "github.com/x/a", Version: "^1.0.0"})
+	f.addMold("github.com/x/a", "1.0.0", a)
+	f.addMold("github.com/x/b", "1.0.0", b)
+
+	_, err := New(f).Build(a, mustRef(t, "github.com/x/a@1.0.0"))
+	if err == nil {
+		t.Fatal("expected cycle error, got nil")
+	}
+	if !strings.Contains(err.Error(), "cycle") {
+		t.Errorf("error should mention 'cycle', got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "github.com/x/a") || !strings.Contains(err.Error(), "github.com/x/b") {
+		t.Errorf("cycle error should contain both members of the cycle, got: %v", err)
+	}
+}
+
+// TestBuild_DedupesByCanonicalKey: alias differences don't change identity.
+func TestBuild_DedupesByCanonicalKey(t *testing.T) {
+	f := newFakeFetcher()
+	leaf := makeMold("leaf")
+	f.addMold("github.com/x/leaf", "1.0.0", leaf)
+
+	root := makeMold("root",
+		mold.Dependency{Mold: "github.com/x/leaf", Version: "^1.0.0", As: "alias-one"},
+		mold.Dependency{Mold: "github.com/x/leaf", Version: "^1.0.0", As: "alias-two"},
+	)
+	f.addMold("github.com/x/root", "1.0.0", root)
+
+	graph, err := New(f).Build(root, mustRef(t, "github.com/x/root@1.0.0"))
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	count := 0
+	for _, n := range graph.Nodes {
+		if n.Key.Source == "github.com/x/leaf" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("leaf appeared %d times; canonical key should de-dup regardless of alias", count)
+	}
+}
+
+// TestBuild_NonMoldDepsIgnored: ingot/ore deps in the graph walk are skipped
+// (they are resolved separately at install time via install_deps).
+func TestBuild_NonMoldDepsIgnored(t *testing.T) {
+	f := newFakeFetcher()
+	root := makeMold("root",
+		mold.Dependency{Ingot: "github.com/x/some-ingot", Version: "^1.0.0"},
+		mold.Dependency{Ore: "github.com/x/some-ore", Version: "^1.0.0"},
+	)
+	f.addMold("github.com/x/root", "1.0.0", root)
+
+	graph, err := New(f).Build(root, mustRef(t, "github.com/x/root@1.0.0"))
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(graph.Nodes) != 1 {
+		t.Fatalf("expected only root node (ingot/ore deps don't enter the graph), got %d", len(graph.Nodes))
+	}
+}
+
+// TestBuild_ParentsAndWith: a transitive node records the parents that pulled
+// it in, and merges any `with:` blocks from each parent edge.
+func TestBuild_ParentsAndWith(t *testing.T) {
+	f := newFakeFetcher()
+	leaf := makeMold("leaf")
+	f.addMold("github.com/x/leaf", "1.0.0", leaf)
+
+	root := makeMold("root",
+		mold.Dependency{
+			Mold: "github.com/x/leaf", Version: "^1.0.0",
+			With: map[string]any{"key": "from-root"},
+		},
+	)
+	f.addMold("github.com/x/root", "1.0.0", root)
+
+	graph, err := New(f).Build(root, mustRef(t, "github.com/x/root@1.0.0"))
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	leafNode := graph.Find("github.com/x/leaf", "")
+	if leafNode == nil {
+		t.Fatal("leaf missing")
+	}
+	if len(leafNode.Parents) != 1 || leafNode.Parents[0].Source != "github.com/x/root" {
+		t.Errorf("leaf.Parents = %+v; want [github.com/x/root]", leafNode.Parents)
+	}
+	if leafNode.With["key"] != "from-root" {
+		t.Errorf("leaf.With[key] = %v; want from-root", leafNode.With["key"])
+	}
+}
+
+// TestBuild_SubpathDistinctIdentity: two molds in the same repo at different
+// subpaths are distinct nodes.
+func TestBuild_SubpathDistinctIdentity(t *testing.T) {
+	f := newFakeFetcher()
+	leafA := makeMold("leaf-a")
+	leafB := makeMold("leaf-b")
+	f.addMold("github.com/x/repo//leaf-a", "1.0.0", leafA)
+	f.addMold("github.com/x/repo//leaf-b", "1.0.0", leafB)
+	f.tags["github.com/x/repo//leaf-a"] = map[string]string{"v1.0.0": "shaA"}
+	f.tags["github.com/x/repo//leaf-b"] = map[string]string{"v1.0.0": "shaB"}
+
+	root := makeMold("root",
+		mold.Dependency{Mold: "github.com/x/repo@^1.0.0//leaf-a", Version: "^1.0.0"},
+		mold.Dependency{Mold: "github.com/x/repo@^1.0.0//leaf-b", Version: "^1.0.0"},
+	)
+	f.addMold("github.com/x/root", "1.0.0", root)
+
+	graph, err := New(f).Build(root, mustRef(t, "github.com/x/root@1.0.0"))
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(graph.Nodes) != 3 {
+		t.Errorf("expected 3 nodes (root + leaf-a + leaf-b), got %d", len(graph.Nodes))
+	}
+}

--- a/pkg/foundry/depgraph/prod_fetcher.go
+++ b/pkg/foundry/depgraph/prod_fetcher.go
@@ -1,0 +1,114 @@
+package depgraph
+
+import (
+	"fmt"
+	"io/fs"
+	"path"
+	"strings"
+
+	"github.com/nimble-giant/ailloy/pkg/foundry"
+	"github.com/nimble-giant/ailloy/pkg/mold"
+)
+
+// ProdFetcher implements Fetcher against the production foundry stack
+// (foundry.ResolveWithMetadata + git ls-remote tag listing). It also caches
+// fetched filesystems so callers can later read the rendered mold contents
+// without re-fetching.
+type ProdFetcher struct {
+	GitRunner foundry.GitRunner
+	// LockPath is forwarded to ResolveWithMetadata so transitive fetches
+	// participate in the same lockfile as the root cast.
+	LockPath string
+
+	cache map[NodeKey]*ProdFetchCacheEntry
+}
+
+// ProdFetchCacheEntry captures everything callers need after Build to perform
+// the actual cast pass for one node: the on-disk fs.FS, the absolute root
+// path inside that FS, and the parsed mold.yaml.
+type ProdFetchCacheEntry struct {
+	FS        fs.FS
+	Root      string
+	Mold      *mold.Mold
+	Resolved  foundry.ResolvedVersion
+	Reference *foundry.Reference
+}
+
+// NewProdFetcher builds a fetcher backed by the default git runner.
+func NewProdFetcher() *ProdFetcher {
+	return &ProdFetcher{
+		GitRunner: foundry.DefaultGitRunner(),
+		cache:     map[NodeKey]*ProdFetchCacheEntry{},
+	}
+}
+
+// CacheEntry returns the cached fetch for the given key, or nil if none.
+// Callers use this after Build to obtain the fs.FS for each transitive node
+// without re-fetching from the remote.
+func (p *ProdFetcher) CacheEntry(key NodeKey) *ProdFetchCacheEntry {
+	if p == nil || p.cache == nil {
+		return nil
+	}
+	return p.cache[key]
+}
+
+// Fetch resolves the given reference and parses its mold.yaml. The fs.FS,
+// resolved version, and parsed Mold are cached for later retrieval via
+// CacheEntry().
+func (p *ProdFetcher) Fetch(ref *foundry.Reference) (FetchResult, error) {
+	if p.cache == nil {
+		p.cache = map[NodeKey]*ProdFetchCacheEntry{}
+	}
+	rawRef := refToRaw(ref)
+	var opts []foundry.ResolveOption
+	if p.LockPath != "" {
+		opts = append(opts, foundry.WithLockPath(p.LockPath))
+	}
+	fsys, result, err := foundry.ResolveWithMetadata(rawRef, opts...)
+	if err != nil {
+		return FetchResult{}, fmt.Errorf("resolve %s: %w", rawRef, err)
+	}
+
+	manifestPath := "mold.yaml"
+	if ref.Subpath != "" {
+		manifestPath = path.Join(strings.Trim(ref.Subpath, "/"), "mold.yaml")
+	}
+	m, err := mold.LoadMoldFromFS(fsys, manifestPath)
+	if err != nil {
+		return FetchResult{}, fmt.Errorf("loading mold.yaml at %s: %w", manifestPath, err)
+	}
+
+	key := NodeKey{Source: ref.CacheKey(), Subpath: ref.Subpath}
+	p.cache[key] = &ProdFetchCacheEntry{
+		FS:        fsys,
+		Root:      result.Root,
+		Mold:      m,
+		Resolved:  result.Resolved,
+		Reference: result.Ref,
+	}
+	return FetchResult{
+		Mold:    m,
+		Version: result.Resolved.Tag,
+		Commit:  result.Resolved.Commit,
+	}, nil
+}
+
+// Tags lists all semver tags for the given source+subpath via git ls-remote.
+func (p *ProdFetcher) Tags(source, subpath string) (map[string]string, error) {
+	url := "https://" + source + ".git"
+	return foundry.RemoteTags(url, subpath, p.GitRunner)
+}
+
+// refToRaw renders a Reference back to a raw string suitable for
+// foundry.ResolveWithMetadata. It mirrors Reference.String() but always emits
+// the version + subpath when present.
+func refToRaw(ref *foundry.Reference) string {
+	s := ref.CacheKey()
+	if ref.Version != "" {
+		s += "@" + ref.Version
+	}
+	if ref.Subpath != "" {
+		s += "//" + ref.Subpath
+	}
+	return s
+}

--- a/pkg/foundry/manifest.go
+++ b/pkg/foundry/manifest.go
@@ -34,6 +34,13 @@ type CastOptionsRecord struct {
 // UninstallMold so the uninstall flow knows what to remove and can detect
 // post-cast modifications. They are intentionally on the manifest (not the
 // lock) so uninstall keeps working when ailloy.lock has not been opted into.
+//
+// InstalledAs distinguishes molds the user cast directly ("direct") from
+// molds installed because some other mold depends on them ("transitive").
+// InstalledBy mirrors ArtifactEntry.Dependents: it lists the parent molds
+// (by source[@subpath]) that pulled this mold in transitively, enabling
+// cascade-uninstall — when a transitive's last parent goes away, it can
+// be GC'd. Direct molds are never garbage-collected by the cascade.
 type InstalledEntry struct {
 	Name        string             `yaml:"name"`
 	Source      string             `yaml:"source"`
@@ -44,6 +51,8 @@ type InstalledEntry struct {
 	Files       []string           `yaml:"files,omitempty"`
 	FileHashes  map[string]string  `yaml:"fileHashes,omitempty"`
 	CastOptions *CastOptionsRecord `yaml:"castOptions,omitempty"`
+	InstalledAs string             `yaml:"installedAs,omitempty"` // "direct" | "transitive"
+	InstalledBy []string           `yaml:"installedBy,omitempty"` // parent mold source[@subpath] strings
 }
 
 // ArtifactEntry records an installed ingot or ore. Mirrors InstalledEntry
@@ -162,6 +171,29 @@ func (m *InstalledManifest) UpsertArtifact(kind string, entry ArtifactEntry) {
 		}
 	}
 	*list = append(*list, entry)
+}
+
+// RemoveMoldDependent strips parentKey from every transitive mold's
+// InstalledBy list. Returns the entries whose InstalledBy became empty AND
+// were installed as transitives — those are removed from the manifest as
+// orphans (caller GCs their files). Direct entries are never removed even
+// when their InstalledBy goes empty, since the user cast them explicitly.
+func (m *InstalledManifest) RemoveMoldDependent(parentKey string) []InstalledEntry {
+	if m == nil {
+		return nil
+	}
+	var orphans []InstalledEntry
+	kept := m.Molds[:0]
+	for _, e := range m.Molds {
+		e.InstalledBy = stripString(e.InstalledBy, parentKey)
+		if e.InstalledAs == "transitive" && len(e.InstalledBy) == 0 {
+			orphans = append(orphans, e)
+			continue
+		}
+		kept = append(kept, e)
+	}
+	m.Molds = kept
+	return orphans
 }
 
 // RemoveDependent strips moldKey from every artifact's Dependents list.

--- a/pkg/foundry/manifest_test.go
+++ b/pkg/foundry/manifest_test.go
@@ -404,6 +404,123 @@ func TestArtifact_All_YieldsAllKinds(t *testing.T) {
 	}
 }
 
+func TestInstalledEntry_RoundTrip_InstalledAsAndInstalledBy(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "installed.yaml")
+	ts := time.Date(2026, 5, 8, 9, 0, 0, 0, time.UTC)
+	original := &InstalledManifest{
+		APIVersion: "v1",
+		Molds: []InstalledEntry{
+			{
+				Name: "top", Source: "g/top", Version: "v1.0.0", Commit: "111", CastAt: ts,
+				InstalledAs: "direct",
+			},
+			{
+				Name: "leaf", Source: "g/leaf", Version: "v1.0.0", Commit: "222", CastAt: ts,
+				InstalledAs: "transitive",
+				InstalledBy: []string{"g/top"},
+			},
+		},
+	}
+	if err := WriteInstalledManifest(path, original); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadInstalledManifest(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Molds) != 2 {
+		t.Fatalf("len = %d", len(got.Molds))
+	}
+	if got.Molds[0].InstalledAs != "direct" {
+		t.Errorf("Molds[0].InstalledAs = %q; want direct", got.Molds[0].InstalledAs)
+	}
+	if got.Molds[1].InstalledAs != "transitive" {
+		t.Errorf("Molds[1].InstalledAs = %q; want transitive", got.Molds[1].InstalledAs)
+	}
+	if len(got.Molds[1].InstalledBy) != 1 || got.Molds[1].InstalledBy[0] != "g/top" {
+		t.Errorf("Molds[1].InstalledBy = %v", got.Molds[1].InstalledBy)
+	}
+}
+
+func TestInstalledEntry_OmitsEmptyInstalledFields(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "installed.yaml")
+	m := &InstalledManifest{
+		APIVersion: "v1",
+		Molds: []InstalledEntry{
+			{Name: "m", Source: "g/m", Version: "v1.0.0", Commit: "abc"},
+		},
+	}
+	if err := WriteInstalledManifest(path, m); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "installedAs") {
+		t.Errorf("expected installedAs to be omitted when empty:\n%s", raw)
+	}
+	if strings.Contains(string(raw), "installedBy") {
+		t.Errorf("expected installedBy to be omitted when empty:\n%s", raw)
+	}
+}
+
+func TestInstalledManifest_RemoveMoldDependent_RemovesOrphanTransitives(t *testing.T) {
+	m := &InstalledManifest{
+		APIVersion: "v1",
+		Molds: []InstalledEntry{
+			{Name: "top", Source: "g/top", Version: "v1.0.0", InstalledAs: "direct"},
+			{
+				Name: "leaf-only-via-top", Source: "g/leaf-a", Version: "v1.0.0",
+				InstalledAs: "transitive", InstalledBy: []string{"g/top"},
+			},
+			{
+				Name: "shared", Source: "g/shared", Version: "v1.0.0",
+				InstalledAs: "transitive", InstalledBy: []string{"g/top", "g/other"},
+			},
+		},
+	}
+	orphans := m.RemoveMoldDependent("g/top")
+	// leaf-only-via-top has only g/top as a parent → orphan, removed.
+	// shared still has g/other → kept with g/top stripped.
+	if len(orphans) != 1 || orphans[0].Name != "leaf-only-via-top" {
+		t.Errorf("orphans = %+v; want only leaf-only-via-top", orphans)
+	}
+	if len(m.Molds) != 2 {
+		t.Fatalf("expected 2 molds after orphan removal, got %d: %+v", len(m.Molds), m.Molds)
+	}
+	// `top` should still be present (direct, not affected).
+	// `shared` should still be present, with InstalledBy stripped of g/top.
+	for _, e := range m.Molds {
+		if e.Name == "shared" {
+			if len(e.InstalledBy) != 1 || e.InstalledBy[0] != "g/other" {
+				t.Errorf("shared.InstalledBy = %v; want [g/other]", e.InstalledBy)
+			}
+		}
+	}
+}
+
+func TestInstalledManifest_RemoveMoldDependent_DirectsAreNeverOrphaned(t *testing.T) {
+	m := &InstalledManifest{
+		APIVersion: "v1",
+		Molds: []InstalledEntry{
+			{Name: "directly-cast", Source: "g/d", InstalledAs: "direct", InstalledBy: []string{"g/parent"}},
+		},
+	}
+	orphans := m.RemoveMoldDependent("g/parent")
+	if len(orphans) != 0 {
+		t.Errorf("direct molds must never become orphans, got: %+v", orphans)
+	}
+	if len(m.Molds) != 1 {
+		t.Fatalf("direct mold must remain: %+v", m.Molds)
+	}
+	if len(m.Molds[0].InstalledBy) != 0 {
+		t.Errorf("InstalledBy should still be stripped: %+v", m.Molds[0].InstalledBy)
+	}
+}
+
 func TestManifest_AbsentDoesNotBreakLockReads(t *testing.T) {
 	dir := t.TempDir()
 	origDir, err := os.Getwd()

--- a/pkg/foundry/resolver.go
+++ b/pkg/foundry/resolver.go
@@ -74,6 +74,29 @@ func ResolveVersion(ref *Reference, git GitRunner) (*ResolvedVersion, error) {
 	}
 }
 
+// RemoteTags lists the semver tags (tag → commit SHA) for the given remote
+// URL, optionally narrowed to a monorepo subpath via the prefix selection
+// rules (`<subpath>-v*` tags when present, falling back to plain tags).
+//
+// Used by graph-aware resolvers (transitive mold deps) that need to intersect
+// constraints from multiple parents and pick the highest-compatible version
+// without re-issuing one git ls-remote per constraint.
+func RemoteTags(url, subpath string, git GitRunner) (map[string]string, error) {
+	all, err := remoteTags(url, git)
+	if err != nil {
+		return nil, err
+	}
+	prefix := ""
+	if s := strings.Trim(subpath, "/"); s != "" {
+		if i := strings.LastIndex(s, "/"); i != -1 {
+			prefix = s[i+1:]
+		} else {
+			prefix = s
+		}
+	}
+	return selectTagsForPrefix(all, prefix), nil
+}
+
 // remoteTags fetches all semver tags from the remote and returns a map of
 // version → commit SHA. Annotated tags (^{}) override lightweight tag SHAs.
 func remoteTags(url string, git GitRunner) (map[string]string, error) {

--- a/pkg/mold/mold.go
+++ b/pkg/mold/mold.go
@@ -47,37 +47,58 @@ type FluxVar struct {
 	Discover    *DiscoverSpec  `yaml:"discover,omitempty"` // Dynamic discovery specification
 }
 
-// Dependency declares a dependency on an ingot or ore. Exactly one of Ingot
-// or Ore must be set per entry; this is enforced at temper time via
-// Dependency.Kind().
+// Dependency declares a dependency on a mold, ingot, or ore. Exactly one of
+// Mold, Ingot, or Ore must be set per entry; this is enforced at temper time
+// via Dependency.Kind().
+//
+// `Mold` accepts the same reference syntax as top-level `ailloy cast` — a
+// foundry-resolvable name, a git URL, or a local path. `With` carries
+// Helm-style sub-chart values that seed the dep's flux at cast time.
 type Dependency struct {
-	Ingot   string `yaml:"ingot,omitempty"`
-	Ore     string `yaml:"ore,omitempty"`
-	Version string `yaml:"version"`
-	As      string `yaml:"as,omitempty"` // ore-only namespace alias; ignored when Ingot is set
+	Mold    string         `yaml:"mold,omitempty"`
+	Ingot   string         `yaml:"ingot,omitempty"`
+	Ore     string         `yaml:"ore,omitempty"`
+	Version string         `yaml:"version"`
+	As      string         `yaml:"as,omitempty"`   // ore namespace alias; for mold deps, alias used in --set <as>.<key>
+	With    map[string]any `yaml:"with,omitempty"` // mold-only: Helm-style values passed into the dep's flux
 }
 
-// Kind returns "ingot" or "ore" based on which field is set. It is an error
-// for both or neither to be set; callers should treat that as a configuration
-// problem to surface at temper or pre-cast time.
+// Kind returns "mold", "ingot", or "ore" based on which field is set. It is
+// an error for more than one or none to be set; callers should treat that
+// as a configuration problem to surface at temper or pre-cast time.
 func (d Dependency) Kind() (string, error) {
+	set := 0
+	if d.Mold != "" {
+		set++
+	}
+	if d.Ingot != "" {
+		set++
+	}
+	if d.Ore != "" {
+		set++
+	}
 	switch {
-	case d.Ingot != "" && d.Ore != "":
-		return "", fmt.Errorf("dependency entry has both 'ingot' and 'ore' set; pick one")
+	case set > 1:
+		return "", fmt.Errorf("dependency entry must set exactly one of 'mold', 'ingot', 'ore'")
+	case d.Mold != "":
+		return "mold", nil
 	case d.Ingot != "":
 		return "ingot", nil
 	case d.Ore != "":
 		return "ore", nil
 	default:
-		return "", fmt.Errorf("dependency entry has neither 'ingot' nor 'ore' set")
+		return "", fmt.Errorf("dependency entry has none of 'mold', 'ingot', 'ore' set")
 	}
 }
 
-// Source returns the non-empty of Ingot or Ore. When both are set (which is
-// invalid per Kind() and should be caught by temper), Ingot is returned —
-// callers should validate via Kind() first if they need to detect ambiguity.
-// Returns "" if neither is set.
+// Source returns the non-empty of Mold, Ingot, or Ore. When more than one is
+// set (which is invalid per Kind() and should be caught by temper), the order
+// is Mold, then Ingot, then Ore — callers should validate via Kind() first if
+// they need to detect ambiguity. Returns "" if none is set.
 func (d Dependency) Source() string {
+	if d.Mold != "" {
+		return d.Mold
+	}
 	if d.Ingot != "" {
 		return d.Ingot
 	}

--- a/pkg/mold/mold_test.go
+++ b/pkg/mold/mold_test.go
@@ -420,3 +420,102 @@ func TestDependency_Source(t *testing.T) {
 		t.Error("ore source")
 	}
 }
+
+func TestDependency_Kind_Mold(t *testing.T) {
+	d := Dependency{Mold: "github.com/x/y", Version: "^1.0.0"}
+	k, err := d.Kind()
+	if err != nil || k != "mold" {
+		t.Errorf("Kind = (%q, %v); want (mold, nil)", k, err)
+	}
+}
+
+func TestDependency_Kind_MoldWithIngot_Errors(t *testing.T) {
+	d := Dependency{Mold: "a", Ingot: "b", Version: "1.0.0"}
+	if _, err := d.Kind(); err == nil {
+		t.Error("expected error when both mold and ingot set")
+	}
+}
+
+func TestDependency_Kind_MoldWithOre_Errors(t *testing.T) {
+	d := Dependency{Mold: "a", Ore: "b", Version: "1.0.0"}
+	if _, err := d.Kind(); err == nil {
+		t.Error("expected error when both mold and ore set")
+	}
+}
+
+func TestDependency_Source_Mold(t *testing.T) {
+	if (Dependency{Mold: "g/m"}).Source() != "g/m" {
+		t.Error("mold source")
+	}
+}
+
+func TestParseMold_MoldDependency(t *testing.T) {
+	data := []byte(`
+apiVersion: v1
+kind: mold
+name: parent
+version: 1.0.0
+dependencies:
+  - mold: github.com/example/child
+    version: "^1.0.0"
+    as: child-alias
+    with:
+      key1: value1
+      nested:
+        inner: 42
+`)
+	m, err := ParseMold(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(m.Dependencies) != 1 {
+		t.Fatalf("expected 1 dependency, got %d", len(m.Dependencies))
+	}
+	d := m.Dependencies[0]
+	if d.Mold != "github.com/example/child" {
+		t.Errorf("Mold = %q; want github.com/example/child", d.Mold)
+	}
+	if d.As != "child-alias" {
+		t.Errorf("As = %q; want child-alias", d.As)
+	}
+	if d.With["key1"] != "value1" {
+		t.Errorf("With[key1] = %v; want value1", d.With["key1"])
+	}
+	if got, _ := d.Kind(); got != "mold" {
+		t.Errorf("Kind = %q; want mold", got)
+	}
+}
+
+func TestValidateMold_MoldDependency(t *testing.T) {
+	m := &Mold{
+		APIVersion: "v1",
+		Kind:       "mold",
+		Name:       "parent",
+		Version:    "1.0.0",
+		Dependencies: []Dependency{
+			{Mold: "github.com/x/y", Version: "^1.0.0"},
+		},
+	}
+	if err := ValidateMold(m); err != nil {
+		t.Errorf("expected no error for valid mold dependency, got: %v", err)
+	}
+}
+
+func TestValidateMold_MoldDepInvalidVersion(t *testing.T) {
+	m := &Mold{
+		APIVersion: "v1",
+		Kind:       "mold",
+		Name:       "parent",
+		Version:    "1.0.0",
+		Dependencies: []Dependency{
+			{Mold: "github.com/x/y", Version: "garbage"},
+		},
+	}
+	err := ValidateMold(m)
+	if err == nil {
+		t.Fatal("expected error for invalid mold dep version")
+	}
+	if !strings.Contains(err.Error(), "dependencies[0].version") {
+		t.Errorf("expected dep version error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Description

Foundation for transitive mold-on-mold dependencies. A mold may now declare other molds via a `mold:` entry in `dependencies:`, and `ailloy cast` resolves the full graph and installs every transitive alongside the parent. Resolution uses npm/cargo-style highest-compatible semver with cycle detection and actionable conflict errors; flux propagates Helm-style (dep defaults ← parent `with:` ← root `--set <alias>.*`); uninstall cascades through `installedBy` reverse edges with direct casts safe from GC.

## Related Issue

Refs #193

## Testing

- `go test ./...` — all packages pass (15s)
- 21 new tests: mold schema (parse/Kind/validate), manifest schema (round-trip/cascade), depgraph (chain, diamond compatible+conflicting, cycle, dedup, branch/sha, parents+with), cast transitives (fake fetcher backed by `fstest.MapFS`), and cascade-uninstall (orphan removal, direct-cast safety, shared-transitive retention)
- `go vet ./...` clean, `gofmt` clean, pre-push lint passes

## UAT

1. Build: `go build ./cmd/ailloy`
2. Author a mold whose `mold.yaml` lists another mold in `dependencies:`, e.g. `- mold: github.com/<owner>/<leaf>`, `version: ^1.0.0`
3. `ailloy cast <parent>` and verify `.ailloy/installed.yaml` shows the parent as `installedAs: direct` and the leaf as `installedAs: transitive`, `installedBy: [<parent source>]`
4. `ailloy uninstall <parent>` and verify the leaf is cascade-removed (files + manifest entry)
5. Try a cycle and a conflicting-constraint diamond — both should error with the offending path / mold

Out of scope (deferred follow-ups also tracked under #193): `quench`/`recast` walking the full graph; `mold show` / `temper` / `forge --show-graph` polish.

## Checklist

- [ ] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [x] I have updated documentation (if applicable)
- [x] My commits have DCO sign-off (`git commit -s`)