### PR TITLE
fix: route mold: dependencies through the mold resolver in temper/forge

### DIFF
--- a/internal/commands/forge_ore_test.go
+++ b/internal/commands/forge_ore_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/nimble-giant/ailloy/pkg/mold"
@@ -104,6 +105,85 @@ func TestResolveDepsEphemeral_RejectsLocalDepFromRemoteMold(t *testing.T) {
 	}
 	if _, err := ResolveDepsEphemeral(manifest, false); err == nil {
 		t.Fatal("expected error for local-path dep when allowLocalDeps=false")
+	}
+}
+
+// TestResolveDepsEphemeral_MoldDep verifies that a `mold:` dependency is
+// resolved through the mold loader (validating mold.yaml) rather than the ore
+// loader — a `mold:` dep must not produce an "ore.yaml not found" failure.
+func TestResolveDepsEphemeral_MoldDep(t *testing.T) {
+	tmp := t.TempDir()
+
+	depMold := filepath.Join(tmp, "dep-mold")
+	if err := os.MkdirAll(depMold, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(depMold, "mold.yaml"),
+		[]byte("apiVersion: v1\nkind: mold\nname: launch\nversion: 0.2.0\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	moldDir := filepath.Join(tmp, "mold")
+	if err := os.MkdirAll(moldDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	cwd, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(moldDir); err != nil {
+		t.Fatal(err)
+	}
+
+	manifest := &mold.Mold{
+		Name:    "support-sandbox",
+		Version: "0.1.0",
+		Dependencies: []mold.Dependency{
+			{Mold: depMold, Version: "^0.2.0"},
+		},
+	}
+
+	resolver, err := ResolveDepsEphemeral(manifest, true)
+	if err != nil {
+		t.Fatalf("ResolveDepsEphemeral with mold dep: %v", err)
+	}
+	if resolver == nil {
+		t.Fatal("nil resolver")
+	}
+	// Mold deps contribute nothing to the schema/defaults merge.
+	if len(resolver.Overlays()) != 0 {
+		t.Errorf("mold dep should produce no overlays, got %+v", resolver.Overlays())
+	}
+}
+
+// TestResolveDepsEphemeral_MoldDepInvalidManifest verifies that a `mold:` dep
+// pointing at a directory without a valid mold.yaml fails with a mold-manifest
+// error, not an ore-manifest error.
+func TestResolveDepsEphemeral_MoldDepInvalidManifest(t *testing.T) {
+	tmp := t.TempDir()
+
+	depMold := filepath.Join(tmp, "dep-mold")
+	if err := os.MkdirAll(depMold, 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	moldDir := filepath.Join(tmp, "mold")
+	if err := os.MkdirAll(moldDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	cwd, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(moldDir); err != nil {
+		t.Fatal(err)
+	}
+
+	manifest := &mold.Mold{
+		Dependencies: []mold.Dependency{{Mold: depMold, Version: "^0.2.0"}},
+	}
+	_, err := ResolveDepsEphemeral(manifest, true)
+	if err == nil {
+		t.Fatal("expected error for mold dep without mold.yaml")
+	}
+	if !strings.Contains(err.Error(), "invalid mold manifest") {
+		t.Errorf("expected mold-manifest error, got: %v", err)
 	}
 }
 

--- a/internal/commands/install_deps_ephemeral.go
+++ b/internal/commands/install_deps_ephemeral.go
@@ -38,9 +38,9 @@ func (r *EphemeralOreResolver) Defaults() map[string]any {
 }
 
 // ResolveDepsEphemeral walks manifest.Dependencies and resolves each ore
-// without copying into .ailloy/. Ingot deps are validated for parseability
-// but contribute nothing to the schema/defaults merge. Returns an empty
-// resolver for nil/empty deps.
+// without copying into .ailloy/. Ingot and mold deps are validated for
+// parseability but contribute nothing to the schema/defaults merge. Returns
+// an empty resolver for nil/empty deps.
 //
 // allowLocalDeps mirrors the security rule from installDeclaredDeps: when
 // the parent mold itself was resolved from a remote source, local-path deps
@@ -73,6 +73,16 @@ func ResolveDepsEphemeral(manifest *mold.Mold, allowLocalDeps bool) (*EphemeralO
 			// overlays — ingots don't contribute to flux schema/defaults.
 			if _, err := mold.LoadIngotFromFS(fsys, "ingot.yaml"); err != nil {
 				return nil, fmt.Errorf("invalid ingot manifest at %s: %w", ref, err)
+			}
+			continue
+		}
+
+		if kind == "mold" {
+			// Validate the mold manifest parses, but don't add anything to
+			// overlays — mold-on-mold deps are resolved transitively by the
+			// cast pipeline, not through the ore schema/defaults merge.
+			if _, err := mold.LoadMoldFromFS(fsys, "mold.yaml"); err != nil {
+				return nil, fmt.Errorf("invalid mold manifest at %s: %w", ref, err)
 			}
 			continue
 		}

--- a/internal/commands/temper.go
+++ b/internal/commands/temper.go
@@ -306,7 +306,7 @@ func appendOreDiagnostics(fsys fs.FS, result *mold.TemperResult) {
 	if rerr != nil {
 		result.Diagnostics = append(result.Diagnostics, mold.Diagnostic{
 			Severity: mold.SeverityError,
-			Message:  fmt.Sprintf("resolving ore dependencies: %v", rerr),
+			Message:  fmt.Sprintf("resolving dependencies: %v", rerr),
 			File:     "mold.yaml",
 		})
 		return


### PR DESCRIPTION
## Description

`ResolveDepsEphemeral` (used by `ailloy temper` and `ailloy forge`) handled `ingot:` and `ore:` dependency kinds but had no case for mold-on-mold deps, so a `mold:` entry fell through to the ore branch and failed with an `ore.yaml` not-found error. This PR adds a `mold` branch that validates the dep's `mold.yaml` without contributing to the schema/defaults merge, mirroring how `installDeclaredDeps` already skips mold deps. The temper diagnostic message was also broadened from "resolving ore dependencies" to "resolving dependencies".

## Related Issue

Fixes #225

## Testing

Added `TestResolveDepsEphemeral_MoldDep` and `TestResolveDepsEphemeral_MoldDepInvalidManifest`; the full `internal/commands` test package passes.

## UAT

Create a mold whose `mold.yaml` declares a `mold:` dependency on another local or remote mold, then run `ailloy temper <dir>` — it should resolve cleanly instead of failing with an `ore.yaml` not-found error.

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [ ] I have updated documentation (if applicable)
- [x] My commits have DCO sign-off (`git commit -s`)