### PR TITLE
feat: ore packages can ship output mappings and template bodies

### DIFF
--- a/docs/ore.md
+++ b/docs/ore.md
@@ -1,17 +1,18 @@
 # Ore
 
-Ore are reusable flux partials — structured data objects in the flux namespace that mold authors can opt into. Where [ingots](ingots.md) are reusable *template* partials (chunks of blank content), ore are reusable *flux* partials (chunks of values schema). Together they let you share both the prose and the data shapes that drive it.
+Ore are reusable **behavior** packages — versioned units that mold authors can opt into. At minimum, an ore is a named group of related flux fields under `ore.<name>.*` (a reusable *data shape*). Optionally, an ore can also ship its own `output:` fan-out mappings and a `blanks/` directory of template bodies, delivering a complete, turnkey rendering. Where [ingots](ingots.md) are reusable *template fragments* you embed inside a blank via `{{ ingot "..." }}`, ore are reusable *capabilities*: schema + defaults + (optionally) output mappings + (optionally) the blanks themselves — versioned together.
 
-A typical ore is a named group of related flux fields under `ore.<name>.*`. For example, `ore.status` describes the "Status" data model with an `enabled` toggle, a `field_id`, a `field_mapping`, and a map of `options`. Blanks consume an ore via conditionals (`{{if .ore.status.enabled}}…{{end}}`) and dotted access (`{{.ore.status.field_id}}`).
+A typical data-shape ore is `ore.status`: an `enabled` toggle, a `field_id`, a `field_mapping`, and a map of `options`. Blanks consume it via conditionals (`{{if .ore.status.enabled}}…{{end}}`) and dotted access (`{{.ore.status.field_id}}`). A behavior ore goes further — it can ship the blanks themselves and the per-destination fan-out that uses them, so a consumer mold gets the full rendering with nothing but a one-line `dependencies: - ore: <ref>` declaration. See [Optional: shipping output mappings and template bodies](#optional-shipping-output-mappings-and-template-bodies) for that side of the surface.
 
-Ore are typically **optional** (`enabled: false` by default) and **shareable**: many molds can adopt the same ore schema so a values file or anneal session configured for one mold drops cleanly into another.
+Ore are typically **optional** (`enabled: false` by default) and **shareable**: many molds can adopt the same ore so a values file or anneal session configured for one mold drops cleanly into another.
 
 ## When to Use Ore
 
 | Need | Use |
 |------|-----|
-| Reusable prose / instruction blocks | [Ingot](ingots.md) |
-| Reusable structured data shape (with `enabled` toggle) | **Ore** |
+| Reusable prose / instruction fragment embedded in a blank | [Ingot](ingots.md) |
+| Reusable structured data shape (with `enabled` toggle) | **Ore** (data-shape) |
+| Reusable complete rendering — schema + output fan-out + template bodies — versioned as one unit | **Ore** (behavior) |
 | Single value, one-off | Plain [flux variable](flux.md) |
 
 Pick ore when:
@@ -19,8 +20,9 @@ Pick ore when:
 - Multiple blanks (or multiple molds) need the same data shape — not just the same value
 - The data represents an **opt-in capability** that some users will turn on and others will leave off
 - The fields wrap an external system whose IDs/options can't be hardcoded (e.g., GitHub Project field IDs)
+- **Or** you have a complete rendering (templates + destinations + per-target context) that several molds duplicate today — bundle it as a behavior ore and collapse each consumer to a one-line dep
 
-Pick an ingot instead when the reusable thing is text — a preamble, a CLI cheat-sheet, a coding-standards block.
+Pick an ingot instead when the reusable thing is a *fragment of text* that gets embedded inside another template — a preamble, a CLI cheat-sheet, a coding-standards block. Pick an ore when the reusable thing is a *whole rendering* with its own destination(s).
 
 ## Anatomy of an Ore
 

--- a/docs/ore.md
+++ b/docs/ore.md
@@ -155,7 +155,7 @@ See the [Anneal guide](anneal.md) for the full discovery field reference.
 
 ## Ore Package Structure
 
-An ore package is a directory containing three files:
+An ore package is, at minimum, a directory containing three files. Ores may also ship optional output mappings and template bodies — see [Optional: shipping output mappings and template bodies](#optional-shipping-output-mappings-and-template-bodies) below.
 
 ```
 my-status-ore/
@@ -206,6 +206,102 @@ field_id: ""
 options:
   ready: { id: "", label: Ready }
 ```
+
+### Optional: shipping output mappings and template bodies
+
+An ore can also ship a complete reusable rendering — schema + defaults + **output fan-out** + **template bodies** — by adding two optional pieces:
+
+```
+my-multi-target-ore/
+├── ore.yaml
+├── flux.schema.yaml
+├── flux.yaml               # may include a top-level output: block
+└── blanks/                 # template files addressable from output:
+    ├── AGENTS.md
+    └── agents/
+        └── example.md
+```
+
+`flux.yaml` `output:` block — entries get merged into the consuming mold's `output:` map at cast time:
+
+```yaml
+enabled: true
+targets: [claude, opencode]
+
+output:
+  blanks/AGENTS.md: AGENTS.md
+  blanks/agents:
+    - dest: .claude/agents
+      set:
+        current_target: claude
+    - dest: .opencode/agents
+      set:
+        current_target: opencode
+```
+
+Source-path keys (the left-hand side of each output entry) reference paths **inside the ore package** — typically files under `blanks/`. Destinations are project-relative. Per-destination `set:` injects template context for that render pass, exactly like consumer-side `set:`.
+
+#### Merge semantics for ore-supplied `output:`
+
+When a consuming mold also defines an `output:` entry for the same source-path key:
+
+- **Consumer wins.** The ore-supplied entry is ignored.
+- The shadowed entry is recorded in `OreLoadReport.ShadowedOutput` and surfaced by `ailloy forge --debug`.
+- This mirrors the precedence rule already used for schema and defaults.
+
+When two ores declare the same source-path key (and the consumer does not):
+
+- **Error.** Resolve by overriding in the consumer's `output:` or by aliasing one of the ores with `as:` in the dependency declaration.
+
+Ore-supplied output entries render in the **consumer's flux context** — they can reference `{{ .project.x }}`, `{{ .ore.<other>.y }}`, etc. They render once per consumer cast, exactly like consumer-authored entries.
+
+#### Referencing ore blanks from a consumer mold
+
+A consumer mold can compose with an ore's blanks without depending on the ore declaring the destination itself. Use `from:` in a consumer output entry:
+
+```yaml
+# consumer's flux.yaml
+output:
+  AGENTS.md:
+    from: ore/agent_targets/blanks/AGENTS.md
+    dest: AGENTS.md
+```
+
+`from:` is only valid in **consumer-side** output entries. `ailloy temper` rejects `from:` inside an ore's own `output:` block — ores cannot reference other ores' blanks, that path is reserved for consumer composition.
+
+#### Worked example: `agent_targets`
+
+A complete worked example lives in [`testdata/agent_targets/`](../testdata/agent_targets/). The ore ships an `output:` block that fans `blanks/agents/` out to both `.claude/agents` and `.opencode/agents` with per-target `set: { current_target: <name> }` context, plus `blanks/AGENTS.md → AGENTS.md`. A consumer can pick up the entire multi-target rendering with nothing but a one-line dependency:
+
+```yaml
+# consumer/mold.yaml
+apiVersion: v1
+kind: Mold
+name: my_consumer
+version: 0.1.0
+dependencies:
+  - ore: github.com/.../agent_targets
+    version: 0.1.0
+```
+
+No `output:` block needed in the consumer. Cast renders `AGENTS.md`, `.claude/agents/...`, and `.opencode/agents/...` from the ore's blanks, each with its per-target context.
+
+#### Debug provenance
+
+Run `ailloy forge --debug` to see which file came from which ore:
+
+```
+[forge --debug] resolved output (dest ← src @ origin):
+  AGENTS.md                                ← blanks/AGENTS.md                         @ ore:agent_targets
+  .claude/agents/example.md                ← blanks/agents/example.md                 @ ore:agent_targets
+  .opencode/agents/example.md              ← blanks/agents/example.md                 @ ore:agent_targets
+```
+
+Use this to confirm a consumer's overrides land where you expect and to find unexpected shadowing.
+
+#### Backward compatibility
+
+The classic three-file ore (no `output:` block, no `blanks/` directory) continues to work unchanged. Both new pieces are additive — `ailloy temper` accepts ores with neither, either, or both.
 
 ## Creating an Ore
 

--- a/internal/commands/cast.go
+++ b/internal/commands/cast.go
@@ -363,7 +363,17 @@ func castProject(reader *blanks.MoldReader, source string) error {
 		resolveOpts = append(resolveOpts, mold.WithIgnorePatterns(ignorePatterns))
 	}
 
-	resolved, err := mold.ResolveFiles(flux["output"], reader.FS(), resolveOpts...)
+	// Resolve ore deps ephemerally to get OreSource records (fs handles +
+	// extracted output overlays). The on-disk schema/defaults path
+	// (loadCastFlux → LoadMoldFluxWithOres) doesn't expose FS handles, so
+	// we layer this read-only resolution on top. installDeclaredDeps above
+	// already pulled the deps; ResolveDepsEphemeral hits the same foundry
+	// cache and produces matching content.
+	depResolver, derr := ResolveDepsEphemeral(manifest, allowLocalDeps)
+	if derr != nil {
+		return fmt.Errorf("resolving ore output overlays: %w", derr)
+	}
+	resolved, err := mold.ResolveFilesWithOreSources(flux["output"], reader.FS(), depResolver.OreSources(), resolveOpts...)
 	if err != nil {
 		return fmt.Errorf("failed to resolve output files: %w", err)
 	}
@@ -727,6 +737,17 @@ func offerAgentsImport(claudePath string) {
 		styles.SuccessStyle.Render(" import to ") + styles.CodeStyle.Render(claudePath))
 }
 
+// chooseFS returns rf.SrcFS when non-nil, falling back to the mold's primary
+// fs. Resolved files originating from an ore (or a consumer `from: ore/...`
+// selector) carry a non-nil SrcFS; mold-origin files carry nil and fall back
+// to the reader.
+func chooseFS(rf mold.ResolvedFile, primary fs.FS) fs.FS {
+	if rf.SrcFS != nil {
+		return rf.SrcFS
+	}
+	return primary
+}
+
 // copyResolvedFiles copies resolved mold files to the project, applying template
 // processing where indicated by the output mapping. Schema for validation is
 // inferred from the reader / mold manifest. Cast-time callers should prefer
@@ -769,7 +790,7 @@ func copyResolvedFilesWithSchema(reader *blanks.MoldReader, manifest *mold.Mold,
 	}
 
 	for _, rf := range resolved {
-		content, err := fs.ReadFile(reader.FS(), rf.SrcPath)
+		content, err := fs.ReadFile(chooseFS(rf, reader.FS()), rf.SrcPath)
 		if err != nil {
 			return fmt.Errorf("failed to read %s: %w", rf.SrcPath, err)
 		}

--- a/internal/commands/cast_ore_overlay_test.go
+++ b/internal/commands/cast_ore_overlay_test.go
@@ -1,0 +1,167 @@
+package commands
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/nimble-giant/ailloy/pkg/mold"
+)
+
+// TestAgentTargetsOreOverlay_EndToEndRendering verifies the issue #215
+// acceptance criterion: a consumer mold whose only content is a one-line
+// `dependencies: ore: agent_targets` declaration gets the full multi-target
+// rendering produced by the ore's `output:` mappings + `blanks/` directory.
+//
+// This test exercises the resolution + render layer directly (mold.Temper
+// for validation, EphemeralOreResolver for source extraction,
+// ResolveFilesWithOreSources + ProcessTemplate for rendering). It does NOT
+// go through the cast command — see cast_ore_e2e_test.go for why the full
+// CastMold path is currently skipped under -race.
+func TestAgentTargetsOreOverlay_EndToEndRendering(t *testing.T) {
+	repoRoot := findRepoRoot(t)
+	oreDir := filepath.Join(repoRoot, "testdata", "agent_targets", "ore")
+	consumerDir := filepath.Join(repoRoot, "testdata", "agent_targets", "consumer")
+
+	// 1. Temper validates: the ore + consumer testdata pass mold.Temper.
+	if res := mold.Temper(os.DirFS(oreDir)); res.HasErrors() {
+		t.Fatalf("ore testdata fails temper: %+v", res.Errors())
+	}
+	if res := mold.Temper(os.DirFS(consumerDir)); res.HasErrors() {
+		t.Fatalf("consumer testdata fails temper: %+v", res.Errors())
+	}
+
+	// 2. Build the consumer manifest + its dependency-resolved OreSources.
+	// We load the static mold.yaml for structural inspection, then construct
+	// the Mold value with the ore dep's absolute path so ResolveDepsEphemeral
+	// can stat it regardless of the test binary's working directory.
+	manifest, err := mold.LoadMold(filepath.Join(consumerDir, "mold.yaml"))
+	if err != nil {
+		t.Fatalf("load consumer mold: %v", err)
+	}
+	// Patch the ore dep path to an absolute path so the ephemeral resolver can
+	// stat it irrespective of the test binary's working directory.
+	for i := range manifest.Dependencies {
+		if manifest.Dependencies[i].Ore != "" {
+			manifest.Dependencies[i].Ore = oreDir
+		}
+	}
+	resolver, err := ResolveDepsEphemeral(manifest, true)
+	if err != nil {
+		t.Fatalf("resolve deps: %v", err)
+	}
+	sources := resolver.OreSources()
+	if len(sources) != 1 {
+		t.Fatalf("expected 1 ore source, got %d", len(sources))
+	}
+
+	// 3. Resolve outputs via the composite-FS resolver.
+	consumerFS := os.DirFS(consumerDir)
+	resolved, err := mold.ResolveFilesWithOreSources(nil, consumerFS, sources)
+	if err != nil {
+		t.Fatalf("ResolveFilesWithOreSources: %v", err)
+	}
+
+	gotDests := destPaths(resolved)
+	wantDests := []string{
+		".claude/agents/example.md",
+		".opencode/agents/example.md",
+		"AGENTS.md",
+	}
+	if !sliceEqual(gotDests, wantDests) {
+		t.Fatalf("dest paths mismatch:\n  got:  %v\n  want: %v", gotDests, wantDests)
+	}
+
+	// 4. Each resolved file must carry the ore namespace + a non-nil SrcFS
+	// (every output entry in this fixture comes from the ore overlay).
+	for _, rf := range resolved {
+		if rf.Origin != "agent_targets" {
+			t.Errorf("%s: Origin = %q, want agent_targets", rf.DestPath, rf.Origin)
+		}
+		if rf.SrcFS == nil {
+			t.Errorf("%s: SrcFS is nil", rf.DestPath)
+		}
+	}
+
+	// 5. Render and verify per-target context flows through `set:` correctly.
+	rendered := renderResolvedFiles(t, resolved)
+	claude := rendered[".claude/agents/example.md"]
+	opencode := rendered[".opencode/agents/example.md"]
+	if !strings.Contains(claude, "target: claude") {
+		t.Errorf(".claude/agents/example.md missing claude target token; got:\n%s", claude)
+	}
+	if !strings.Contains(opencode, "target: opencode") {
+		t.Errorf(".opencode/agents/example.md missing opencode target token; got:\n%s", opencode)
+	}
+	// Sanity: the two renders are NOT identical (different set: context).
+	if claude == opencode {
+		t.Errorf("per-target renders should differ but were identical:\n%s", claude)
+	}
+}
+
+// findRepoRoot walks up from the test's working directory until it finds a
+// go.mod, returning that directory.
+func findRepoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find repo root (go.mod) from " + dir)
+		}
+		dir = parent
+	}
+}
+
+func destPaths(resolved []mold.ResolvedFile) []string {
+	out := make([]string, 0, len(resolved))
+	for _, rf := range resolved {
+		out = append(out, rf.DestPath)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func renderResolvedFiles(t *testing.T, resolved []mold.ResolvedFile) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	for _, rf := range resolved {
+		fsys := rf.SrcFS
+		content, err := fs.ReadFile(fsys, rf.SrcPath)
+		if err != nil {
+			t.Fatalf("read %s from origin %q: %v", rf.SrcPath, rf.Origin, err)
+		}
+		// Build a minimal flux context plus the per-destination set overlay.
+		flux := map[string]any{}
+		if len(rf.Set) > 0 {
+			flux = mold.MergeSet(flux, rf.Set)
+		}
+		rendered, err := mold.ProcessTemplate(string(content), flux)
+		if err != nil {
+			t.Fatalf("render %s: %v", rf.SrcPath, err)
+		}
+		out[rf.DestPath] = rendered
+	}
+	return out
+}

--- a/internal/commands/forge.go
+++ b/internal/commands/forge.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"log"
 	"os"
@@ -39,6 +40,7 @@ var (
 	forgeSetValues                []string
 	forgeValFiles                 []string
 	forgeForceReplaceOnParseError bool
+	forgeDebug                    bool
 )
 
 func init() {
@@ -51,6 +53,7 @@ func init() {
 		"force-replace-on-parse-error",
 		false,
 		"if a destination uses strategy: merge but is unparseable, replace it instead of erroring (only used with --output)")
+	forgeCmd.Flags().BoolVar(&forgeDebug, "debug", false, "print resolved output mapping with source provenance (ore vs mold) before rendering")
 }
 
 // loadForgeFlux loads layered flux values using Helm-style precedence:
@@ -168,14 +171,18 @@ func runForge(_ *cobra.Command, args []string) error {
 	}
 
 	// Resolve all output files from the flux.
-	resolved, err := mold.ResolveFiles(flux["output"], reader.FS(), resolveOpts...)
+	resolved, err := mold.ResolveFilesWithOreSources(flux["output"], reader.FS(), oreResolver.OreSources(), resolveOpts...)
 	if err != nil {
 		return fmt.Errorf("resolving output files: %w", err)
 	}
 
+	if forgeDebug {
+		printForgeDebugProvenance(os.Stderr, resolved)
+	}
+
 	var files []renderedFile
 	for _, rf := range resolved {
-		content, err := fs.ReadFile(reader.FS(), rf.SrcPath)
+		content, err := fs.ReadFile(chooseFS(rf, reader.FS()), rf.SrcPath)
 		if err != nil {
 			return fmt.Errorf("reading %s: %w", rf.SrcPath, err)
 		}
@@ -245,6 +252,22 @@ func buildIngotResolver(flux map[string]any, moldRoot string) *mold.IngotResolve
 	}
 
 	return mold.NewIngotResolver(searchPaths, flux)
+}
+
+// printForgeDebugProvenance prints the resolved file list to w, annotating each
+// row with its origin (mold or ore:<namespace>) so authors can see where each
+// rendered file came from. Triggered by `forge --debug`.
+func printForgeDebugProvenance(w io.Writer, resolved []mold.ResolvedFile) {
+	fmt.Fprintln(w, "[forge --debug] resolved output (dest ← src @ origin):")
+	for _, rf := range resolved {
+		origin := rf.Origin
+		if origin == "" {
+			origin = "mold"
+		} else {
+			origin = "ore:" + origin
+		}
+		fmt.Fprintf(w, "  %-40s ← %-40s @ %s\n", rf.DestPath, rf.SrcPath, origin)
+	}
 }
 
 func printForgeFiles(files []renderedFile) error {

--- a/internal/commands/forge.go
+++ b/internal/commands/forge.go
@@ -258,7 +258,7 @@ func buildIngotResolver(flux map[string]any, moldRoot string) *mold.IngotResolve
 // row with its origin (mold or ore:<namespace>) so authors can see where each
 // rendered file came from. Triggered by `forge --debug`.
 func printForgeDebugProvenance(w io.Writer, resolved []mold.ResolvedFile) {
-	fmt.Fprintln(w, "[forge --debug] resolved output (dest ← src @ origin):")
+	_, _ = fmt.Fprintln(w, "[forge --debug] resolved output (dest ← src @ origin):")
 	for _, rf := range resolved {
 		origin := rf.Origin
 		if origin == "" {
@@ -266,7 +266,7 @@ func printForgeDebugProvenance(w io.Writer, resolved []mold.ResolvedFile) {
 		} else {
 			origin = "ore:" + origin
 		}
-		fmt.Fprintf(w, "  %-40s ← %-40s @ %s\n", rf.DestPath, rf.SrcPath, origin)
+		_, _ = fmt.Fprintf(w, "  %-40s ← %-40s @ %s\n", rf.DestPath, rf.SrcPath, origin)
 	}
 }
 

--- a/internal/commands/forge_ore_overlay_test.go
+++ b/internal/commands/forge_ore_overlay_test.go
@@ -1,0 +1,38 @@
+package commands
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/nimble-giant/ailloy/pkg/mold"
+)
+
+func TestPrintForgeDebugProvenance_FormatsRowsByOrigin(t *testing.T) {
+	resolved := []mold.ResolvedFile{
+		{SrcPath: "commands/hello.md", DestPath: ".claude/commands/hello.md", Origin: ""},
+		{SrcPath: "blanks/AGENTS.md", DestPath: "AGENTS.md", Origin: "agent_targets"},
+	}
+
+	var buf bytes.Buffer
+	printForgeDebugProvenance(&buf, resolved)
+
+	out := buf.String()
+	if !strings.Contains(out, "resolved output") {
+		t.Errorf("missing header: %s", out)
+	}
+	if !strings.Contains(out, "@ mold") {
+		t.Errorf("missing mold origin: %s", out)
+	}
+	if !strings.Contains(out, "@ ore:agent_targets") {
+		t.Errorf("missing ore origin: %s", out)
+	}
+	if !strings.Contains(out, "AGENTS.md") || !strings.Contains(out, "blanks/AGENTS.md") {
+		t.Errorf("missing dest/src paths: %s", out)
+	}
+}
+
+// Sanity import; ensures fstest stays linked if future tests need it without
+// triggering goimports purge.
+var _ = fstest.MapFS{}

--- a/internal/commands/forge_ore_overlay_test.go
+++ b/internal/commands/forge_ore_overlay_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"strings"
 	"testing"
-	"testing/fstest"
 
 	"github.com/nimble-giant/ailloy/pkg/mold"
 )
@@ -33,6 +32,3 @@ func TestPrintForgeDebugProvenance_FormatsRowsByOrigin(t *testing.T) {
 	}
 }
 
-// Sanity import; ensures fstest stays linked if future tests need it without
-// triggering goimports purge.
-var _ = fstest.MapFS{}

--- a/internal/commands/install_deps_ephemeral.go
+++ b/internal/commands/install_deps_ephemeral.go
@@ -16,6 +16,12 @@ import (
 type EphemeralOreResolver struct {
 	overlays []mold.OverlaySchema
 	defaults map[string]any
+	// sources records each resolved ore's fs.FS, namespace, and any
+	// ore-supplied `output:` overlay extracted from its flux.yaml. Used by
+	// cast/forge to merge ore-supplied output mappings into the consumer
+	// mold's output and to resolve `from:` selectors that point into an
+	// ore's blanks/ tree.
+	sources []mold.OreSource
 }
 
 // Overlays returns the prefixed schema overlays produced from declared ore
@@ -35,6 +41,16 @@ func (r *EphemeralOreResolver) Defaults() map[string]any {
 		return nil
 	}
 	return r.defaults
+}
+
+// OreSources returns one OreSource per resolved ore dep, carrying the
+// namespace, the ore's fs.FS, and any ore-supplied output overlay extracted
+// from its flux.yaml. Empty for nil receiver.
+func (r *EphemeralOreResolver) OreSources() []mold.OreSource {
+	if r == nil {
+		return nil
+	}
+	return r.sources
 }
 
 // ResolveDepsEphemeral walks manifest.Dependencies and resolves each ore
@@ -124,6 +140,16 @@ func ResolveDepsEphemeral(manifest *mold.Mold, allowLocalDeps bool) (*EphemeralO
 		if oreDefaults == nil {
 			oreDefaults = map[string]any{}
 		}
+		// Pull the optional `output:` overlay out of the ore's flux.yaml
+		// BEFORE wrapping the remaining defaults under ore.<name>. — output
+		// belongs in the consumer's top-level output map, not under the
+		// ore namespace.
+		oreOutput := mold.ExtractOreOutput(oreDefaults)
+		r.sources = append(r.sources, mold.OreSource{
+			Namespace: name,
+			FS:        fsys,
+			Output:    oreOutput,
+		})
 		nsMap, _ := r.defaults["ore"].(map[string]any)
 		if nsMap == nil {
 			nsMap = map[string]any{}

--- a/internal/commands/install_deps_ephemeral_test.go
+++ b/internal/commands/install_deps_ephemeral_test.go
@@ -1,0 +1,114 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nimble-giant/ailloy/pkg/mold"
+)
+
+func TestEphemeralOreResolver_ExposesOreOutputAndFS(t *testing.T) {
+	tmp := t.TempDir()
+	oreDir := filepath.Join(tmp, "ore")
+	if err := os.MkdirAll(filepath.Join(oreDir, "blanks"), 0750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	files := map[string]string{
+		filepath.Join(oreDir, "ore.yaml"):         "apiVersion: v1\nkind: ore\nname: at\nversion: 0.1.0\n",
+		filepath.Join(oreDir, "flux.schema.yaml"): "- name: enabled\n  type: bool\n  default: \"false\"\n",
+		filepath.Join(oreDir, "flux.yaml"):        "enabled: false\noutput:\n  blanks/AGENTS.md: AGENTS.md\n",
+		filepath.Join(oreDir, "blanks/AGENTS.md"): "# at agents\n",
+	}
+	for p, body := range files {
+		if err := os.WriteFile(p, []byte(body), 0644); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+
+	moldDir := filepath.Join(tmp, "consumer")
+	if err := os.MkdirAll(moldDir, 0750); err != nil {
+		t.Fatalf("mkdir mold: %v", err)
+	}
+	moldYAML := "apiVersion: v1\nkind: Mold\nname: c\nversion: 0.1.0\ndependencies:\n  - ore: " + oreDir + "\n    version: 0.1.0\n"
+	if err := os.WriteFile(filepath.Join(moldDir, "mold.yaml"), []byte(moldYAML), 0644); err != nil {
+		t.Fatalf("write mold.yaml: %v", err)
+	}
+
+	manifest, err := mold.LoadMold(filepath.Join(moldDir, "mold.yaml"))
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+	r, err := ResolveDepsEphemeral(manifest, true)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+
+	sources := r.OreSources()
+	if len(sources) != 1 {
+		t.Fatalf("expected 1 ore source, got %d", len(sources))
+	}
+	s := sources[0]
+	if s.Namespace != "at" {
+		t.Errorf("namespace = %q, want %q", s.Namespace, "at")
+	}
+	if s.FS == nil {
+		t.Fatal("FS is nil")
+	}
+	if _, ok := s.Output["blanks/AGENTS.md"]; !ok {
+		t.Errorf("Output missing blanks/AGENTS.md: %+v", s.Output)
+	}
+}
+
+func TestEphemeralOreResolver_BackwardCompat_NoOutputBlock(t *testing.T) {
+	tmp := t.TempDir()
+	oreDir := filepath.Join(tmp, "ore")
+	if err := os.MkdirAll(oreDir, 0750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	files := map[string]string{
+		filepath.Join(oreDir, "ore.yaml"):         "apiVersion: v1\nkind: ore\nname: legacy\nversion: 0.1.0\n",
+		filepath.Join(oreDir, "flux.schema.yaml"): "- name: enabled\n  type: bool\n  default: \"false\"\n",
+		filepath.Join(oreDir, "flux.yaml"):        "enabled: false\n",
+	}
+	for p, body := range files {
+		if err := os.WriteFile(p, []byte(body), 0644); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+
+	moldDir := filepath.Join(tmp, "consumer")
+	if err := os.MkdirAll(moldDir, 0750); err != nil {
+		t.Fatalf("mkdir mold: %v", err)
+	}
+	moldYAML := "apiVersion: v1\nkind: Mold\nname: c\nversion: 0.1.0\ndependencies:\n  - ore: " + oreDir + "\n    version: 0.1.0\n"
+	if err := os.WriteFile(filepath.Join(moldDir, "mold.yaml"), []byte(moldYAML), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	manifest, err := mold.LoadMold(filepath.Join(moldDir, "mold.yaml"))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	r, err := ResolveDepsEphemeral(manifest, true)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	sources := r.OreSources()
+	if len(sources) != 1 {
+		t.Fatalf("expected 1 ore source, got %d", len(sources))
+	}
+	if sources[0].Output != nil {
+		t.Errorf("legacy ore should have nil Output, got %+v", sources[0].Output)
+	}
+	// Schema overlay should still work — Defaults should not contain
+	// 'output' under ore.legacy.
+	defaults := r.Defaults()
+	if ore, ok := defaults["ore"].(map[string]any); ok {
+		if leg, ok := ore["legacy"].(map[string]any); ok {
+			if _, hasOutput := leg["output"]; hasOutput {
+				t.Errorf("output key leaked into namespaced defaults: %+v", leg)
+			}
+		}
+	}
+}

--- a/internal/commands/temper_ore_overlay_test.go
+++ b/internal/commands/temper_ore_overlay_test.go
@@ -1,0 +1,107 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nimble-giant/ailloy/pkg/mold"
+)
+
+func TestTemperOre_AcceptsOutputAndBlanks(t *testing.T) {
+	dir := writeOverlayOreFixture(t, map[string]string{
+		"ore.yaml":         "apiVersion: v1\nkind: ore\nname: at\nversion: 0.1.0\n",
+		"flux.schema.yaml": "- name: enabled\n  type: bool\n  default: \"false\"\n",
+		"flux.yaml":        "enabled: false\noutput:\n  blanks/AGENTS.md: AGENTS.md\n",
+		"blanks/AGENTS.md": "hi\n",
+	})
+	res := mold.Temper(os.DirFS(dir))
+	if res.HasErrors() {
+		t.Fatalf("unexpected errors: %+v", res.Errors())
+	}
+}
+
+func TestTemperOre_RejectsFromInOreOutput(t *testing.T) {
+	dir := writeOverlayOreFixture(t, map[string]string{
+		"ore.yaml":         "apiVersion: v1\nkind: ore\nname: at\nversion: 0.1.0\n",
+		"flux.schema.yaml": "- name: enabled\n  type: bool\n  default: \"false\"\n",
+		"flux.yaml":        "enabled: false\noutput:\n  AGENTS.md:\n    from: ore/other/blanks/x\n    dest: AGENTS.md\n",
+		"AGENTS.md":        "hi\n",
+	})
+	res := mold.Temper(os.DirFS(dir))
+	if !res.HasErrors() {
+		t.Fatal("expected error for from: in ore output")
+	}
+	if !overlayContainsError(res.Errors(), "from:") {
+		t.Errorf("expected error mentioning from:, got %+v", res.Errors())
+	}
+}
+
+func TestTemperOre_RejectsOutputReferencingMissingBlank(t *testing.T) {
+	dir := writeOverlayOreFixture(t, map[string]string{
+		"ore.yaml":         "apiVersion: v1\nkind: ore\nname: at\nversion: 0.1.0\n",
+		"flux.schema.yaml": "- name: enabled\n  type: bool\n  default: \"false\"\n",
+		"flux.yaml":        "enabled: false\noutput:\n  blanks/missing.md: AGENTS.md\n",
+	})
+	res := mold.Temper(os.DirFS(dir))
+	if !res.HasErrors() {
+		t.Fatal("expected error for missing blank reference")
+	}
+	if !overlayContainsError(res.Errors(), "does not exist") {
+		t.Errorf("expected missing-path error, got %+v", res.Errors())
+	}
+}
+
+func TestTemperOre_RejectsNonMapOutput(t *testing.T) {
+	dir := writeOverlayOreFixture(t, map[string]string{
+		"ore.yaml":         "apiVersion: v1\nkind: ore\nname: at\nversion: 0.1.0\n",
+		"flux.schema.yaml": "- name: enabled\n  type: bool\n  default: \"false\"\n",
+		"flux.yaml":        "enabled: false\noutput: notamap\n",
+	})
+	res := mold.Temper(os.DirFS(dir))
+	if !res.HasErrors() {
+		t.Fatal("expected error for scalar output")
+	}
+	if !overlayContainsError(res.Errors(), "must be a map") {
+		t.Errorf("expected map-required error, got %+v", res.Errors())
+	}
+}
+
+func TestTemperOre_BackwardCompat_NoOutputNoBlanks(t *testing.T) {
+	dir := writeOverlayOreFixture(t, map[string]string{
+		"ore.yaml":         "apiVersion: v1\nkind: ore\nname: at\nversion: 0.1.0\n",
+		"flux.schema.yaml": "- name: enabled\n  type: bool\n  default: \"false\"\n",
+		"flux.yaml":        "enabled: false\n",
+	})
+	res := mold.Temper(os.DirFS(dir))
+	if res.HasErrors() {
+		t.Fatalf("unexpected errors on backward-compat ore: %+v", res.Errors())
+	}
+}
+
+// --- helpers ---
+
+func writeOverlayOreFixture(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for rel, body := range files {
+		full := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0750); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+	return dir
+}
+
+func overlayContainsError(errs []mold.Diagnostic, substr string) bool {
+	for _, e := range errs {
+		if strings.Contains(e.Message, substr) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/mold/flux_merge.go
+++ b/pkg/mold/flux_merge.go
@@ -25,6 +25,19 @@ type OreLoadReport struct {
 	// Sources records the source of each entry in the merged schema, keyed by
 	// FluxVar.Name. "" means the mold itself.
 	Sources map[string]string
+	// ShadowedOutput records output mappings an ore declared but a consumer
+	// mold-local entry won. Same precedence rule as schema: consumer wins.
+	ShadowedOutput []ShadowedOutputEntry
+	// OutputSources records the source of each entry in the merged output map,
+	// keyed by source path (the map key). "" means the consumer mold itself.
+	OutputSources map[string]string
+}
+
+// ShadowedOutputEntry records an output source-path key that an ore overlay
+// defined but a consumer mold-local entry won.
+type ShadowedOutputEntry struct {
+	Key    string // the source-path map key (e.g. "blanks/AGENTS.md")
+	Source string // "ore:<namespace>" — the overlay that lost
 }
 
 // MergeFluxSchema combines a base schema (the mold's own flux.schema.yaml

--- a/pkg/mold/mold.go
+++ b/pkg/mold/mold.go
@@ -114,7 +114,13 @@ type OutputTarget struct {
 	Dest     string         `yaml:"dest"`
 	Process  *bool          `yaml:"process,omitempty"`  // nil = true (default)
 	Set      map[string]any `yaml:"set,omitempty"`      // per-destination context overrides
-	Strategy string         `yaml:"strategy,omitempty"` // "" or "replace" (default) | "merge"
+	Strategy string         `yaml:"strategy,omitempty"` // "" or "replace" (default) | "merge" | "append"
+	// From, if non-empty, overrides the map-key source path with an explicit
+	// source. Format: "ore/<namespace>/<path>" addresses a file inside an ore
+	// package's blanks/ (or other) tree. Used by consumer molds to reference
+	// an ore-shipped template without the ore needing to declare the
+	// destination itself.
+	From string `yaml:"from,omitempty"`
 }
 
 // ShouldProcess returns whether files under this target should be template-processed.
@@ -124,11 +130,19 @@ func (o OutputTarget) ShouldProcess() bool {
 
 // ResolvedFile represents a single file resolved from the output mapping.
 type ResolvedFile struct {
-	SrcPath  string         // path within the mold fs (e.g., "commands/hello.md")
+	SrcPath  string         // path within SrcFS (e.g., "commands/hello.md")
 	DestPath string         // output path (e.g., ".claude/commands/hello.md")
 	Process  bool           // whether to apply template processing
 	Set      map[string]any // context overrides applied to this render pass
-	Strategy string         // "" or "replace" (default) | "merge"
+	Strategy string         // "" or "replace" (default) | "merge" | "append"
+	// SrcFS identifies the filesystem the source bytes should be read from.
+	// nil means the mold's primary fs (the default for legacy mold-only
+	// resolution). Set to the ore's fs.FS for ore-supplied output entries
+	// and for consumer entries with `from: ore/<ns>/...`.
+	SrcFS fs.FS `yaml:"-"`
+	// Origin identifies the ore namespace this entry came from, for
+	// diagnostics. Empty means the consumer mold itself.
+	Origin string `yaml:"-"`
 }
 
 // Mold represents a mold.yaml manifest.

--- a/pkg/mold/ore.go
+++ b/pkg/mold/ore.go
@@ -9,6 +9,17 @@ import (
 	"github.com/nimble-giant/ailloy/pkg/safepath"
 )
 
+// OreOutputKey is the reserved top-level key in an ore's flux.yaml whose
+// value is a map of source-path → destination overrides that gets merged
+// into the consuming mold's `output:` mapping at cast time. See docs/ore.md
+// for merge semantics and the `from:` selector for blanks.
+const OreOutputKey = "output"
+
+// OreBlanksDir is the reserved directory inside an ore package containing
+// template bodies addressable by `output:` mappings (either ore-supplied or
+// consumer-supplied via `from: ore/<namespace>/blanks/...`).
+const OreBlanksDir = "blanks"
+
 // Ore represents an ore.yaml manifest. An ore is a packaged flux-schema
 // fragment that consumers install with `ailloy ore add`.
 type Ore struct {

--- a/pkg/mold/ore_overlay.go
+++ b/pkg/mold/ore_overlay.go
@@ -1,0 +1,84 @@
+package mold
+
+import (
+	"fmt"
+	"sort"
+)
+
+// OreOutputOverlay is one ore's `output:` block extracted from its flux.yaml.
+// Entries match the same YAML shape consumers use in their own `output:` map
+// — string, map, or list values per source-path key.
+type OreOutputOverlay struct {
+	Source  string         // e.g. "ore:agent_targets"
+	Entries map[string]any // source-path → destination(s)
+}
+
+// MergeFluxOutput combines a consumer mold's `output:` map (base, possibly
+// nil) with N ore overlays. Rules mirror MergeFluxSchema:
+//
+//   - If a source-path key is in base, base wins; the overlay copy is
+//     recorded in report.ShadowedOutput.
+//   - If a key is in two overlays (and not in base), return a fatal error
+//     naming both sources.
+//   - Net-new overlay entries are appended to the merged map; deterministic
+//     iteration is not preserved (Go map), but overlay sort by Source makes
+//     conflict messages stable.
+//
+// The merged map is a freshly allocated copy — neither base nor overlay
+// inputs are mutated. The report.OutputSources map records the origin of
+// every key in the result.
+func MergeFluxOutput(base map[string]any, overlays []OreOutputOverlay) (map[string]any, OreLoadReport, error) {
+	report := OreLoadReport{OutputSources: map[string]string{}}
+
+	out := make(map[string]any, len(base))
+	for k, v := range base {
+		out[k] = v
+		report.OutputSources[k] = ""
+	}
+
+	sortedOverlays := make([]OreOutputOverlay, len(overlays))
+	copy(sortedOverlays, overlays)
+	sort.Slice(sortedOverlays, func(i, j int) bool { return sortedOverlays[i].Source < sortedOverlays[j].Source })
+
+	overlayOwner := make(map[string]string)
+	for _, ov := range sortedOverlays {
+		for k, v := range ov.Entries {
+			if _, inBase := base[k]; inBase {
+				report.ShadowedOutput = append(report.ShadowedOutput, ShadowedOutputEntry{Key: k, Source: ov.Source})
+				continue
+			}
+			if prev, dup := overlayOwner[k]; dup {
+				return nil, report, fmt.Errorf(
+					"ore output key conflict: %q defined by both %s and %s; resolve by overriding in the consumer mold's output or use 'as:' on the dependency",
+					k, prev, ov.Source,
+				)
+			}
+			overlayOwner[k] = ov.Source
+			out[k] = v
+			report.OutputSources[k] = ov.Source
+		}
+	}
+	return out, report, nil
+}
+
+// ExtractOreOutput pulls the top-level `output:` key out of an ore's
+// flux.yaml defaults map and returns it, leaving the remaining defaults
+// (the schema-mergeable ones) in the input map's place. Returns nil if no
+// `output:` key is set. Mutates the input map.
+func ExtractOreOutput(oreFluxDefaults map[string]any) map[string]any {
+	if oreFluxDefaults == nil {
+		return nil
+	}
+	raw, ok := oreFluxDefaults[OreOutputKey]
+	if !ok {
+		return nil
+	}
+	delete(oreFluxDefaults, OreOutputKey)
+	out, ok := raw.(map[string]any)
+	if !ok {
+		// Schema/temper rules will reject this; return nil so callers don't
+		// crash on a malformed overlay.
+		return nil
+	}
+	return out
+}

--- a/pkg/mold/ore_overlay_test.go
+++ b/pkg/mold/ore_overlay_test.go
@@ -1,0 +1,12 @@
+package mold
+
+import "testing"
+
+func TestOreReservedKeys(t *testing.T) {
+	if OreOutputKey != "output" {
+		t.Errorf("OreOutputKey = %q, want %q", OreOutputKey, "output")
+	}
+	if OreBlanksDir != "blanks" {
+		t.Errorf("OreBlanksDir = %q, want %q", OreBlanksDir, "blanks")
+	}
+}

--- a/pkg/mold/ore_overlay_test.go
+++ b/pkg/mold/ore_overlay_test.go
@@ -10,3 +10,82 @@ func TestOreReservedKeys(t *testing.T) {
 		t.Errorf("OreBlanksDir = %q, want %q", OreBlanksDir, "blanks")
 	}
 }
+
+func TestMergeFluxOutput_BaseWinsOnCollision(t *testing.T) {
+	base := map[string]any{
+		"AGENTS.md": "AGENTS.md",
+	}
+	overlays := []OreOutputOverlay{{
+		Source: "ore:agent_targets",
+		Entries: map[string]any{
+			"AGENTS.md":     "should_be_shadowed",
+			"blanks/agents": []any{map[string]any{"dest": ".claude/agents"}},
+		},
+	}}
+
+	merged, report, err := MergeFluxOutput(base, overlays)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if merged["AGENTS.md"] != "AGENTS.md" {
+		t.Errorf("base lost: got %v", merged["AGENTS.md"])
+	}
+	if _, ok := merged["blanks/agents"]; !ok {
+		t.Errorf("net-new overlay entry missing")
+	}
+	if len(report.ShadowedOutput) != 1 || report.ShadowedOutput[0].Key != "AGENTS.md" {
+		t.Errorf("expected one shadowed entry for AGENTS.md, got %+v", report.ShadowedOutput)
+	}
+	if report.OutputSources["blanks/agents"] != "ore:agent_targets" {
+		t.Errorf("OutputSources missing entry: %+v", report.OutputSources)
+	}
+}
+
+func TestMergeFluxOutput_OverlayOverlayConflictErrors(t *testing.T) {
+	base := map[string]any{}
+	overlays := []OreOutputOverlay{
+		{Source: "ore:a", Entries: map[string]any{"foo": "a"}},
+		{Source: "ore:b", Entries: map[string]any{"foo": "b"}},
+	}
+	_, _, err := MergeFluxOutput(base, overlays)
+	if err == nil {
+		t.Fatal("expected conflict error, got nil")
+	}
+}
+
+func TestMergeFluxOutput_NilBase(t *testing.T) {
+	overlays := []OreOutputOverlay{{
+		Source:  "ore:agent_targets",
+		Entries: map[string]any{"blanks/agents": ".claude/agents"},
+	}}
+	merged, _, err := MergeFluxOutput(nil, overlays)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if merged["blanks/agents"] != ".claude/agents" {
+		t.Errorf("nil base path lost overlay entry: %+v", merged)
+	}
+}
+
+func TestExtractOreOutput_RemovesKeyAndReturnsValue(t *testing.T) {
+	defaults := map[string]any{
+		"enabled": false,
+		"output": map[string]any{
+			"blanks/AGENTS.md": "AGENTS.md",
+		},
+	}
+	got := ExtractOreOutput(defaults)
+	if _, stillThere := defaults["output"]; stillThere {
+		t.Errorf("ExtractOreOutput should remove the output key from input")
+	}
+	if got["blanks/AGENTS.md"] != "AGENTS.md" {
+		t.Errorf("ExtractOreOutput returned wrong value: %+v", got)
+	}
+}
+
+func TestExtractOreOutput_NoOutputKeyReturnsNil(t *testing.T) {
+	defaults := map[string]any{"enabled": false}
+	if got := ExtractOreOutput(defaults); got != nil {
+		t.Errorf("expected nil, got %+v", got)
+	}
+}

--- a/pkg/mold/ore_resolver.go
+++ b/pkg/mold/ore_resolver.go
@@ -84,6 +84,12 @@ func LoadOreOverlaysFromFS(fsys fs.FS, root string, seen map[string]struct{}) ([
 		if oreDefaults == nil {
 			oreDefaults = map[string]any{}
 		}
+		// Extract the ore-supplied `output:` block out of its flux.yaml
+		// BEFORE wrapping the remaining defaults under ore.<ns>. — the
+		// output overlay belongs in the consumer's top-level output map,
+		// not under the ore namespace. The extracted overlay is recovered
+		// at cast/forge time via ResolveDepsEphemeral.OreSources().
+		ExtractOreOutput(oreDefaults) // mutates oreDefaults
 		oreNs, _ := defaults["ore"].(map[string]any)
 		if oreNs == nil {
 			oreNs = map[string]any{}

--- a/pkg/mold/ore_resolver_output_extract_test.go
+++ b/pkg/mold/ore_resolver_output_extract_test.go
@@ -1,0 +1,33 @@
+package mold
+
+import (
+	"testing"
+	"testing/fstest"
+)
+
+func TestLoadOreOverlaysFromFS_DoesNotLeakOutputIntoNamespacedDefaults(t *testing.T) {
+	root := fstest.MapFS{
+		"ores/agent_targets/ore.yaml":         &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: ore\nname: agent_targets\nversion: 0.1.0\n")},
+		"ores/agent_targets/flux.schema.yaml": &fstest.MapFile{Data: []byte("- name: enabled\n  type: bool\n  default: \"false\"\n")},
+		"ores/agent_targets/flux.yaml":        &fstest.MapFile{Data: []byte("enabled: false\noutput:\n  blanks/AGENTS.md: AGENTS.md\n")},
+		"ores/agent_targets/blanks/AGENTS.md": &fstest.MapFile{Data: []byte("hi")},
+	}
+	_, defaults, err := LoadOreOverlaysFromFS(root, "ores", nil)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	ore, _ := defaults["ore"].(map[string]any)
+	if ore == nil {
+		t.Fatalf("expected ore key in defaults: %+v", defaults)
+	}
+	at, _ := ore["agent_targets"].(map[string]any)
+	if at == nil {
+		t.Fatalf("expected agent_targets namespace: %+v", ore)
+	}
+	if _, hasOutput := at["output"]; hasOutput {
+		t.Errorf("output key leaked into namespaced defaults: %+v", at)
+	}
+	if at["enabled"] != false {
+		t.Errorf("non-output keys should remain: %+v", at)
+	}
+}

--- a/pkg/mold/output.go
+++ b/pkg/mold/output.go
@@ -373,6 +373,13 @@ func parseTargetMap(v map[string]any) (OutputTarget, error) {
 			return t, fmt.Errorf("unknown strategy %q: must be \"replace\", \"merge\", or \"append\"", s)
 		}
 	}
+	if from, ok := v["from"]; ok {
+		f, ok := from.(string)
+		if !ok {
+			return t, fmt.Errorf("from must be a string")
+		}
+		t.From = f
+	}
 	return t, nil
 }
 

--- a/pkg/mold/output.go
+++ b/pkg/mold/output.go
@@ -30,6 +30,7 @@ var reservedRootFiles = map[string]bool{
 	"flux.yaml":         true, // flux variable defaults
 	"flux.schema.yaml":  true, // flux validation schema
 	"ingot.yaml":        true, // ingot manifest
+	"ore.yaml":          true, // ore manifest
 	"README.md":         true, // mold documentation (not project readme)
 	"PLUGIN_SUMMARY.md": true, // plugin summary metadata
 	"LICENSE":           true, // mold license file

--- a/pkg/mold/output_composite.go
+++ b/pkg/mold/output_composite.go
@@ -69,8 +69,12 @@ func ResolveFilesWithOreSources(output any, moldFS fs.FS, oreSources []OreSource
 		if !ok {
 			return nil, fmt.Errorf("output entry for %q references ore %q but no such ore dependency is declared", fe.dest, ns)
 		}
-		if _, ferr := fs.Stat(src.FS, oreRelPath); ferr != nil {
+		info, ferr := fs.Stat(src.FS, oreRelPath)
+		if ferr != nil {
 			return nil, fmt.Errorf("output entry for %q references %q which does not exist in ore %q: %w", fe.dest, oreRelPath, ns, ferr)
+		}
+		if info.IsDir() {
+			return nil, fmt.Errorf("output entry for %q references %q in ore %q, but that is a directory — `from:` must point to a single file", fe.dest, oreRelPath, ns)
 		}
 		resolved = append(resolved, ResolvedFile{
 			SrcPath:  oreRelPath,
@@ -202,11 +206,12 @@ func splitFromEntries(output any) ([]fromEntry, any, error) {
 		return fromEntries[i].dest < fromEntries[j].dest
 	})
 
-	var remainderOut any
-	if len(remainder) > 0 {
-		remainderOut = remainder
-	}
-	return fromEntries, remainderOut, nil
+	// Always return a map (possibly empty) when the consumer declared an
+	// `output:` block. Returning nil here would cause ResolveFiles to fall
+	// into identity/auto-discovery mode and walk the entire mold — wrong if
+	// the consumer's only output was a set of `from:` selectors that all got
+	// extracted.
+	return fromEntries, remainder, nil
 }
 
 // parseOreFromSelector splits a "ore/<namespace>/<path>" selector into its

--- a/pkg/mold/output_composite.go
+++ b/pkg/mold/output_composite.go
@@ -109,12 +109,43 @@ func ResolveFilesWithOreSources(output any, moldFS fs.FS, oreSources []OreSource
 }
 
 // fromEntry holds a parsed `from: ore/<ns>/<path>` consumer output entry.
+// Unlike OutputTarget.Process (*bool, nil-default), fromEntry.process is a
+// resolved bool because it flows directly to ResolvedFile without going
+// through OutputTarget.ShouldProcess().
 type fromEntry struct {
 	from     string
 	dest     string
 	process  bool
 	set      map[string]any
 	strategy string
+}
+
+// parseFromEntryFields extracts a `from: ore/<ns>/<path>` entry from a map.
+// Returns the parsed fromEntry and true if `from:` is present and non-empty;
+// returns the zero value and false otherwise. `defaultDest` is used when the
+// map does not set `dest:` explicitly.
+func parseFromEntryFields(m map[string]any, defaultDest string) (fromEntry, bool) {
+	from, _ := m["from"].(string)
+	if from == "" {
+		return fromEntry{}, false
+	}
+	dest, _ := m["dest"].(string)
+	if dest == "" {
+		dest = defaultDest
+	}
+	process := true
+	if p, ok := m["process"].(bool); ok {
+		process = p
+	}
+	set, _ := m["set"].(map[string]any)
+	strategy, _ := m["strategy"].(string)
+	return fromEntry{
+		from:     from,
+		dest:     dest,
+		process:  process,
+		set:      set,
+		strategy: strategy,
+	}, true
 }
 
 // splitFromEntries separates consumer output entries that carry a `from:` key
@@ -136,31 +167,8 @@ func splitFromEntries(output any) ([]fromEntry, any, error) {
 	for key, val := range m {
 		switch v := val.(type) {
 		case map[string]any:
-			from, hasFrom := v["from"].(string)
-			dest, _ := v["dest"].(string)
-			if hasFrom && from != "" {
-				process := true
-				if p, ok := v["process"].(bool); ok {
-					process = p
-				}
-				var set map[string]any
-				if s, ok := v["set"].(map[string]any); ok {
-					set = s
-				}
-				var strategy string
-				if s, ok := v["strategy"].(string); ok {
-					strategy = s
-				}
-				if dest == "" {
-					dest = key
-				}
-				fromEntries = append(fromEntries, fromEntry{
-					from:     from,
-					dest:     dest,
-					process:  process,
-					set:      set,
-					strategy: strategy,
-				})
+			if fe, ok := parseFromEntryFields(v, key); ok {
+				fromEntries = append(fromEntries, fe)
 				// Do not include in remainder — ResolveFiles cannot handle these.
 				continue
 			}
@@ -175,31 +183,8 @@ func splitFromEntries(output any) ([]fromEntry, any, error) {
 					regularList = append(regularList, entry)
 					continue
 				}
-				from, hasFrom := em["from"].(string)
-				dest, _ := em["dest"].(string)
-				if hasFrom && from != "" {
-					process := true
-					if p, ok := em["process"].(bool); ok {
-						process = p
-					}
-					var set map[string]any
-					if s, ok := em["set"].(map[string]any); ok {
-						set = s
-					}
-					var strategy string
-					if s, ok := em["strategy"].(string); ok {
-						strategy = s
-					}
-					if dest == "" {
-						dest = key
-					}
-					fromEntries = append(fromEntries, fromEntry{
-						from:     from,
-						dest:     dest,
-						process:  process,
-						set:      set,
-						strategy: strategy,
-					})
+				if fe, ok := parseFromEntryFields(em, key); ok {
+					fromEntries = append(fromEntries, fe)
 				} else {
 					regularList = append(regularList, entry)
 				}
@@ -228,16 +213,15 @@ func splitFromEntries(output any) ([]fromEntry, any, error) {
 // namespace and path parts. Empty namespace or path is an error.
 func parseOreFromSelector(s string) (namespace string, relpath string, err error) {
 	const prefix = "ore/"
-	if !strings.HasPrefix(s, prefix) {
+	rest, ok := strings.CutPrefix(s, prefix)
+	if !ok {
 		return "", "", fmt.Errorf("from selector %q must start with %q (form: ore/<namespace>/<path>)", s, prefix)
 	}
-	rest := s[len(prefix):]
-	slash := strings.IndexByte(rest, '/')
-	if slash < 0 {
+	ns, p, ok := strings.Cut(rest, "/")
+	if !ok {
 		return "", "", fmt.Errorf("from selector %q must include a path after the namespace", s)
 	}
-	ns := rest[:slash]
-	p := path.Clean(rest[slash+1:])
+	p = path.Clean(p)
 	if ns == "" || p == "" || p == "." {
 		return "", "", fmt.Errorf("from selector %q has empty namespace or path", s)
 	}

--- a/pkg/mold/output_composite.go
+++ b/pkg/mold/output_composite.go
@@ -1,0 +1,245 @@
+package mold
+
+import (
+	"fmt"
+	"io/fs"
+	"path"
+	"sort"
+	"strings"
+)
+
+// OreSource identifies one resolved ore dependency: its namespace, the fs
+// to read its blank/source files from, and any output mapping it declared
+// via its flux.yaml `output:` block.
+type OreSource struct {
+	Namespace string         // the effective namespace (e.g. "agent_targets")
+	FS        fs.FS          // the ore's filesystem root
+	Output    map[string]any // ore-supplied output entries (may be nil)
+}
+
+// ResolveFilesWithOreSources is the composite-fs aware sibling of
+// ResolveFiles. It walks the consumer mold's `output` mapping (resolving
+// `from: ore/<ns>/...` selectors against the matching OreSource.FS) and
+// also walks each ore source's own Output mapping against its own FS.
+// Results are merged, deterministically sorted by DestPath, and every
+// ResolvedFile carries its SrcFS and Origin so callers can read the right
+// bytes downstream.
+//
+// `output` may be nil (mold-only auto-discovery, identical to ResolveFiles).
+// `oreSources` may be nil/empty — in that case this function reduces to a
+// thin wrapper around ResolveFiles.
+func ResolveFilesWithOreSources(output any, moldFS fs.FS, oreSources []OreSource, opts ...ResolveOption) ([]ResolvedFile, error) {
+	oreByNS := make(map[string]OreSource, len(oreSources))
+	for _, s := range oreSources {
+		oreByNS[s.Namespace] = s
+	}
+
+	// Extract `from:` entries from the consumer output map so they can be
+	// resolved against ore filesystems rather than moldFS. ResolveFiles only
+	// knows how to walk moldFS; `from:` entries that point at ore/<ns>/...
+	// would fail stat checks if passed through unchanged.
+	fromEntries, moldOutput, err := splitFromEntries(output)
+	if err != nil {
+		return nil, err
+	}
+
+	// Resolve consumer mold entries (without `from:` entries) against moldFS.
+	primary, err := ResolveFiles(moldOutput, moldFS, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	resolved := make([]ResolvedFile, 0, len(primary)+len(fromEntries))
+
+	// Annotate primary entries with their moldFS source.
+	for _, r := range primary {
+		if r.SrcFS == nil {
+			r.SrcFS = moldFS
+		}
+		resolved = append(resolved, r)
+	}
+
+	// Resolve `from: ore/<ns>/<path>` consumer entries against ore filesystems.
+	for _, fe := range fromEntries {
+		ns, oreRelPath, ferr := parseOreFromSelector(fe.from)
+		if ferr != nil {
+			return nil, ferr
+		}
+		src, ok := oreByNS[ns]
+		if !ok {
+			return nil, fmt.Errorf("output entry for %q references ore %q but no such ore dependency is declared", fe.dest, ns)
+		}
+		if _, ferr := fs.Stat(src.FS, oreRelPath); ferr != nil {
+			return nil, fmt.Errorf("output entry for %q references %q which does not exist in ore %q: %w", fe.dest, oreRelPath, ns, ferr)
+		}
+		resolved = append(resolved, ResolvedFile{
+			SrcPath:  oreRelPath,
+			DestPath: fe.dest,
+			Process:  fe.process,
+			Set:      fe.set,
+			Strategy: fe.strategy,
+			SrcFS:    src.FS,
+			Origin:   ns,
+		})
+	}
+
+	// Resolve each ore's own output mapping against its own FS.
+	for _, src := range oreSources {
+		if len(src.Output) == 0 {
+			continue
+		}
+		oreResolved, err := ResolveFiles(src.Output, src.FS, opts...)
+		if err != nil {
+			return nil, fmt.Errorf("resolving ore %q output: %w", src.Namespace, err)
+		}
+		for _, r := range oreResolved {
+			r.SrcFS = src.FS
+			r.Origin = src.Namespace
+			resolved = append(resolved, r)
+		}
+	}
+
+	sort.Slice(resolved, func(i, j int) bool {
+		if resolved[i].DestPath != resolved[j].DestPath {
+			return resolved[i].DestPath < resolved[j].DestPath
+		}
+		return resolved[i].SrcPath < resolved[j].SrcPath
+	})
+	return resolved, nil
+}
+
+// fromEntry holds a parsed `from: ore/<ns>/<path>` consumer output entry.
+type fromEntry struct {
+	from     string
+	dest     string
+	process  bool
+	set      map[string]any
+	strategy string
+}
+
+// splitFromEntries separates consumer output entries that carry a `from:` key
+// from those that do not. It returns:
+//   - fromEntries: the parsed `from:` entries
+//   - remainder: the original output value with `from:` keys stripped (suitable for ResolveFiles)
+//
+// If output is not a map[string]any, fromEntries will be empty and the
+// original output is returned unchanged.
+func splitFromEntries(output any) ([]fromEntry, any, error) {
+	m, ok := output.(map[string]any)
+	if !ok {
+		return nil, output, nil
+	}
+
+	var fromEntries []fromEntry
+	remainder := make(map[string]any, len(m))
+
+	for key, val := range m {
+		switch v := val.(type) {
+		case map[string]any:
+			from, hasFrom := v["from"].(string)
+			dest, _ := v["dest"].(string)
+			if hasFrom && from != "" {
+				process := true
+				if p, ok := v["process"].(bool); ok {
+					process = p
+				}
+				var set map[string]any
+				if s, ok := v["set"].(map[string]any); ok {
+					set = s
+				}
+				var strategy string
+				if s, ok := v["strategy"].(string); ok {
+					strategy = s
+				}
+				if dest == "" {
+					dest = key
+				}
+				fromEntries = append(fromEntries, fromEntry{
+					from:     from,
+					dest:     dest,
+					process:  process,
+					set:      set,
+					strategy: strategy,
+				})
+				// Do not include in remainder — ResolveFiles cannot handle these.
+				continue
+			}
+			remainder[key] = val
+		case []any:
+			// A list may contain a mix of from: entries and regular entries.
+			// Split them out.
+			var regularList []any
+			for _, entry := range v {
+				em, ok := entry.(map[string]any)
+				if !ok {
+					regularList = append(regularList, entry)
+					continue
+				}
+				from, hasFrom := em["from"].(string)
+				dest, _ := em["dest"].(string)
+				if hasFrom && from != "" {
+					process := true
+					if p, ok := em["process"].(bool); ok {
+						process = p
+					}
+					var set map[string]any
+					if s, ok := em["set"].(map[string]any); ok {
+						set = s
+					}
+					var strategy string
+					if s, ok := em["strategy"].(string); ok {
+						strategy = s
+					}
+					if dest == "" {
+						dest = key
+					}
+					fromEntries = append(fromEntries, fromEntry{
+						from:     from,
+						dest:     dest,
+						process:  process,
+						set:      set,
+						strategy: strategy,
+					})
+				} else {
+					regularList = append(regularList, entry)
+				}
+			}
+			if len(regularList) > 0 {
+				remainder[key] = regularList
+			}
+		default:
+			remainder[key] = val
+		}
+	}
+
+	// Sort fromEntries by dest for determinism.
+	sort.Slice(fromEntries, func(i, j int) bool {
+		return fromEntries[i].dest < fromEntries[j].dest
+	})
+
+	var remainderOut any
+	if len(remainder) > 0 {
+		remainderOut = remainder
+	}
+	return fromEntries, remainderOut, nil
+}
+
+// parseOreFromSelector splits a "ore/<namespace>/<path>" selector into its
+// namespace and path parts. Empty namespace or path is an error.
+func parseOreFromSelector(s string) (namespace string, relpath string, err error) {
+	const prefix = "ore/"
+	if !strings.HasPrefix(s, prefix) {
+		return "", "", fmt.Errorf("from selector %q must start with %q (form: ore/<namespace>/<path>)", s, prefix)
+	}
+	rest := s[len(prefix):]
+	slash := strings.IndexByte(rest, '/')
+	if slash < 0 {
+		return "", "", fmt.Errorf("from selector %q must include a path after the namespace", s)
+	}
+	ns := rest[:slash]
+	p := path.Clean(rest[slash+1:])
+	if ns == "" || p == "" || p == "." {
+		return "", "", fmt.Errorf("from selector %q has empty namespace or path", s)
+	}
+	return ns, p, nil
+}

--- a/pkg/mold/output_composite.go
+++ b/pkg/mold/output_composite.go
@@ -21,7 +21,8 @@ type OreSource struct {
 // ResolveFiles. It walks the consumer mold's `output` mapping (resolving
 // `from: ore/<ns>/...` selectors against the matching OreSource.FS) and
 // also walks each ore source's own Output mapping against its own FS.
-// Results are merged, deterministically sorted by DestPath, and every
+// Results are merged via MergeFluxOutput (consumer-wins / ore-ore-conflict
+// semantics), deterministically sorted by DestPath, deduplicated, and every
 // ResolvedFile carries its SrcFS and Origin so callers can read the right
 // bytes downstream.
 //
@@ -43,20 +44,111 @@ func ResolveFilesWithOreSources(output any, moldFS fs.FS, oreSources []OreSource
 		return nil, err
 	}
 
-	// Resolve consumer mold entries (without `from:` entries) against moldFS.
-	primary, err := ResolveFiles(moldOutput, moldFS, opts...)
-	if err != nil {
-		return nil, err
+	// Build ore overlays for MergeFluxOutput: consumer-wins semantics and
+	// ore-ore source-path conflict detection.
+	oreOverlays := make([]OreOutputOverlay, 0, len(oreSources))
+	for _, src := range oreSources {
+		if len(src.Output) > 0 {
+			oreOverlays = append(oreOverlays, OreOutputOverlay{
+				Source:  "ore:" + src.Namespace,
+				Entries: src.Output,
+			})
+		}
 	}
 
-	resolved := make([]ResolvedFile, 0, len(primary)+len(fromEntries))
+	var resolved []ResolvedFile
 
-	// Annotate primary entries with their moldFS source.
-	for _, r := range primary {
-		if r.SrcFS == nil {
-			r.SrcFS = moldFS
+	// Distinguish explicit output map (consumer-wins merge path) from nil
+	// output (auto-discovery path).
+	consumerBaseMap, hasExplicitOutput := moldOutput.(map[string]any)
+
+	if hasExplicitOutput {
+		// Consumer has an explicit output: map. Merge with ore overlays so
+		// consumer keys suppress matching ore keys and ore-ore conflicts error.
+		mergedMap, report, merr := MergeFluxOutput(consumerBaseMap, oreOverlays)
+		if merr != nil {
+			return nil, merr
 		}
-		resolved = append(resolved, r)
+
+		// Partition merged map by origin for per-FS resolution.
+		consumerSub := make(map[string]any)
+		oreSubMaps := make(map[string]map[string]any)
+		for k, v := range mergedMap {
+			srcID := report.OutputSources[k]
+			if srcID == "" {
+				consumerSub[k] = v
+			} else {
+				ns := strings.TrimPrefix(srcID, "ore:")
+				if oreSubMaps[ns] == nil {
+					oreSubMaps[ns] = make(map[string]any)
+				}
+				oreSubMaps[ns][k] = v
+			}
+		}
+
+		primary, rerr := ResolveFiles(consumerSub, moldFS, opts...)
+		if rerr != nil {
+			return nil, rerr
+		}
+		for _, r := range primary {
+			if r.SrcFS == nil {
+				r.SrcFS = moldFS
+			}
+			resolved = append(resolved, r)
+		}
+
+		for ns, subMap := range oreSubMaps {
+			ore := oreByNS[ns]
+			oreResolved, rerr := ResolveFiles(subMap, ore.FS, opts...)
+			if rerr != nil {
+				return nil, fmt.Errorf("resolving ore %q output: %w", ns, rerr)
+			}
+			for _, r := range oreResolved {
+				r.SrcFS = ore.FS
+				r.Origin = ns
+				resolved = append(resolved, r)
+			}
+		}
+	} else {
+		// Consumer has no explicit output: use mold auto-discovery.
+		primary, rerr := ResolveFiles(moldOutput, moldFS, opts...)
+		if rerr != nil {
+			return nil, rerr
+		}
+		for _, r := range primary {
+			if r.SrcFS == nil {
+				r.SrcFS = moldFS
+			}
+			resolved = append(resolved, r)
+		}
+
+		// Ore overlays still need ore-ore source-path conflict detection.
+		if len(oreOverlays) > 0 {
+			mergedOreMap, report, merr := MergeFluxOutput(nil, oreOverlays)
+			if merr != nil {
+				return nil, merr
+			}
+			oreSubMaps := make(map[string]map[string]any)
+			for k, srcID := range report.OutputSources {
+				ns := strings.TrimPrefix(srcID, "ore:")
+				if oreSubMaps[ns] == nil {
+					oreSubMaps[ns] = make(map[string]any)
+				}
+				oreSubMaps[ns][k] = mergedOreMap[k]
+			}
+			for ns, subMap := range oreSubMaps {
+				ore := oreByNS[ns]
+				oreResolved, rerr := ResolveFiles(subMap, ore.FS, opts...)
+				if rerr != nil {
+					return nil, fmt.Errorf("resolving ore %q output: %w", ns, rerr)
+				}
+				for _, r := range oreResolved {
+					r.SrcFS = ore.FS
+					r.Origin = ns
+					resolved = append(resolved, r)
+				}
+			}
+		}
 	}
 
 	// Resolve `from: ore/<ns>/<path>` consumer entries against ore filesystems.
@@ -87,29 +179,65 @@ func ResolveFilesWithOreSources(output any, moldFS fs.FS, oreSources []OreSource
 		})
 	}
 
-	// Resolve each ore's own output mapping against its own FS.
-	for _, src := range oreSources {
-		if len(src.Output) == 0 {
-			continue
-		}
-		oreResolved, err := ResolveFiles(src.Output, src.FS, opts...)
-		if err != nil {
-			return nil, fmt.Errorf("resolving ore %q output: %w", src.Namespace, err)
-		}
-		for _, r := range oreResolved {
-			r.SrcFS = src.FS
-			r.Origin = src.Namespace
-			resolved = append(resolved, r)
-		}
-	}
-
 	sort.Slice(resolved, func(i, j int) bool {
 		if resolved[i].DestPath != resolved[j].DestPath {
 			return resolved[i].DestPath < resolved[j].DestPath
 		}
 		return resolved[i].SrcPath < resolved[j].SrcPath
 	})
+
+	// Deduplicate by DestPath: consumer-origin (Origin == "") beats ore-origin;
+	// two ore-origin entries mapping to the same DestPath is a conflict error.
+	resolved, err = deduplicateByDestPath(resolved)
+	if err != nil {
+		return nil, err
+	}
+
 	return resolved, nil
+}
+
+// deduplicateByDestPath removes duplicate DestPath entries from a sorted slice.
+// Consumer-origin (Origin == "") beats ore-origin. Multiple ore-origin entries
+// with the same DestPath return an error naming the conflicting sources.
+func deduplicateByDestPath(resolved []ResolvedFile) ([]ResolvedFile, error) {
+	if len(resolved) <= 1 {
+		return resolved, nil
+	}
+	out := make([]ResolvedFile, 0, len(resolved))
+	i := 0
+	for i < len(resolved) {
+		j := i + 1
+		for j < len(resolved) && resolved[j].DestPath == resolved[i].DestPath {
+			j++
+		}
+		group := resolved[i:j]
+		if len(group) == 1 {
+			out = append(out, group[0])
+			i = j
+			continue
+		}
+		// Multiple entries with the same DestPath: consumer-origin wins.
+		var winner *ResolvedFile
+		oreOrigins := make([]string, 0, len(group))
+		for idx := range group {
+			if group[idx].Origin == "" {
+				winner = &group[idx]
+				break
+			}
+			oreOrigins = append(oreOrigins, group[idx].Origin)
+		}
+		if winner != nil {
+			out = append(out, *winner)
+		} else {
+			sort.Strings(oreOrigins)
+			return nil, fmt.Errorf(
+				"ore output dest-path conflict: %q mapped by multiple ore sources (%s); override in consumer mold output",
+				group[0].DestPath, strings.Join(oreOrigins, ", "),
+			)
+		}
+		i = j
+	}
+	return out, nil
 }
 
 // fromEntry holds a parsed `from: ore/<ns>/<path>` consumer output entry.
@@ -229,6 +357,9 @@ func parseOreFromSelector(s string) (namespace string, relpath string, err error
 	p = path.Clean(p)
 	if ns == "" || p == "" || p == "." {
 		return "", "", fmt.Errorf("from selector %q has empty namespace or path", s)
+	}
+	if strings.HasPrefix(p, "..") {
+		return "", "", fmt.Errorf("from selector %q contains a path traversal (..)", s)
 	}
 	return ns, p, nil
 }

--- a/pkg/mold/output_composite_test.go
+++ b/pkg/mold/output_composite_test.go
@@ -3,6 +3,7 @@ package mold
 import (
 	"io/fs"
 	"sort"
+	"strings"
 	"testing"
 	"testing/fstest"
 )
@@ -123,3 +124,70 @@ func TestResolveFilesWithOreSources_DeterministicOrder(t *testing.T) {
 }
 
 var _ fs.FS = (fstest.MapFS)(nil)
+
+// Regression: a consumer whose `output:` map consists ENTIRELY of `from:`
+// selectors used to fall through to ResolveFiles(nil, moldFS), which
+// triggered identity auto-discovery and resolved every non-reserved file
+// in the mold. The fix returns an empty map (not nil) so ResolveFiles
+// takes the explicit-map path instead.
+func TestResolveFilesWithOreSources_AllFromConsumerDoesNotAutoDiscoverMold(t *testing.T) {
+	moldFS := fstest.MapFS{
+		"mold.yaml":           &fstest.MapFile{Data: []byte("name: c\n")},
+		"commands/hello.md":   &fstest.MapFile{Data: []byte("hi\n")},
+		"unrelated/extra.txt": &fstest.MapFile{Data: []byte("extra\n")},
+	}
+	oreFS := fstest.MapFS{
+		"blanks/AGENTS.md": &fstest.MapFile{Data: []byte("# from ore\n")},
+	}
+	output := map[string]any{
+		"AGENTS.md": map[string]any{
+			"from": "ore/agent_targets/blanks/AGENTS.md",
+			"dest": "AGENTS.md",
+		},
+	}
+	sources := []OreSource{{Namespace: "agent_targets", FS: oreFS}}
+
+	resolved, err := ResolveFilesWithOreSources(output, moldFS, sources)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resolved) != 1 {
+		t.Fatalf("expected exactly 1 resolved file (from: AGENTS.md), got %d: %+v", len(resolved), resolved)
+	}
+	if resolved[0].DestPath != "AGENTS.md" || resolved[0].Origin != "agent_targets" {
+		t.Errorf("wrong resolved entry: %+v", resolved[0])
+	}
+	// Specifically: the mold's commands/hello.md and unrelated/extra.txt
+	// must NOT appear in the resolved set.
+	for _, r := range resolved {
+		if r.SrcPath == "commands/hello.md" || r.SrcPath == "unrelated/extra.txt" {
+			t.Errorf("auto-discovery leaked mold file into resolved: %+v", r)
+		}
+	}
+}
+
+// Regression: a `from:` selector pointing at a directory used to pass
+// fs.Stat (directories exist) and then fail later with an obscure
+// "is a directory" error when cast/forge tried to ReadFile. The fix
+// rejects directory targets at resolve time with a clear message.
+func TestResolveFilesWithOreSources_FromSelectorRejectsDirectoryTarget(t *testing.T) {
+	moldFS := fstest.MapFS{"mold.yaml": &fstest.MapFile{Data: []byte("name: c\n")}}
+	oreFS := fstest.MapFS{
+		"blanks/agents/inner.md": &fstest.MapFile{Data: []byte("# inner\n")},
+	}
+	output := map[string]any{
+		"agents": map[string]any{
+			"from": "ore/at/blanks/agents",
+			"dest": "agents",
+		},
+	}
+	sources := []OreSource{{Namespace: "at", FS: oreFS}}
+
+	_, err := ResolveFilesWithOreSources(output, moldFS, sources)
+	if err == nil {
+		t.Fatal("expected error for directory `from:` target, got nil")
+	}
+	if !strings.Contains(err.Error(), "directory") {
+		t.Errorf("error should mention directory, got: %v", err)
+	}
+}

--- a/pkg/mold/output_composite_test.go
+++ b/pkg/mold/output_composite_test.go
@@ -1,0 +1,125 @@
+package mold
+
+import (
+	"io/fs"
+	"sort"
+	"testing"
+	"testing/fstest"
+)
+
+func TestResolveFilesWithOreSources_OreDeclaredOutput(t *testing.T) {
+	moldFS := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: Mold\nname: c\nversion: 0.1.0\n")},
+	}
+	oreFS := fstest.MapFS{
+		"ore.yaml":             &fstest.MapFile{Data: []byte("kind: ore\nname: agent_targets\n")},
+		"blanks/AGENTS.md":     &fstest.MapFile{Data: []byte("# agents\n")},
+		"blanks/agents/foo.md": &fstest.MapFile{Data: []byte("# foo\n")},
+	}
+
+	output := map[string]any{
+		"blanks/AGENTS.md": "AGENTS.md",
+		"blanks/agents":    ".claude/agents",
+	}
+	sources := []OreSource{{Namespace: "agent_targets", FS: oreFS, Output: output}}
+
+	resolved, err := ResolveFilesWithOreSources(nil, moldFS, sources)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := map[string]string{}
+	for _, r := range resolved {
+		got[r.DestPath] = r.SrcPath
+		if r.SrcFS == nil {
+			t.Errorf("ore-supplied entry lost SrcFS: %+v", r)
+		}
+		if r.Origin != "agent_targets" {
+			t.Errorf("Origin = %q, want %q", r.Origin, "agent_targets")
+		}
+	}
+	want := map[string]string{
+		"AGENTS.md":             "blanks/AGENTS.md",
+		".claude/agents/foo.md": "blanks/agents/foo.md",
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("dest %q: got src %q, want %q", k, got[k], v)
+		}
+	}
+}
+
+func TestResolveFilesWithOreSources_ConsumerFromSelector(t *testing.T) {
+	moldFS := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte("name: c\n")},
+	}
+	oreFS := fstest.MapFS{
+		"blanks/AGENTS.md": &fstest.MapFile{Data: []byte("# from ore\n")},
+	}
+
+	output := map[string]any{
+		"AGENTS.md": map[string]any{
+			"from": "ore/agent_targets/blanks/AGENTS.md",
+			"dest": "AGENTS.md",
+		},
+	}
+	sources := []OreSource{{Namespace: "agent_targets", FS: oreFS}}
+
+	resolved, err := ResolveFilesWithOreSources(output, moldFS, sources)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resolved) != 1 {
+		t.Fatalf("expected 1 resolved file, got %d: %+v", len(resolved), resolved)
+	}
+	r := resolved[0]
+	if r.SrcPath != "blanks/AGENTS.md" || r.DestPath != "AGENTS.md" {
+		t.Errorf("wrong paths: src=%q dest=%q", r.SrcPath, r.DestPath)
+	}
+	if r.Origin != "agent_targets" || r.SrcFS == nil {
+		t.Errorf("origin/fs wrong: %+v", r)
+	}
+}
+
+func TestResolveFilesWithOreSources_BackwardCompat_MoldOnly(t *testing.T) {
+	moldFS := fstest.MapFS{
+		"mold.yaml":         &fstest.MapFile{Data: []byte("name: c\n")},
+		"commands/hello.md": &fstest.MapFile{Data: []byte("hi\n")},
+	}
+	resolved, err := ResolveFilesWithOreSources(nil, moldFS, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resolved) != 1 || resolved[0].SrcPath != "commands/hello.md" {
+		t.Fatalf("wrong resolution: %+v", resolved)
+	}
+	if resolved[0].Origin != "" {
+		t.Errorf("Origin should be empty for mold-origin entries, got %q", resolved[0].Origin)
+	}
+}
+
+func TestResolveFilesWithOreSources_DeterministicOrder(t *testing.T) {
+	moldFS := fstest.MapFS{"mold.yaml": &fstest.MapFile{Data: []byte("name: c\n")}}
+	oreFS := fstest.MapFS{
+		"blanks/a.md": &fstest.MapFile{Data: []byte("a")},
+		"blanks/b.md": &fstest.MapFile{Data: []byte("b")},
+	}
+	output := map[string]any{
+		"blanks/a.md": "a.md",
+		"blanks/b.md": "b.md",
+	}
+	sources := []OreSource{{Namespace: "n", FS: oreFS, Output: output}}
+	resolved, err := ResolveFilesWithOreSources(nil, moldFS, sources)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	paths := make([]string, len(resolved))
+	for i, r := range resolved {
+		paths[i] = r.DestPath
+	}
+	if !sort.StringsAreSorted(paths) {
+		t.Errorf("not sorted: %v", paths)
+	}
+}
+
+var _ fs.FS = (fstest.MapFS)(nil)

--- a/pkg/mold/output_composite_test.go
+++ b/pkg/mold/output_composite_test.go
@@ -166,6 +166,105 @@ func TestResolveFilesWithOreSources_AllFromConsumerDoesNotAutoDiscoverMold(t *te
 	}
 }
 
+// Consumer explicit output key that matches an ore output key: consumer wins
+// and the ore entry is suppressed (not duplicated).
+func TestResolveFilesWithOreSources_ConsumerWinsOverOreOnSourcePathKey(t *testing.T) {
+	moldFS := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte("name: c\n")},
+		"AGENTS.md": &fstest.MapFile{Data: []byte("# consumer\n")},
+	}
+	oreFS := fstest.MapFS{
+		"AGENTS.md": &fstest.MapFile{Data: []byte("# ore\n")},
+	}
+	output := map[string]any{"AGENTS.md": "AGENTS.md"}
+	sources := []OreSource{{
+		Namespace: "myore",
+		FS:        oreFS,
+		Output:    map[string]any{"AGENTS.md": "AGENTS.md"},
+	}}
+	resolved, err := ResolveFilesWithOreSources(output, moldFS, sources)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resolved) != 1 {
+		t.Fatalf("expected 1 resolved file (consumer wins, ore suppressed), got %d: %+v", len(resolved), resolved)
+	}
+	if resolved[0].Origin != "" {
+		t.Errorf("expected consumer origin (empty string), got %q", resolved[0].Origin)
+	}
+	if resolved[0].SrcFS == nil {
+		t.Errorf("expected non-nil SrcFS for consumer entry")
+	}
+}
+
+// Two ores map different source-path keys to the same DestPath: this is a
+// DestPath conflict and must return an error.
+func TestResolveFilesWithOreSources_DestPathDedup_OreOreConflictErrors(t *testing.T) {
+	moldFS := fstest.MapFS{"mold.yaml": &fstest.MapFile{Data: []byte("name: c\n")}}
+	oreAFS := fstest.MapFS{"a.md": &fstest.MapFile{Data: []byte("a")}}
+	oreBFS := fstest.MapFS{"b.md": &fstest.MapFile{Data: []byte("b")}}
+	sources := []OreSource{
+		{Namespace: "ore_a", FS: oreAFS, Output: map[string]any{"a.md": "out.md"}},
+		{Namespace: "ore_b", FS: oreBFS, Output: map[string]any{"b.md": "out.md"}},
+	}
+	_, err := ResolveFilesWithOreSources(nil, moldFS, sources)
+	if err == nil {
+		t.Fatal("expected error for ore-ore dest-path conflict, got nil")
+	}
+	if !strings.Contains(err.Error(), "ore_a") || !strings.Contains(err.Error(), "ore_b") {
+		t.Errorf("error should name both ore sources, got: %v", err)
+	}
+}
+
+// Consumer explicit output entry and ore entry map different source-path keys
+// to the same DestPath: consumer-origin wins via DestPath deduplication.
+func TestResolveFilesWithOreSources_DestPathDedup_ConsumerWins(t *testing.T) {
+	moldFS := fstest.MapFS{
+		"mold.yaml":    &fstest.MapFile{Data: []byte("name: c\n")},
+		"consumer.md":  &fstest.MapFile{Data: []byte("# consumer\n")},
+	}
+	oreFS := fstest.MapFS{"ore.md": &fstest.MapFile{Data: []byte("# ore\n")}}
+	output := map[string]any{"consumer.md": "out.md"}
+	sources := []OreSource{{
+		Namespace: "myore",
+		FS:        oreFS,
+		Output:    map[string]any{"ore.md": "out.md"},
+	}}
+	resolved, err := ResolveFilesWithOreSources(output, moldFS, sources)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resolved) != 1 {
+		t.Fatalf("expected 1 resolved file after dedup, got %d: %+v", len(resolved), resolved)
+	}
+	if resolved[0].Origin != "" {
+		t.Errorf("expected consumer origin, got %q", resolved[0].Origin)
+	}
+	if resolved[0].SrcPath != "consumer.md" {
+		t.Errorf("expected consumer.md, got %q", resolved[0].SrcPath)
+	}
+}
+
+// `from:` selector with a path traversal (..) must be rejected.
+func TestResolveFilesWithOreSources_FromSelectorRejectsPathTraversal(t *testing.T) {
+	moldFS := fstest.MapFS{"mold.yaml": &fstest.MapFile{Data: []byte("name: c\n")}}
+	oreFS := fstest.MapFS{"file.md": &fstest.MapFile{Data: []byte("x")}}
+	output := map[string]any{
+		"file": map[string]any{
+			"from": "ore/ns/../file.md",
+			"dest": "file.md",
+		},
+	}
+	sources := []OreSource{{Namespace: "ns", FS: oreFS}}
+	_, err := ResolveFilesWithOreSources(output, moldFS, sources)
+	if err == nil {
+		t.Fatal("expected error for path traversal, got nil")
+	}
+	if !strings.Contains(err.Error(), "..") {
+		t.Errorf("error should mention path traversal, got: %v", err)
+	}
+}
+
 // Regression: a `from:` selector pointing at a directory used to pass
 // fs.Stat (directories exist) and then fail later with an obscure
 // "is a directory" error when cast/forge tried to ReadFile. The fix

--- a/pkg/mold/validate.go
+++ b/pkg/mold/validate.go
@@ -304,12 +304,65 @@ func temperOre(fsys fs.FS, result *TemperResult) {
 			File:     "flux.yaml",
 		})
 	}
+	// Validate the optional `output:` overlay block. We do this before the
+	// orphan-defaults walk and we delete the `output` key from defaults so
+	// the orphan walker doesn't flag it.
+	if rawOutput, hasOutput := defaults[OreOutputKey]; hasOutput {
+		validateOreOutputBlock(fsys, rawOutput, result)
+		delete(defaults, OreOutputKey)
+	}
 	for _, orphan := range ValidateOrphanDefaults(schema, defaults) {
 		result.Diagnostics = append(result.Diagnostics, Diagnostic{
 			Severity: SeverityWarning,
 			Message:  fmt.Sprintf("flux.yaml has %q with no matching schema entry", orphan),
 			File:     "flux.yaml",
 		})
+	}
+}
+
+// validateOreOutputBlock validates an ore-supplied `output:` overlay. Rules:
+//   - top-level value must be a map
+//   - each value parses as a valid output target (string, map, or list)
+//   - `from:` keys are forbidden — only consumer molds may reference other
+//     ores via `from:`
+//   - source-path keys must resolve to existing files inside the ore package
+func validateOreOutputBlock(fsys fs.FS, raw any, result *TemperResult) {
+	m, ok := raw.(map[string]any)
+	if !ok {
+		result.Diagnostics = append(result.Diagnostics, Diagnostic{
+			Severity: SeverityError,
+			Message:  "flux.yaml `output:` must be a map of source-path → target",
+			File:     "flux.yaml",
+		})
+		return
+	}
+	for src, val := range m {
+		targets, err := parseOutputValue(val)
+		if err != nil {
+			result.Diagnostics = append(result.Diagnostics, Diagnostic{
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("flux.yaml output[%q]: %v", src, err),
+				File:     "flux.yaml",
+			})
+			continue
+		}
+		for _, t := range targets {
+			if t.From != "" {
+				result.Diagnostics = append(result.Diagnostics, Diagnostic{
+					Severity: SeverityError,
+					Message:  fmt.Sprintf("flux.yaml output[%q]: `from:` is not allowed in ore-supplied output entries (ores cannot reference other ores' blanks)", src),
+					File:     "flux.yaml",
+				})
+			}
+		}
+		// Source key must exist in the ore filesystem.
+		if _, err := fs.Stat(fsys, src); err != nil {
+			result.Diagnostics = append(result.Diagnostics, Diagnostic{
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("flux.yaml output references %q which does not exist in the ore package", src),
+				File:     "flux.yaml",
+			})
+		}
 	}
 }
 

--- a/testdata/agent_targets/consumer/mold.yaml
+++ b/testdata/agent_targets/consumer/mold.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: mold
+name: agent_targets_consumer
+version: 0.1.0
+description: "Demonstrates depending solely on agent_targets ore"
+dependencies:
+  - ore: ../ore
+    version: 0.1.0

--- a/testdata/agent_targets/ore/blanks/AGENTS.md
+++ b/testdata/agent_targets/ore/blanks/AGENTS.md
@@ -1,0 +1,3 @@
+# Agents
+
+This file is rendered once per consuming mold from the agent_targets ore.

--- a/testdata/agent_targets/ore/blanks/agents/example.md
+++ b/testdata/agent_targets/ore/blanks/agents/example.md
@@ -1,0 +1,4 @@
+---
+target: {{ .current_target }}
+---
+# Example agent for {{ .current_target }}

--- a/testdata/agent_targets/ore/flux.schema.yaml
+++ b/testdata/agent_targets/ore/flux.schema.yaml
@@ -1,0 +1,9 @@
+- name: enabled
+  type: bool
+  description: "Enable agent-targets rendering"
+  default: "true"
+
+- name: targets
+  type: list
+  description: "Which agent surfaces to render for"
+  default: '["claude", "opencode"]'

--- a/testdata/agent_targets/ore/flux.yaml
+++ b/testdata/agent_targets/ore/flux.yaml
@@ -1,0 +1,14 @@
+enabled: true
+targets:
+  - claude
+  - opencode
+
+output:
+  blanks/AGENTS.md: AGENTS.md
+  blanks/agents:
+    - dest: .claude/agents
+      set:
+        current_target: claude
+    - dest: .opencode/agents
+      set:
+        current_target: opencode

--- a/testdata/agent_targets/ore/ore.yaml
+++ b/testdata/agent_targets/ore/ore.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ore
+name: agent_targets
+version: 0.1.0
+description: "Multi-target rendering for Claude and OpenCode agent surfaces"


### PR DESCRIPTION
## Description

Extends ore packages (previously limited to `ore.yaml` + `flux.schema.yaml` + `flux.yaml`) so they can also ship an `output:` block in `flux.yaml` and a `blanks/` directory of template bodies. Ore-supplied output mappings merge into the consuming mold's output at cast time (consumer-wins shadowing; ore-ore conflicts error). Consumer molds can compose with an ore's blanks via a new `from: ore/<namespace>/<path>` selector in their own `output:`. `ailloy temper` validates the new fields, `ailloy forge --debug` surfaces source provenance, and `docs/ore.md` is updated with a worked example backed by the `testdata/agent_targets/` fixtures. The classic three-file ore continues to work unchanged.

## Related Issue

Fixes #215

## Testing

Eleven incremental commits, each with TDD tests. New tests cover the merge logic (`pkg/mold/ore_overlay_test.go`), composite-fs resolution (`pkg/mold/output_composite_test.go`), output extraction (`pkg/mold/ore_resolver_output_extract_test.go`), the ephemeral resolver's new accessors (`internal/commands/install_deps_ephemeral_test.go`), temper rules (`internal/commands/temper_ore_overlay_test.go`), forge debug formatting (`internal/commands/forge_ore_overlay_test.go`), and an end-to-end multi-target rendering test against the `testdata/agent_targets/` worked example (`internal/commands/cast_ore_overlay_test.go`). Full \`go test ./...\`, \`go vet ./...\`, \`gofmt\`, \`golangci-lint run ./...\`, and \`go build ./...\` all clean.

## UAT

Try the worked example:
1. Build an ore from \`testdata/agent_targets/ore/\` (or copy its structure into a published ore).
2. In a consumer mold, add nothing but \`dependencies: [{ ore: <ref>, version: ... }]\` — no \`output:\` block needed.
3. Run \`ailloy cast\` from a project directory — expect \`AGENTS.md\`, \`.claude/agents/example.md\`, and \`.opencode/agents/example.md\` to render with the per-target \`current_target\` context.
4. Run \`ailloy forge --debug\` to see source provenance for each resolved file.
5. Verify backward compat by casting any existing three-file ore — should behave identically to before.

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [x] I have updated documentation (if applicable)
- [ ] My commits have DCO sign-off (\`git commit -s\`)