### PR TITLE
feat(mold): add optional license field to manifests

### DIFF
--- a/docs/assay.md
+++ b/docs/assay.md
@@ -64,6 +64,7 @@ These rules lint a mold's source tree (rather than rendered AI instruction files
 | Rule | Severity | Description |
 |------|----------|-------------|
 | `ore-shadowing` | Warning | A mold has both a packaged ore at `./ores/<n>/` and hand-rolled `ore.<n>.*` entries in `flux.schema.yaml`; the hand-rolled entries silently shadow the package and almost always indicate a missed cleanup after migrating from the in-tree convention |
+| `license-missing` | Suggestion | The package manifest (`mold.yaml`, `ingot.yaml`, or `ore.yaml`) has no `license` field; consumers can't tell how the package may be used. Declare an [SPDX identifier](https://spdx.org/licenses/) such as `Apache-2.0`, `MIT`, or `BSD-3-Clause`, or `LicenseRef-<id>` for custom licenses |
 
 ## Claude Plugin Directory Support
 

--- a/docs/foundry.md
+++ b/docs/foundry.md
@@ -19,6 +19,7 @@ kind: mold
 name: my-team-mold
 version: 1.0.0
 description: "My team's AI workflow blanks"
+license: Apache-2.0       # optional; SPDX identifier
 author:
   name: My Team
   url: https://github.com/my-org

--- a/docs/smelt.md
+++ b/docs/smelt.md
@@ -41,12 +41,20 @@ kind: mold
 name: my-team-mold
 version: 1.0.0
 description: "Our team's AI workflow blanks"
+license: Apache-2.0       # optional; SPDX identifier (see https://spdx.org/licenses/)
 author:
   name: My Team
   url: https://github.com/my-org
 requires:
   ailloy: ">=0.2.0"
 ```
+
+The `license` field is optional. When set, [`ailloy temper`](temper.md) will:
+
+- Warn if the value isn't a recognized SPDX identifier (use `LicenseRef-<id>` for custom or proprietary licenses).
+- Warn if no `LICENSE` file is present at the package root.
+
+Authors who omit the field get a low-severity suggestion to add one — it's never blocking.
 
 ## Step 2: Write `flux.yaml` (optional)
 

--- a/internal/commands/mold.go
+++ b/internal/commands/mold.go
@@ -354,6 +354,11 @@ func runGetMold(_ *cobra.Command, args []string) error {
 	if manifest.Description != "" {
 		fmt.Println(styles.SubtleStyle.Render("  " + manifest.Description))
 	}
+	license := manifest.License
+	if license == "" {
+		license = "not specified"
+	}
+	fmt.Println(styles.InfoStyle.Render("License:    ") + styles.CodeStyle.Render(license))
 	fmt.Println(styles.InfoStyle.Render("Cache path: ") + styles.CodeStyle.Render(cachePath))
 
 	return nil

--- a/pkg/assay/rules_license.go
+++ b/pkg/assay/rules_license.go
@@ -1,0 +1,89 @@
+package assay
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/nimble-giant/ailloy/pkg/mold"
+)
+
+func init() {
+	Register(&licenseMissingRule{})
+}
+
+// licenseMissingRule reports a suggestion when a mold/ingot/ore package at
+// the assay root lacks a `license` field on its manifest. Low-severity,
+// informational — declaring a license is best practice for distributed
+// packages but never blocks linting.
+//
+// The rule fires for the manifest types ailloy publishes (mold.yaml,
+// ingot.yaml, ore.yaml) at the root, plus each package in a multi-ingot
+// layout under ingots/. Manifests with a non-empty `license` are silent.
+type licenseMissingRule struct{}
+
+func (r *licenseMissingRule) Name() string                       { return "license-missing" }
+func (r *licenseMissingRule) DefaultSeverity() mold.DiagSeverity { return mold.SeveritySuggestion }
+func (r *licenseMissingRule) Platforms() []Platform              { return nil }
+
+func (r *licenseMissingRule) Check(ctx *RuleContext) []mold.Diagnostic {
+	if ctx == nil || ctx.RootDir == "" {
+		return nil
+	}
+
+	var diags []mold.Diagnostic
+
+	if path := filepath.Join(ctx.RootDir, "mold.yaml"); fileExistsAt(path) {
+		if m, err := mold.LoadMold(path); err == nil && m.License == "" {
+			diags = append(diags, r.diag("mold.yaml"))
+		}
+	}
+	if path := filepath.Join(ctx.RootDir, "ore.yaml"); fileExistsAt(path) {
+		if o, err := mold.LoadOre(path); err == nil && o.License == "" {
+			diags = append(diags, r.diag("ore.yaml"))
+		}
+	}
+	if path := filepath.Join(ctx.RootDir, "ingot.yaml"); fileExistsAt(path) {
+		if i, err := mold.LoadIngot(path); err == nil && i.License == "" {
+			diags = append(diags, r.diag("ingot.yaml"))
+		}
+	}
+
+	// Multi-ingot layout: ingots/<name>/ingot.yaml.
+	ingotsDir := filepath.Join(ctx.RootDir, "ingots")
+	if entries, err := os.ReadDir(ingotsDir); err == nil {
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			manifestPath := filepath.Join(ingotsDir, e.Name(), "ingot.yaml")
+			if !fileExistsAt(manifestPath) {
+				continue
+			}
+			i, err := mold.LoadIngot(manifestPath)
+			if err != nil || i == nil {
+				continue
+			}
+			if i.License == "" {
+				diags = append(diags, r.diag(filepath.Join("ingots", e.Name(), "ingot.yaml")))
+			}
+		}
+	}
+
+	return diags
+}
+
+func (r *licenseMissingRule) diag(file string) mold.Diagnostic {
+	return mold.Diagnostic{
+		Severity: r.DefaultSeverity(),
+		Message:  fmt.Sprintf("%s has no `license` field; consider declaring an SPDX identifier so consumers know how the package may be used", file),
+		Tip:      "see https://spdx.org/licenses/ for the SPDX list; common choices include Apache-2.0, MIT, BSD-3-Clause",
+		File:     file,
+		Rule:     r.Name(),
+	}
+}
+
+func fileExistsAt(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/pkg/assay/rules_license_test.go
+++ b/pkg/assay/rules_license_test.go
@@ -1,0 +1,67 @@
+package assay
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeManifest(t *testing.T, dir, file, body string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, file), []byte(body), 0644); err != nil { //#nosec G306
+		t.Fatal(err)
+	}
+}
+
+func TestLicenseMissingRule_FiresOnMoldWithoutLicense(t *testing.T) {
+	root := t.TempDir()
+	writeManifest(t, root, "mold.yaml", "apiVersion: v1\nkind: mold\nname: m\nversion: 1.0.0\n")
+
+	diags := (&licenseMissingRule{}).Check(&RuleContext{RootDir: root, Config: DefaultConfig()})
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic, got %d: %+v", len(diags), diags)
+	}
+	if diags[0].File != "mold.yaml" {
+		t.Errorf("expected File=mold.yaml, got %q", diags[0].File)
+	}
+	if diags[0].Rule != "license-missing" {
+		t.Errorf("expected Rule=license-missing, got %q", diags[0].Rule)
+	}
+}
+
+func TestLicenseMissingRule_SilentWhenDeclared(t *testing.T) {
+	root := t.TempDir()
+	writeManifest(t, root, "mold.yaml", "apiVersion: v1\nkind: mold\nname: m\nversion: 1.0.0\nlicense: Apache-2.0\n")
+
+	diags := (&licenseMissingRule{}).Check(&RuleContext{RootDir: root, Config: DefaultConfig()})
+	if len(diags) != 0 {
+		t.Errorf("expected 0 diagnostics when license is set, got: %+v", diags)
+	}
+}
+
+func TestLicenseMissingRule_FiresPerIngotInMultiIngotLayout(t *testing.T) {
+	root := t.TempDir()
+	writeManifest(t, filepath.Join(root, "ingots", "alpha"), "ingot.yaml",
+		"apiVersion: v1\nkind: ingot\nname: alpha\nversion: 1.0.0\n")
+	writeManifest(t, filepath.Join(root, "ingots", "beta"), "ingot.yaml",
+		"apiVersion: v1\nkind: ingot\nname: beta\nversion: 1.0.0\nlicense: MIT\n")
+
+	diags := (&licenseMissingRule{}).Check(&RuleContext{RootDir: root, Config: DefaultConfig()})
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic (only alpha), got %d: %+v", len(diags), diags)
+	}
+	if filepath.ToSlash(diags[0].File) != "ingots/alpha/ingot.yaml" {
+		t.Errorf("expected File=ingots/alpha/ingot.yaml, got %q", diags[0].File)
+	}
+}
+
+func TestLicenseMissingRule_NoManifestNoOp(t *testing.T) {
+	root := t.TempDir()
+	diags := (&licenseMissingRule{}).Check(&RuleContext{RootDir: root, Config: DefaultConfig()})
+	if len(diags) != 0 {
+		t.Errorf("expected 0 diagnostics for empty root, got: %+v", diags)
+	}
+}

--- a/pkg/mold/ingot.go
+++ b/pkg/mold/ingot.go
@@ -16,6 +16,7 @@ type Ingot struct {
 	Name        string   `yaml:"name"`
 	Version     string   `yaml:"version"`
 	Description string   `yaml:"description,omitempty"`
+	License     string   `yaml:"license,omitempty"`
 	Files       []string `yaml:"files,omitempty"`
 	Requires    Requires `yaml:"requires,omitempty"`
 }

--- a/pkg/mold/mold.go
+++ b/pkg/mold/mold.go
@@ -138,6 +138,7 @@ type Mold struct {
 	Name         string       `yaml:"name"`
 	Version      string       `yaml:"version"`
 	Description  string       `yaml:"description,omitempty"`
+	License      string       `yaml:"license,omitempty"`
 	Author       Author       `yaml:"author,omitempty"`
 	Requires     Requires     `yaml:"requires,omitempty"`
 	Flux         []FluxVar    `yaml:"flux,omitempty"`

--- a/pkg/mold/mold_test.go
+++ b/pkg/mold/mold_test.go
@@ -13,6 +13,7 @@ kind: mold
 name: test-mold
 version: 1.0.0
 description: "A test mold"
+license: Apache-2.0
 author:
   name: Test Author
   url: https://example.com
@@ -52,6 +53,9 @@ dependencies:
 	}
 	if m.Description != "A test mold" {
 		t.Errorf("expected description 'A test mold', got %s", m.Description)
+	}
+	if m.License != "Apache-2.0" {
+		t.Errorf("expected license Apache-2.0, got %s", m.License)
 	}
 	if m.Author.Name != "Test Author" {
 		t.Errorf("expected author name Test Author, got %s", m.Author.Name)

--- a/pkg/mold/ore.go
+++ b/pkg/mold/ore.go
@@ -30,6 +30,7 @@ type Ore struct {
 	Namespace   string   `yaml:"namespace,omitempty"`
 	Version     string   `yaml:"version"`
 	Description string   `yaml:"description,omitempty"`
+	License     string   `yaml:"license,omitempty"`
 	Author      Author   `yaml:"author,omitempty"`
 	Requires    Requires `yaml:"requires,omitempty"`
 }

--- a/pkg/mold/spdx.go
+++ b/pkg/mold/spdx.go
@@ -1,0 +1,150 @@
+package mold
+
+import (
+	"sort"
+	"strings"
+)
+
+// curatedSPDXIDs is the embedded set of common SPDX license identifiers
+// recognized by ailloy. Authors needing an ID outside this list can use the
+// SPDX `LicenseRef-<id>` form for custom/proprietary licenses without
+// triggering a warning. Expand this list as community needs grow — the SPDX
+// canonical list at https://spdx.org/licenses/ is the source of truth.
+var curatedSPDXIDs = []string{
+	"0BSD",
+	"AGPL-3.0-only",
+	"AGPL-3.0-or-later",
+	"Apache-2.0",
+	"Artistic-2.0",
+	"BSD-2-Clause",
+	"BSD-3-Clause",
+	"BSD-3-Clause-Clear",
+	"BSL-1.0",
+	"CC-BY-4.0",
+	"CC-BY-SA-4.0",
+	"CC0-1.0",
+	"EPL-2.0",
+	"GPL-2.0-only",
+	"GPL-2.0-or-later",
+	"GPL-3.0-only",
+	"GPL-3.0-or-later",
+	"ISC",
+	"LGPL-2.1-only",
+	"LGPL-2.1-or-later",
+	"LGPL-3.0-only",
+	"LGPL-3.0-or-later",
+	"MIT",
+	"MPL-2.0",
+	"Unlicense",
+	"WTFPL",
+	"Zlib",
+}
+
+// spdxIDSet is a lookup of curated SPDX IDs by lowercased form for
+// case-insensitive matching. SPDX IDs are case-sensitive in spec, but author
+// typos are common — we lower-compare for IsValidSPDX, and the suggester
+// returns the canonical casing.
+var spdxIDSet = func() map[string]string {
+	m := make(map[string]string, len(curatedSPDXIDs))
+	for _, id := range curatedSPDXIDs {
+		m[strings.ToLower(id)] = id
+	}
+	return m
+}()
+
+// IsValidSPDX reports whether s is a recognized SPDX identifier from the
+// curated list, or an SPDX `LicenseRef-<id>` reference. Empty input returns
+// false; callers handle the "license omitted" case separately.
+func IsValidSPDX(s string) bool {
+	if s == "" {
+		return false
+	}
+	if strings.HasPrefix(s, "LicenseRef-") {
+		// Per SPDX spec, LicenseRef- + idstring where idstring is
+		// [a-zA-Z0-9.-]+. Any non-empty suffix is accepted here; deeper
+		// validation isn't worth the spec-tracking burden.
+		return len(s) > len("LicenseRef-")
+	}
+	_, ok := spdxIDSet[strings.ToLower(s)]
+	return ok
+}
+
+// CanonicalSPDX returns the canonically-cased SPDX ID for s if s is in the
+// curated list (case-insensitive match). For LicenseRef- inputs and unknown
+// IDs, it returns s unchanged.
+func CanonicalSPDX(s string) string {
+	if strings.HasPrefix(s, "LicenseRef-") {
+		return s
+	}
+	if canonical, ok := spdxIDSet[strings.ToLower(s)]; ok {
+		return canonical
+	}
+	return s
+}
+
+// SuggestSPDX returns the closest curated SPDX ID to s by edit distance,
+// for inclusion in temper warnings. Returns "" when no candidate is within
+// a reasonable distance, to avoid suggesting nonsense for wholly unrelated
+// input — the cap is min(4, len(s)-1), so short or exotic inputs (e.g. a
+// stray emoji) get no suggestion rather than a misleading one.
+func SuggestSPDX(s string) string {
+	if s == "" {
+		return ""
+	}
+	target := strings.ToLower(s)
+	maxDist := min(4, len(target)-1)
+	if maxDist < 1 {
+		return ""
+	}
+	bestID := ""
+	bestDist := maxDist + 1
+	for _, id := range curatedSPDXIDs {
+		d := levenshtein(target, strings.ToLower(id))
+		if d < bestDist {
+			bestDist = d
+			bestID = id
+		}
+	}
+	return bestID
+}
+
+// CuratedSPDXIDs returns a sorted copy of the curated SPDX identifier list.
+// Useful for help text and `ailloy license` tooling.
+func CuratedSPDXIDs() []string {
+	out := make([]string, len(curatedSPDXIDs))
+	copy(out, curatedSPDXIDs)
+	sort.Strings(out)
+	return out
+}
+
+// levenshtein computes edit distance between two strings using the classic
+// row-by-row DP. Small inputs (SPDX IDs are <30 chars) — no need for a
+// trickier algorithm.
+func levenshtein(a, b string) int {
+	if a == b {
+		return 0
+	}
+	if len(a) == 0 {
+		return len(b)
+	}
+	if len(b) == 0 {
+		return len(a)
+	}
+	prev := make([]int, len(b)+1)
+	curr := make([]int, len(b)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(a); i++ {
+		curr[0] = i
+		for j := 1; j <= len(b); j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			curr[j] = min(curr[j-1]+1, prev[j]+1, prev[j-1]+cost)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(b)]
+}

--- a/pkg/mold/spdx_test.go
+++ b/pkg/mold/spdx_test.go
@@ -1,0 +1,60 @@
+package mold
+
+import "testing"
+
+func TestIsValidSPDX(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"empty", "", false},
+		{"canonical Apache", "Apache-2.0", true},
+		{"canonical MIT", "MIT", true},
+		{"canonical BSD-3-Clause", "BSD-3-Clause", true},
+		{"case-insensitive match", "apache-2.0", true},
+		{"LicenseRef custom", "LicenseRef-Internal-1", true},
+		{"LicenseRef bare prefix", "LicenseRef-", false},
+		{"unknown", "Apache 2", false},
+		{"made-up", "Megacorp-1.0", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsValidSPDX(tc.input); got != tc.want {
+				t.Errorf("IsValidSPDX(%q) = %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSuggestSPDX(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"typo Apache 2", "Apache2.0", "Apache-2.0"},
+		{"lowercase mit", "mit", "MIT"},
+		{"BSD-3 typo", "BSD-3Clause", "BSD-3-Clause"},
+		{"unrelated nonsense", "🦊", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := SuggestSPDX(tc.input); got != tc.want {
+				t.Errorf("SuggestSPDX(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCanonicalSPDX(t *testing.T) {
+	if got := CanonicalSPDX("apache-2.0"); got != "Apache-2.0" {
+		t.Errorf("CanonicalSPDX(apache-2.0) = %q, want Apache-2.0", got)
+	}
+	if got := CanonicalSPDX("LicenseRef-X"); got != "LicenseRef-X" {
+		t.Errorf("CanonicalSPDX(LicenseRef-X) = %q, want LicenseRef-X", got)
+	}
+	if got := CanonicalSPDX("MadeUp"); got != "MadeUp" {
+		t.Errorf("CanonicalSPDX(MadeUp) = %q, want MadeUp (unchanged)", got)
+	}
+}

--- a/pkg/mold/temper_test.go
+++ b/pkg/mold/temper_test.go
@@ -580,3 +580,175 @@ func TestTemperResult_NoErrors(t *testing.T) {
 		t.Error("expected HasErrors to return false with only warnings")
 	}
 }
+
+// diagWithRule returns the first diagnostic with the given rule name, or nil
+// when no such diagnostic exists. Used by the license-related temper tests
+// below to avoid brittle message-string matching.
+func diagWithRule(diags []Diagnostic, rule string) *Diagnostic {
+	for i := range diags {
+		if diags[i].Rule == rule {
+			return &diags[i]
+		}
+	}
+	return nil
+}
+
+func TestTemper_License_OmittedSuggestsAddingOne(t *testing.T) {
+	fsys := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte(`
+apiVersion: v1
+kind: mold
+name: test-mold
+version: 1.0.0
+`)},
+	}
+
+	result := Temper(fsys)
+
+	if result.HasErrors() {
+		t.Fatalf("expected no errors, got: %v", result.Errors())
+	}
+	d := diagWithRule(result.Suggestions(), "license-missing")
+	if d == nil {
+		t.Fatalf("expected license-missing suggestion, got: %+v", result.Diagnostics)
+	}
+	if d.Severity != SeveritySuggestion {
+		t.Errorf("expected SeveritySuggestion, got %v", d.Severity)
+	}
+}
+
+func TestTemper_License_KnownSPDXNoWarning(t *testing.T) {
+	fsys := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte(`
+apiVersion: v1
+kind: mold
+name: test-mold
+version: 1.0.0
+license: Apache-2.0
+`)},
+		"LICENSE": &fstest.MapFile{Data: []byte("Apache License 2.0...")},
+	}
+
+	result := Temper(fsys)
+
+	if d := diagWithRule(result.Diagnostics, "license-spdx"); d != nil {
+		t.Errorf("did not expect license-spdx diagnostic, got: %+v", d)
+	}
+	if d := diagWithRule(result.Diagnostics, "license-file-missing"); d != nil {
+		t.Errorf("did not expect license-file-missing diagnostic, got: %+v", d)
+	}
+	if d := diagWithRule(result.Diagnostics, "license-missing"); d != nil {
+		t.Errorf("did not expect license-missing diagnostic when license is set, got: %+v", d)
+	}
+}
+
+func TestTemper_License_UnknownSPDXWarnsWithSuggestion(t *testing.T) {
+	fsys := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte(`
+apiVersion: v1
+kind: mold
+name: test-mold
+version: 1.0.0
+license: Apache2.0
+`)},
+		"LICENSE": &fstest.MapFile{Data: []byte("...")},
+	}
+
+	result := Temper(fsys)
+
+	d := diagWithRule(result.Warnings(), "license-spdx")
+	if d == nil {
+		t.Fatalf("expected license-spdx warning, got diagnostics: %+v", result.Diagnostics)
+	}
+	if !strings.Contains(d.Tip, "Apache-2.0") {
+		t.Errorf("expected tip to suggest Apache-2.0, got: %q", d.Tip)
+	}
+}
+
+func TestTemper_License_LicenseRefAccepted(t *testing.T) {
+	fsys := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte(`
+apiVersion: v1
+kind: mold
+name: test-mold
+version: 1.0.0
+license: LicenseRef-Internal-1
+`)},
+		"LICENSE": &fstest.MapFile{Data: []byte("...")},
+	}
+
+	result := Temper(fsys)
+
+	if d := diagWithRule(result.Diagnostics, "license-spdx"); d != nil {
+		t.Errorf("did not expect license-spdx diagnostic for LicenseRef, got: %+v", d)
+	}
+}
+
+func TestTemper_License_SetButLICENSEFileMissing(t *testing.T) {
+	fsys := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte(`
+apiVersion: v1
+kind: mold
+name: test-mold
+version: 1.0.0
+license: MIT
+`)},
+	}
+
+	result := Temper(fsys)
+
+	d := diagWithRule(result.Warnings(), "license-file-missing")
+	if d == nil {
+		t.Fatalf("expected license-file-missing warning, got: %+v", result.Diagnostics)
+	}
+}
+
+func TestTemper_License_IngotPath(t *testing.T) {
+	fsys := fstest.MapFS{
+		"ingot.yaml": &fstest.MapFile{Data: []byte(`
+apiVersion: v1
+kind: ingot
+name: test-ingot
+version: 1.0.0
+license: MIT
+`)},
+	}
+
+	result := Temper(fsys)
+
+	d := diagWithRule(result.Warnings(), "license-file-missing")
+	if d == nil {
+		t.Fatalf("expected license-file-missing warning for ingot, got: %+v", result.Diagnostics)
+	}
+	if d.File != "ingot.yaml" {
+		t.Errorf("expected File=ingot.yaml, got %q", d.File)
+	}
+}
+
+func TestTemper_License_OrePath(t *testing.T) {
+	fsys := fstest.MapFS{
+		"ore.yaml": &fstest.MapFile{Data: []byte(`
+apiVersion: v1
+kind: ore
+name: test_ore
+version: 1.0.0
+license: bogus
+`)},
+		"LICENSE": &fstest.MapFile{Data: []byte("...")},
+		"flux.schema.yaml": &fstest.MapFile{Data: []byte(`- name: enabled
+  type: bool
+`)},
+		"flux.yaml": &fstest.MapFile{Data: []byte(`enabled: false
+`)},
+	}
+
+	result := Temper(fsys)
+
+	d := diagWithRule(result.Warnings(), "license-spdx")
+	if d == nil {
+		t.Fatalf("expected license-spdx warning for ore, got: %+v", result.Diagnostics)
+	}
+	if d.File != "ore.yaml" {
+		t.Errorf("expected File=ore.yaml, got %q", d.File)
+	}
+}

--- a/pkg/mold/validate.go
+++ b/pkg/mold/validate.go
@@ -178,6 +178,48 @@ func ValidateOre(o *Ore) error {
 	return nil
 }
 
+// temperLicense emits diagnostics about the optional `license` manifest field.
+// Authors who declare a license get checked for SPDX validity and the presence
+// of a LICENSE file; authors who omit it get an informational suggestion to
+// add one. None of these block validation — the field is optional.
+func temperLicense(fsys fs.FS, manifestFile, license string, result *TemperResult) {
+	if license == "" {
+		result.Diagnostics = append(result.Diagnostics, Diagnostic{
+			Severity: SeveritySuggestion,
+			Message:  "no license declared; consider adding a `license:` field with an SPDX identifier (e.g. Apache-2.0, MIT)",
+			Tip:      "see https://spdx.org/licenses/ for the full SPDX list",
+			File:     manifestFile,
+			Rule:     "license-missing",
+		})
+		return
+	}
+
+	if !IsValidSPDX(license) {
+		msg := fmt.Sprintf("license %q is not a recognized SPDX identifier", license)
+		tip := "use `LicenseRef-<id>` for custom or proprietary licenses"
+		if suggestion := SuggestSPDX(license); suggestion != "" {
+			tip = fmt.Sprintf("did you mean %q? (or use `LicenseRef-<id>` for custom licenses)", suggestion)
+		}
+		result.Diagnostics = append(result.Diagnostics, Diagnostic{
+			Severity: SeverityWarning,
+			Message:  msg,
+			Tip:      tip,
+			File:     manifestFile,
+			Rule:     "license-spdx",
+		})
+	}
+
+	if !fileExists(fsys, "LICENSE") {
+		result.Diagnostics = append(result.Diagnostics, Diagnostic{
+			Severity: SeverityWarning,
+			Message:  fmt.Sprintf("license %q declared but no LICENSE file found at package root", license),
+			Tip:      "add a LICENSE file with the full license text so consumers can read it",
+			File:     manifestFile,
+			Rule:     "license-file-missing",
+		})
+	}
+}
+
 // temperOre validates an ore-directory package. Rules:
 //   - manifest fields valid (apiVersion, kind=ore, snake_case name, semver version)
 //   - flux.schema.yaml present and parseable
@@ -216,6 +258,8 @@ func temperOre(fsys fs.FS, result *TemperResult) {
 			File:     "ore.yaml",
 		})
 	}
+
+	temperLicense(fsys, "ore.yaml", o.License, result)
 
 	schema, err := LoadFluxSchema(fsys, "flux.schema.yaml")
 	if err != nil {
@@ -515,6 +559,8 @@ func temperMold(fsys fs.FS, result *TemperResult) {
 		}
 	}
 
+	temperLicense(fsys, "mold.yaml", m.License, result)
+
 	// Validate output source references. Output can come from flux.yaml or
 	// from a top-level output: in mold.yaml; flux.yaml wins when both exist.
 	flux, _ := LoadFluxFile(fsys, "flux.yaml")
@@ -570,6 +616,8 @@ func temperIngotAt(fsys fs.FS, manifestPath string, result *TemperResult) {
 			})
 		}
 	}
+
+	temperLicense(fsys, manifestPath, i.License, result)
 
 	if len(i.Files) > 0 {
 		for _, f := range i.Files {


### PR DESCRIPTION
## Summary

Adds an optional SPDX `license` field to mold, ingot, and ore manifests so authors can declare licensing intent for their packages.

- **Manifest field** — `License string` (yaml `license,omitempty`) on `Mold`, `Ingot`, `Ore`.
- **SPDX validator** — curated SPDX list + case-insensitive match + Levenshtein-based suggester (`pkg/mold/spdx.go`). Accepts `LicenseRef-<id>` for proprietary licenses.
- **Temper diagnostics** — three rules wired into all three temper paths:
  - `license-missing` (suggestion) when omitted
  - `license-spdx` (warning) with "did you mean…" hint for unknown ids
  - `license-file-missing` (warning) when declared but no `LICENSE` at root
- **Assay rule** — `license-missing` low-severity suggestion that fires on manifests at the assay root (including per-package in multi-ingot layouts).
- **`ailloy mold get`** — prints `License: <value or "not specified">` alongside Description / Cache path.
- **Docs** — updated `docs/foundry.md`, `docs/smelt.md`, `docs/assay.md`.

The field is optional and never blocks validation — existing manifests without `license` continue to cast unchanged.

Closes #218. Follow-up `ailloy license` CLI for dependency-graph auditing is tracked in #219.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./...`
- [x] `gofmt -l pkg/ internal/` (clean)
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] New unit coverage: SPDX validator (`pkg/mold/spdx_test.go`), temper license paths for mold/ingot/ore (`pkg/mold/temper_test.go`), assay rule including multi-ingot layout (`pkg/assay/rules_license_test.go`)
- [ ] Manual smoke: scaffold a mold with `license: Apache-2.0` + LICENSE file → temper clean
- [ ] Manual smoke: scaffold a mold with `license: Apache2.0` → temper warns with `did you mean "Apache-2.0"?`
- [ ] Manual smoke: scaffold a mold without `license:` → temper suggestion fires; `ailloy assay` echoes the same suggestion