### PR TITLE
feat: support top-level output: in mold.yaml for flux parity

### DIFF
--- a/docs/flux.md
+++ b/docs/flux.md
@@ -71,11 +71,25 @@ flux:
     required: true
 ```
 
+### `mold.yaml` `output:` field
+
+`mold.yaml` may also declare a top-level `output:` mapping with the same syntax as `flux.yaml`'s `output:`. It acts as a fallback that's overridden by `flux.yaml`, `-f` value files, and `--set`. Useful for molds that ship sensible default destinations without requiring a separate `flux.yaml`:
+
+```yaml
+apiVersion: v1
+kind: mold
+name: my-mold
+version: 1.0.0
+output:
+  commands: .claude/commands
+  skills: .claude/skills
+```
+
 ## Value Precedence
 
 When blanks are rendered with `forge` or `cast`, flux values are resolved in this order (lowest to highest priority):
 
-1. **`mold.yaml` `flux:` schema defaults** — Default values from inline declarations
+1. **`mold.yaml` `flux:` schema defaults and `output:` field** — Default values from inline declarations
 2. **`flux.yaml` defaults** — Values shipped with the mold
 3. **`-f, --values` files** — Override files passed at install time (left to right, later files win)
 4. **`--set` flags** — Highest priority, set individual values from the command line

--- a/internal/commands/cast.go
+++ b/internal/commands/cast.go
@@ -190,7 +190,8 @@ func loadCastFlux(reader *blanks.MoldReader, source string) (map[string]any, []m
 	// Merge mold.yaml's in-line flux: schema in. LoadMoldFluxWithOres only
 	// reads the standalone flux.schema.yaml file; molds that declare their
 	// schema inline (no flux.schema.yaml on disk) still need their defaults.
-	if manifest, _ := reader.LoadManifest(); manifest != nil && len(manifest.Flux) > 0 {
+	manifest, _ := reader.LoadManifest()
+	if manifest != nil && len(manifest.Flux) > 0 {
 		fluxDefaults = mold.ApplyFluxDefaults(manifest.Flux, fluxDefaults)
 		if len(mergedSchema) == 0 {
 			mergedSchema = manifest.Flux
@@ -201,6 +202,7 @@ func loadCastFlux(reader *blanks.MoldReader, source string) (map[string]any, []m
 	for k, v := range fluxDefaults {
 		flux[k] = v
 	}
+	mold.ApplyManifestOutputDefault(flux, manifest)
 
 	// Layer 3: persisted flux files written by the foundries TUI (global, then
 	// project — project wins on conflict). Layered before user-supplied -f so

--- a/internal/commands/cast_core.go
+++ b/internal/commands/cast_core.go
@@ -267,7 +267,8 @@ func layerFluxForCore(reader *blanks.MoldReader, source string, valueFiles, setO
 	}
 	// Merge mold.yaml's in-line flux: schema in for molds that declare their
 	// schema inline rather than via a separate flux.schema.yaml.
-	if manifest, _ := reader.LoadManifest(); manifest != nil && len(manifest.Flux) > 0 {
+	manifest, _ := reader.LoadManifest()
+	if manifest != nil && len(manifest.Flux) > 0 {
 		defaults = mold.ApplyFluxDefaults(manifest.Flux, defaults)
 		if len(mergedSchema) == 0 {
 			mergedSchema = manifest.Flux
@@ -277,6 +278,7 @@ func layerFluxForCore(reader *blanks.MoldReader, source string, valueFiles, setO
 	for k, v := range defaults {
 		flux[k] = v
 	}
+	mold.ApplyManifestOutputDefault(flux, manifest)
 	if persisted := mold.PersistedFluxPaths(source); len(persisted) > 0 {
 		overlay, perr := mold.LayerFluxFiles(persisted)
 		if perr != nil {

--- a/internal/commands/cast_core_test.go
+++ b/internal/commands/cast_core_test.go
@@ -73,6 +73,83 @@ opencode body
 	}
 }
 
+// TestCastMold_MoldYamlOutputMapping verifies that a top-level output: in
+// mold.yaml is honored as a fallback when no flux.yaml exists. Embedded flux
+// in mold.yaml has parity with a standalone flux.yaml's output: key.
+func TestCastMold_MoldYamlOutputMapping(t *testing.T) {
+	projectDir := t.TempDir()
+	t.Chdir(projectDir)
+	t.Setenv("HOME", t.TempDir())
+
+	moldDir := filepath.Join(projectDir, "mold")
+	if err := os.MkdirAll(filepath.Join(moldDir, "commands"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	manifest := []byte(`apiVersion: v1
+kind: Mold
+name: parity
+version: 0.1.0
+output:
+  commands: .claude/commands
+`)
+	if err := os.WriteFile(filepath.Join(moldDir, "mold.yaml"), manifest, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(moldDir, "commands", "hello.md"), []byte("hi"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := CastMold(t.Context(), moldDir, CastOptions{}); err != nil {
+		t.Fatalf("CastMold: %v", err)
+	}
+
+	expected := filepath.Join(projectDir, ".claude", "commands", "hello.md")
+	if _, err := os.Stat(expected); err != nil {
+		t.Fatalf("expected %s to exist (mold.yaml output mapping should be honored): %v", expected, err)
+	}
+}
+
+// TestCastMold_FluxYamlOverridesMoldYamlOutput verifies that flux.yaml's
+// output: still wins over mold.yaml's output: when both are present.
+func TestCastMold_FluxYamlOverridesMoldYamlOutput(t *testing.T) {
+	projectDir := t.TempDir()
+	t.Chdir(projectDir)
+	t.Setenv("HOME", t.TempDir())
+
+	moldDir := filepath.Join(projectDir, "mold")
+	if err := os.MkdirAll(filepath.Join(moldDir, "commands"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	manifest := []byte(`apiVersion: v1
+kind: Mold
+name: parity
+version: 0.1.0
+output:
+  commands: .claude/commands
+`)
+	if err := os.WriteFile(filepath.Join(moldDir, "mold.yaml"), manifest, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	flux := []byte("output:\n  commands: .cursor/rules\n")
+	if err := os.WriteFile(filepath.Join(moldDir, "flux.yaml"), flux, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(moldDir, "commands", "hello.md"), []byte("hi"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := CastMold(t.Context(), moldDir, CastOptions{}); err != nil {
+		t.Fatalf("CastMold: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(projectDir, ".cursor", "rules", "hello.md")); err != nil {
+		t.Fatalf("expected flux.yaml output (.cursor/rules) to win: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(projectDir, ".claude", "commands", "hello.md")); err == nil {
+		t.Errorf("mold.yaml output should have been overridden by flux.yaml")
+	}
+}
+
 // TestCastMold_ConcurrentRunsStaySilent guards against the regression where
 // CastMold used a process-global `castSilent` toggle plus a global
 // log.SetOutput() to suppress per-file "✅ Created" lines. When the foundries

--- a/internal/commands/cast_deps.go
+++ b/internal/commands/cast_deps.go
@@ -223,6 +223,7 @@ func loadDepFlux(reader *blanks.MoldReader, manifest *mold.Mold, node *depgraph.
 	for k, v := range defaults {
 		flux[k] = v
 	}
+	mold.ApplyManifestOutputDefault(flux, manifest)
 
 	// Layer parent-supplied `with:` values.
 	for k, v := range node.With {

--- a/internal/commands/forge.go
+++ b/internal/commands/forge.go
@@ -82,6 +82,7 @@ func loadForgeFlux(reader *blanks.MoldReader, resolver *EphemeralOreResolver) (m
 	if err := mergo.Merge(&flux, fluxDefaults, mergo.WithOverride); err != nil {
 		return nil, fmt.Errorf("merging mold defaults over ore defaults: %w", err)
 	}
+	mold.ApplyManifestOutputDefault(flux, manifest)
 
 	// Layer 3: Layer -f files left-to-right (each overrides previous)
 	if len(forgeValFiles) > 0 {

--- a/internal/commands/temper.go
+++ b/internal/commands/temper.go
@@ -421,6 +421,7 @@ func loadTemperFlux(reader *blanks.MoldReader) (map[string]any, error) {
 	for k, v := range fluxDefaults {
 		flux[k] = v
 	}
+	mold.ApplyManifestOutputDefault(flux, manifest)
 
 	// Layer 3: Layer -f files left-to-right
 	if len(temperValFiles) > 0 {

--- a/pkg/mold/mold.go
+++ b/pkg/mold/mold.go
@@ -141,6 +141,7 @@ type Mold struct {
 	Author       Author       `yaml:"author,omitempty"`
 	Requires     Requires     `yaml:"requires,omitempty"`
 	Flux         []FluxVar    `yaml:"flux,omitempty"`
+	Output       any          `yaml:"output,omitempty"`
 	Dependencies []Dependency `yaml:"dependencies,omitempty"`
 	Ignore       []string     `yaml:"ignore,omitempty"`
 }
@@ -165,6 +166,20 @@ func LoadMoldFromFS(fsys fs.FS, path string) (*Mold, error) {
 		return nil, fmt.Errorf("reading mold manifest from fs: %w", err)
 	}
 	return ParseMold(data)
+}
+
+// ApplyManifestOutputDefault sets flux["output"] from the manifest's top-level
+// output: when flux doesn't already have an output mapping. This gives
+// mold.yaml's output: field parity with flux.yaml's, while keeping flux.yaml,
+// -f files, and --set as higher-precedence overrides.
+func ApplyManifestOutputDefault(flux map[string]any, manifest *Mold) {
+	if flux == nil || manifest == nil || manifest.Output == nil {
+		return
+	}
+	if _, has := flux["output"]; has {
+		return
+	}
+	flux["output"] = manifest.Output
 }
 
 // ParseMold parses raw YAML bytes into a Mold struct.

--- a/pkg/mold/mold_test.go
+++ b/pkg/mold/mold_test.go
@@ -79,6 +79,54 @@ dependencies:
 	}
 }
 
+func TestParseMold_TopLevelOutput(t *testing.T) {
+	// A mold.yaml may declare a top-level output: mapping as a fallback for
+	// consumers that don't supply flux.yaml — full parity with flux.yaml's
+	// output: key.
+	data := []byte(`
+apiVersion: v1
+kind: mold
+name: test-mold
+version: 1.0.0
+output:
+  commands: .claude/commands
+  workflows:
+    dest: .github/workflows
+    process: false
+`)
+
+	m, err := ParseMold(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.Output == nil {
+		t.Fatal("expected Output to be populated, got nil")
+	}
+	outMap, ok := m.Output.(map[string]any)
+	if !ok {
+		t.Fatalf("expected Output to be map[string]any, got %T", m.Output)
+	}
+	if outMap["commands"] != ".claude/commands" {
+		t.Errorf("expected commands → .claude/commands, got %v", outMap["commands"])
+	}
+}
+
+func TestParseMold_NoOutput(t *testing.T) {
+	data := []byte(`
+apiVersion: v1
+kind: mold
+name: test-mold
+version: 1.0.0
+`)
+	m, err := ParseMold(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.Output != nil {
+		t.Errorf("expected Output to be nil when absent, got %v", m.Output)
+	}
+}
+
 func TestParseMold_InvalidYAML(t *testing.T) {
 	data := []byte(`{{{invalid yaml`)
 	_, err := ParseMold(data)
@@ -96,6 +144,49 @@ func TestParseMold_EmptyDocument(t *testing.T) {
 	// Empty YAML produces zero-value struct
 	if m.Name != "" {
 		t.Errorf("expected empty name, got %s", m.Name)
+	}
+}
+
+func TestApplyManifestOutputDefault_FillsWhenMissing(t *testing.T) {
+	flux := map[string]any{"project": map[string]any{"org": "acme"}}
+	manifest := &Mold{Output: map[string]any{"commands": ".claude/commands"}}
+
+	ApplyManifestOutputDefault(flux, manifest)
+
+	outMap, ok := flux["output"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected flux[output] to be map[string]any, got %T", flux["output"])
+	}
+	if outMap["commands"] != ".claude/commands" {
+		t.Errorf("expected commands → .claude/commands, got %v", outMap["commands"])
+	}
+}
+
+func TestApplyManifestOutputDefault_DoesNotOverrideExistingFluxOutput(t *testing.T) {
+	flux := map[string]any{"output": map[string]any{"commands": ".cursor/rules"}}
+	manifest := &Mold{Output: map[string]any{"commands": ".claude/commands"}}
+
+	ApplyManifestOutputDefault(flux, manifest)
+
+	outMap := flux["output"].(map[string]any)
+	if outMap["commands"] != ".cursor/rules" {
+		t.Errorf("expected flux.yaml output to win, got %v", outMap["commands"])
+	}
+}
+
+func TestApplyManifestOutputDefault_NilManifestIsNoop(t *testing.T) {
+	flux := map[string]any{}
+	ApplyManifestOutputDefault(flux, nil)
+	if _, has := flux["output"]; has {
+		t.Errorf("expected no output key, got %v", flux["output"])
+	}
+}
+
+func TestApplyManifestOutputDefault_NilManifestOutputIsNoop(t *testing.T) {
+	flux := map[string]any{}
+	ApplyManifestOutputDefault(flux, &Mold{})
+	if _, has := flux["output"]; has {
+		t.Errorf("expected no output key, got %v", flux["output"])
 	}
 }
 

--- a/pkg/mold/validate.go
+++ b/pkg/mold/validate.go
@@ -515,8 +515,13 @@ func temperMold(fsys fs.FS, result *TemperResult) {
 		}
 	}
 
-	// Validate output source references (output lives in flux.yaml)
+	// Validate output source references. Output can come from flux.yaml or
+	// from a top-level output: in mold.yaml; flux.yaml wins when both exist.
 	flux, _ := LoadFluxFile(fsys, "flux.yaml")
+	if flux == nil {
+		flux = map[string]any{}
+	}
+	ApplyManifestOutputDefault(flux, m)
 	if err := ValidateOutputSources(flux["output"], fsys); err != nil {
 		result.Diagnostics = append(result.Diagnostics, Diagnostic{
 			Severity: SeverityError,

--- a/pkg/plugin/generator.go
+++ b/pkg/plugin/generator.go
@@ -96,6 +96,9 @@ func (g *Generator) loadBlanks() error {
 	if err != nil {
 		flux = make(map[string]any)
 	}
+	if manifest, mErr := g.reader.LoadManifest(); mErr == nil {
+		mold.ApplyManifestOutputDefault(flux, manifest)
+	}
 
 	resolved, err := mold.ResolveFiles(flux["output"], g.reader.FS())
 	if err != nil {


### PR DESCRIPTION
## Description

Adds a top-level `output:` field to `mold.yaml` so an embedded flux declaration has full parity with a standalone `flux.yaml`. Previously, `flux.yaml` supported output mappings but `mold.yaml` did not — molds that ship without a separate `flux.yaml` had no way to declare default destination paths. `flux.yaml`, `-f` value files, and `--set` still override the manifest's `output:`, so consumer-side customization is preserved.

## Related Issue

N/A

## Testing

- `go test ./...` (all packages pass).
- New unit tests: `TestParseMold_TopLevelOutput`, `TestApplyManifestOutputDefault_*`.
- New integration tests: `TestCastMold_MoldYamlOutputMapping` (fallback honored) and `TestCastMold_FluxYamlOverridesMoldYamlOutput` (precedence preserved).

## UAT

Author a mold with a top-level `output:` block in `mold.yaml` and no `flux.yaml`, then run `ailloy cast`. Files should land at the destinations declared in `mold.yaml`. Adding a `flux.yaml` with its own `output:`, or passing `--set output.<key>=…`, should override the manifest's mapping.

## Checklist

- [ ] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [x] I have updated documentation (if applicable)
- [ ] My commits have DCO sign-off (`git commit -s`)