### PR TITLE
fix: enforce requires.ailloy version constraint at cast time

### DIFF
--- a/internal/commands/cast.go
+++ b/internal/commands/cast.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/charmbracelet/huh"
 	"github.com/goccy/go-yaml"
 	"github.com/nimble-giant/ailloy/internal/tui/ceremony"
@@ -107,6 +108,9 @@ func runCast(_ *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	if err := checkAilloyRequirement(reader); err != nil {
+		return err
+	}
 	if castClaudePluginFlag {
 		return castClaudePlugin(reader, source)
 	}
@@ -125,6 +129,53 @@ func validatePluginFlags() error {
 		}
 	}
 	return nil
+}
+
+// checkAilloyRequirement enforces a mold's `requires.ailloy` constraint before
+// any casting work begins. Without this gate an old binary silently ignores
+// the constraint and proceeds with a degraded cast (e.g. skipping transitive
+// dependency installation), leaving the user with a partially installed mold
+// and no explanation (#229).
+//
+// Manifest load failures are swallowed here: the cast pipeline reloads the
+// manifest downstream and reports those errors with better context.
+func checkAilloyRequirement(reader *blanks.MoldReader) error {
+	manifest, err := reader.LoadManifest()
+	if err != nil || manifest == nil {
+		return nil
+	}
+	return enforceAilloyVersion(manifest.Requires.Ailloy)
+}
+
+// enforceAilloyVersion checks the running ailloy build against a mold's
+// requires.ailloy constraint, returning an actionable error when it is not
+// satisfied. It passes (returns nil) when there is no constraint, when the
+// constraint is unparseable (`temper` flags malformed constraints — a cast
+// should not double as a linter), or when the running binary has no release
+// version to compare (dev builds, where evolveCurrentVersion is empty/"dev").
+func enforceAilloyVersion(requires string) error {
+	requires = strings.TrimSpace(requires)
+	if requires == "" {
+		return nil
+	}
+	current := strings.TrimSpace(evolveCurrentVersion)
+	if current == "" || current == "dev" {
+		return nil
+	}
+	constraint, err := semver.NewConstraint(requires)
+	if err != nil {
+		return nil
+	}
+	v, err := semver.NewVersion(strings.TrimPrefix(current, "v"))
+	if err != nil {
+		return nil
+	}
+	if constraint.Check(v) {
+		return nil
+	}
+	return fmt.Errorf(
+		"this mold requires ailloy %s, but you are running v%s\nRun `brew upgrade ailloy` to update",
+		requires, strings.TrimPrefix(current, "v"))
 }
 
 // resolvedRemote holds metadata about the most recently resolved remote mold.

--- a/internal/commands/cast_requires_test.go
+++ b/internal/commands/cast_requires_test.go
@@ -1,0 +1,99 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nimble-giant/ailloy/pkg/blanks"
+)
+
+func TestEnforceAilloyVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		requires string
+		current  string
+		wantErr  bool
+	}{
+		{name: "no constraint passes", requires: "", current: "0.6.32", wantErr: false},
+		{name: "satisfied minimum", requires: ">=0.6.33", current: "0.6.33", wantErr: false},
+		{name: "satisfied newer", requires: ">=0.6.33", current: "0.7.0", wantErr: false},
+		{name: "unsatisfied minimum", requires: ">=0.6.33", current: "0.6.32", wantErr: true},
+		{name: "v-prefixed current still compared", requires: ">=0.6.33", current: "v0.6.32", wantErr: true},
+		{name: "dev build skips check", requires: ">=0.6.33", current: "dev", wantErr: false},
+		{name: "empty current skips check", requires: ">=0.6.33", current: "", wantErr: false},
+		{name: "malformed constraint passes", requires: "latest", current: "0.6.32", wantErr: false},
+		{name: "caret constraint satisfied", requires: "^0.6.0", current: "0.6.40", wantErr: false},
+	}
+
+	orig := evolveCurrentVersion
+	defer func() { evolveCurrentVersion = orig }()
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			evolveCurrentVersion = tc.current
+			err := enforceAilloyVersion(tc.requires)
+			if tc.wantErr && err == nil {
+				t.Fatalf("enforceAilloyVersion(%q) with current %q: want error, got nil", tc.requires, tc.current)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("enforceAilloyVersion(%q) with current %q: want nil, got %v", tc.requires, tc.current, err)
+			}
+		})
+	}
+}
+
+// TestEnforceAilloyVersion_ErrorMessage verifies the error names the required
+// version, the current version, and an upgrade hint (issue #229 acceptance).
+func TestEnforceAilloyVersion_ErrorMessage(t *testing.T) {
+	orig := evolveCurrentVersion
+	defer func() { evolveCurrentVersion = orig }()
+	evolveCurrentVersion = "0.6.32"
+
+	err := enforceAilloyVersion(">=0.6.33")
+	if err == nil {
+		t.Fatal("want error, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{">=0.6.33", "v0.6.32", "brew upgrade ailloy"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message %q missing %q", msg, want)
+		}
+	}
+}
+
+// TestCheckAilloyRequirement reads requires.ailloy straight from a mold.yaml on
+// disk and enforces it against the running version.
+func TestCheckAilloyRequirement(t *testing.T) {
+	orig := evolveCurrentVersion
+	defer func() { evolveCurrentVersion = orig }()
+	evolveCurrentVersion = "0.6.32"
+
+	newReader := func(t *testing.T, manifest string) *blanks.MoldReader {
+		t.Helper()
+		moldDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(moldDir, "mold.yaml"), []byte(manifest), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		reader, err := blanks.NewMoldReaderFromPath(moldDir)
+		if err != nil {
+			t.Fatalf("NewMoldReaderFromPath: %v", err)
+		}
+		return reader
+	}
+
+	t.Run("blocks when constraint unmet", func(t *testing.T) {
+		reader := newReader(t, "apiVersion: v1\nkind: mold\nname: gated\nversion: 0.1.0\nrequires:\n  ailloy: \">=0.6.33\"\n")
+		if err := checkAilloyRequirement(reader); err == nil {
+			t.Fatal("want error for unmet requires.ailloy, got nil")
+		}
+	})
+
+	t.Run("passes when no constraint", func(t *testing.T) {
+		reader := newReader(t, "apiVersion: v1\nkind: mold\nname: open\nversion: 0.1.0\n")
+		if err := checkAilloyRequirement(reader); err != nil {
+			t.Fatalf("want nil, got %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Description

`ailloy cast` now reads `requires.ailloy` from `mold.yaml` and fails fast with an actionable error when the running build does not satisfy the constraint, instead of silently ignoring it and producing a partially installed mold. Dev builds and malformed constraints pass through unchanged so casts aren't blocked spuriously, and the gate covers both `cast` and `cast --claude-plugin`.

## Related Issue

Fixes #229

## Testing

Added `internal/commands/cast_requires_test.go` covering satisfied/unsatisfied constraints, `v`-prefixed and dev versions, caret ranges, the error-message contents, and `checkAilloyRequirement` against a real `mold.yaml`. `go build ./...`, `go vet`, `gofmt`, and the full `internal/commands` suite (`-short`) all pass.

## UAT

With a release build older than a mold's `requires.ailloy`, run `ailloy cast <that-mold>` and confirm it now exits with `this mold requires ailloy >=X.Y.Z, but you are running vA.B.C` plus an upgrade hint, rather than completing a degraded cast.

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [ ] I have updated documentation (if applicable)
- [x] My commits have DCO sign-off (`git commit -s`)