### PR TITLE
fix: resolve mold dep constraints against dependency mold.yaml version

### DIFF
--- a/internal/commands/cast_deps_test.go
+++ b/internal/commands/cast_deps_test.go
@@ -139,7 +139,7 @@ func (f *fakeDepFetcher) Fetch(ref *foundry.Reference) (depgraph.FetchResult, er
 	}, nil
 }
 
-func (f *fakeDepFetcher) Tags(source, subpath string) (map[string]string, error) {
+func (f *fakeDepFetcher) Tags(source, subpath string) (map[string]depgraph.TagInfo, error) {
 	key := source
 	if subpath != "" {
 		key = source + "//" + subpath
@@ -148,9 +148,9 @@ func (f *fakeDepFetcher) Tags(source, subpath string) (map[string]string, error)
 	if tags == nil {
 		return nil, &fakeNotFoundErr{key}
 	}
-	out := make(map[string]string, len(tags))
+	out := make(map[string]depgraph.TagInfo, len(tags))
 	for k, v := range tags {
-		out[k] = v
+		out[k] = depgraph.TagInfo{SHA: v}
 	}
 	return out, nil
 }

--- a/internal/commands/quench.go
+++ b/internal/commands/quench.go
@@ -105,6 +105,7 @@ func runQuench(_ *cobra.Command, args []string) error {
 
 	// Resolve current versions and write a fresh lock.
 	git := foundry.DefaultGitRunner()
+	fetcher, fetcherErr := foundry.NewFetcher(git)
 	newLock := &foundry.LockFile{APIVersion: "v1"}
 	for _, entry := range entries {
 		ref, err := referenceFromInstalledEntry(&entry)
@@ -112,18 +113,31 @@ func runQuench(_ *cobra.Command, args []string) error {
 			fmt.Printf("  %s skipping %s: %v\n", styles.WarningStyle.Render("!"), entry.Name, err)
 			continue
 		}
-		resolved, err := foundry.ResolveVersion(ref, git)
+		// Rank against the mold's declared version so release-train monorepo
+		// pins record the correct moldVersion. Fall back to plain resolution
+		// if the bare clone can't be prepared.
+		var resolved *foundry.ResolvedVersion
+		if fetcherErr == nil {
+			if reader, rerr := fetcher.MoldVersionReaderFor(ref); rerr == nil {
+				resolved, err = foundry.ResolveVersionWithMoldReader(ref, git, reader)
+			} else {
+				resolved, err = foundry.ResolveVersion(ref, git)
+			}
+		} else {
+			resolved, err = foundry.ResolveVersion(ref, git)
+		}
 		if err != nil {
 			fmt.Printf("  %s skipping %s: %v\n", styles.WarningStyle.Render("!"), entry.Name, err)
 			continue
 		}
 		newLock.UpsertEntry(foundry.LockEntry{
-			Name:      entry.Name,
-			Source:    entry.Source,
-			Version:   resolved.Tag,
-			Commit:    resolved.Commit,
-			Subpath:   entry.Subpath,
-			Timestamp: time.Now().UTC(),
+			Name:        entry.Name,
+			Source:      entry.Source,
+			Version:     resolved.Tag,
+			Commit:      resolved.Commit,
+			MoldVersion: resolved.MoldVersion,
+			Subpath:     entry.Subpath,
+			Timestamp:   time.Now().UTC(),
 		})
 		fmt.Printf("  %s  %s @ %s\n",
 			styles.FoxBullet(entry.Name),

--- a/pkg/foundry/depgraph/depgraph.go
+++ b/pkg/foundry/depgraph/depgraph.go
@@ -83,6 +83,13 @@ type FetchResult struct {
 	Commit  string // commit SHA
 }
 
+// TagInfo is one entry from a Fetcher.Tags listing: where the tag points and
+// the version the mold declared at that tag.
+type TagInfo struct {
+	SHA         string // commit SHA the tag points at
+	MoldVersion string // version declared in the mold's mold.yaml at the tag
+}
+
 // Fetcher abstracts the I/O the builder needs: resolving + loading a mold
 // at a given reference, and listing the available semver tags for a source.
 // Tests inject a fake; production wires this to foundry.ResolveWithMetadata
@@ -91,10 +98,12 @@ type Fetcher interface {
 	// Fetch resolves the reference (which may be a constraint, exact, branch,
 	// or SHA) to a concrete version and returns the parsed mold.yaml.
 	Fetch(ref *foundry.Reference) (FetchResult, error)
-	// Tags returns the available semver tags (tag → SHA) for the source. Used
-	// by the constraint solver to pick the highest version satisfying every
-	// accumulated constraint when more than one was encountered.
-	Tags(source, subpath string) (map[string]string, error)
+	// Tags returns the available semver tags for the source. Used by the
+	// constraint solver to pick the highest version satisfying every
+	// accumulated constraint when more than one was encountered. Each tag
+	// carries its mold.yaml version so constraints resolve correctly on
+	// release-train monorepos.
+	Tags(source, subpath string) (map[string]TagInfo, error)
 }
 
 // Builder builds dep graphs.
@@ -494,26 +503,23 @@ func isHex(s string) bool {
 	return true
 }
 
-// highestSatisfying picks the highest semver tag that satisfies every supplied
-// constraint. Returns (tag, sha, true) on success.
-func highestSatisfying(tags map[string]string, constraints []*semver.Constraints) (string, string, bool) {
+// highestSatisfying picks the highest-versioned tag that satisfies every
+// supplied constraint. Candidates are ranked by their mold.yaml version when
+// known, falling back to the tag-embedded semver. Returns (tag, sha, true) on
+// success.
+func highestSatisfying(tags map[string]TagInfo, constraints []*semver.Constraints) (string, string, bool) {
 	type entry struct {
-		tag string
-		sha string
-		ver *semver.Version
+		tag    string
+		sha    string
+		ver    *semver.Version // rank version (mold version when known)
+		tagVer *semver.Version // tag-embedded version, for tie-breaking
 	}
 	var candidates []entry
-	for tag, sha := range tags {
-		raw := strings.TrimPrefix(tag, "v")
-		// Allow prefixed tags like "wiki-v1.2.3" by trimming up to the last 'v'.
-		if i := strings.LastIndex(tag, "-v"); i >= 0 {
-			raw = tag[i+2:]
-		}
-		v, err := semver.NewVersion(raw)
-		if err != nil {
+	for tag, info := range tags {
+		v, ok := foundry.RankVersion(tag, info.MoldVersion)
+		if !ok {
 			continue
 		}
-		ok := true
 		for _, c := range constraints {
 			if !c.Check(v) {
 				ok = false
@@ -523,13 +529,24 @@ func highestSatisfying(tags map[string]string, constraints []*semver.Constraints
 		if !ok {
 			continue
 		}
-		candidates = append(candidates, entry{tag: tag, sha: sha, ver: v})
+		tagVer, _ := foundry.RankVersion(tag, "")
+		candidates = append(candidates, entry{tag: tag, sha: info.SHA, ver: v, tagVer: tagVer})
 	}
 	if len(candidates) == 0 {
 		return "", "", false
 	}
+	// Order by rank version, then by tag-embedded version as a tie-breaker:
+	// release-train monorepos share one mold version across many tags, so the
+	// newest tag is the right checkout pointer.
 	sort.Slice(candidates, func(i, j int) bool {
-		return candidates[i].ver.LessThan(candidates[j].ver)
+		a, b := candidates[i], candidates[j]
+		if !a.ver.Equal(b.ver) {
+			return a.ver.LessThan(b.ver)
+		}
+		if a.tagVer != nil && b.tagVer != nil && !a.tagVer.Equal(b.tagVer) {
+			return a.tagVer.LessThan(b.tagVer)
+		}
+		return a.tag < b.tag
 	})
 	best := candidates[len(candidates)-1]
 	return best.tag, best.sha, true

--- a/pkg/foundry/depgraph/depgraph_test.go
+++ b/pkg/foundry/depgraph/depgraph_test.go
@@ -13,14 +13,16 @@ import (
 // fakeFetcher is an in-memory Fetcher used by tests. It lets us assemble a
 // foundry of fake molds with declared tag lists without touching git.
 type fakeFetcher struct {
-	molds map[string]map[string]*mold.Mold // sourceKey -> version -> mold
-	tags  map[string]map[string]string     // sourceKey -> tag -> sha
+	molds       map[string]map[string]*mold.Mold // sourceKey -> version -> mold
+	tags        map[string]map[string]string     // sourceKey -> tag -> sha
+	moldVersion map[string]map[string]string     // sourceKey -> tag -> mold.yaml version
 }
 
 func newFakeFetcher() *fakeFetcher {
 	return &fakeFetcher{
-		molds: map[string]map[string]*mold.Mold{},
-		tags:  map[string]map[string]string{},
+		molds:       map[string]map[string]*mold.Mold{},
+		tags:        map[string]map[string]string{},
+		moldVersion: map[string]map[string]string{},
 	}
 }
 
@@ -99,7 +101,7 @@ func highestSatisfyingFromRaw(tags map[string]string, raw string) (string, strin
 	return best.tag, best.sha, true
 }
 
-func (f *fakeFetcher) Tags(source, subpath string) (map[string]string, error) {
+func (f *fakeFetcher) Tags(source, subpath string) (map[string]TagInfo, error) {
 	key := source
 	if subpath != "" {
 		key = source + "//" + subpath
@@ -108,9 +110,9 @@ func (f *fakeFetcher) Tags(source, subpath string) (map[string]string, error) {
 	if tags == nil {
 		return nil, errNotFound(key)
 	}
-	out := make(map[string]string, len(tags))
+	out := make(map[string]TagInfo, len(tags))
 	for k, v := range tags {
-		out[k] = v
+		out[k] = TagInfo{SHA: v, MoldVersion: f.moldVersion[key][k]}
 	}
 	return out, nil
 }
@@ -393,5 +395,53 @@ func TestBuild_SubpathDistinctIdentity(t *testing.T) {
 	}
 	if len(graph.Nodes) != 3 {
 		t.Errorf("expected 3 nodes (root + leaf-a + leaf-b), got %d", len(graph.Nodes))
+	}
+}
+
+func mustConstraint(t *testing.T, s string) *semver.Constraints {
+	t.Helper()
+	c, err := semver.NewConstraint(s)
+	if err != nil {
+		t.Fatalf("bad constraint %q: %v", s, err)
+	}
+	return c
+}
+
+// TestHighestSatisfying_MoldVersion exercises the release-train case: several
+// tags share one mold version, so the intersected constraints match them all
+// and the newest tag wins the tie-break.
+func TestHighestSatisfying_MoldVersion(t *testing.T) {
+	tags := map[string]TagInfo{
+		"launch-v0.6.0": {SHA: "sha60", MoldVersion: "0.2.1"},
+		"launch-v0.7.0": {SHA: "sha70", MoldVersion: "0.2.1"},
+		"launch-v0.7.1": {SHA: "sha71", MoldVersion: "0.2.1"},
+	}
+	constraints := []*semver.Constraints{
+		mustConstraint(t, "^0.2.0"),
+		mustConstraint(t, ">=0.2.1"),
+	}
+	tag, sha, ok := highestSatisfying(tags, constraints)
+	if !ok {
+		t.Fatal("expected a satisfying tag")
+	}
+	if tag != "launch-v0.7.1" {
+		t.Errorf("tag = %q, want launch-v0.7.1 (newest train tag)", tag)
+	}
+	if sha != "sha71" {
+		t.Errorf("sha = %q, want sha71", sha)
+	}
+}
+
+// TestHighestSatisfying_FallbackToTag confirms tags with no mold version are
+// ranked by their tag-embedded semver.
+func TestHighestSatisfying_FallbackToTag(t *testing.T) {
+	tags := map[string]TagInfo{
+		"v1.0.0": {SHA: "a"},
+		"v1.2.0": {SHA: "b"},
+		"v0.9.0": {SHA: "c"},
+	}
+	tag, sha, ok := highestSatisfying(tags, []*semver.Constraints{mustConstraint(t, "^1.0.0")})
+	if !ok || tag != "v1.2.0" || sha != "b" {
+		t.Errorf("got (%q, %q, %v), want (v1.2.0, b, true)", tag, sha, ok)
 	}
 }

--- a/pkg/foundry/depgraph/prod_fetcher.go
+++ b/pkg/foundry/depgraph/prod_fetcher.go
@@ -3,7 +3,6 @@ package depgraph
 import (
 	"fmt"
 	"io/fs"
-	"path"
 	"strings"
 
 	"github.com/nimble-giant/ailloy/pkg/foundry"
@@ -59,23 +58,24 @@ func (p *ProdFetcher) Fetch(ref *foundry.Reference) (FetchResult, error) {
 	if p.cache == nil {
 		p.cache = map[NodeKey]*ProdFetchCacheEntry{}
 	}
-	rawRef := refToRaw(ref)
 	var opts []foundry.ResolveOption
 	if p.LockPath != "" {
 		opts = append(opts, foundry.WithLockPath(p.LockPath))
 	}
-	fsys, result, err := foundry.ResolveWithMetadata(rawRef, opts...)
+	// Resolve from the *Reference directly so an explicitly-set Type (e.g. an
+	// exact pin to a monorepo-prefixed tag during constraint re-fetch) is not
+	// lost to a raw-string round-trip.
+	fsys, result, err := foundry.ResolveReferenceWithMetadata(ref, opts...)
 	if err != nil {
-		return FetchResult{}, fmt.Errorf("resolve %s: %w", rawRef, err)
+		return FetchResult{}, fmt.Errorf("resolve %s: %w", refToRaw(ref), err)
 	}
 
-	manifestPath := "mold.yaml"
-	if ref.Subpath != "" {
-		manifestPath = path.Join(strings.Trim(ref.Subpath, "/"), "mold.yaml")
-	}
-	m, err := mold.LoadMoldFromFS(fsys, manifestPath)
+	// foundry.ResolveWithMetadata already returns an fs.FS rooted at the
+	// mold directory (subpath navigation applied), so the manifest is at the
+	// fs root regardless of any subpath on the reference.
+	m, err := mold.LoadMoldFromFS(fsys, "mold.yaml")
 	if err != nil {
-		return FetchResult{}, fmt.Errorf("loading mold.yaml at %s: %w", manifestPath, err)
+		return FetchResult{}, fmt.Errorf("loading mold.yaml for %s: %w", refToRaw(ref), err)
 	}
 
 	key := NodeKey{Source: ref.CacheKey(), Subpath: ref.Subpath}
@@ -93,10 +93,53 @@ func (p *ProdFetcher) Fetch(ref *foundry.Reference) (FetchResult, error) {
 	}, nil
 }
 
-// Tags lists all semver tags for the given source+subpath via git ls-remote.
-func (p *ProdFetcher) Tags(source, subpath string) (map[string]string, error) {
+// Tags lists the semver tags for the given source+subpath via git ls-remote.
+// For monorepo subpath molds it also reads each tag's mold.yaml version so the
+// constraint solver ranks by the mold's own version rather than the shared
+// release-train version baked into the tag name. Tags whose mold manifest is
+// absent are dropped.
+func (p *ProdFetcher) Tags(source, subpath string) (map[string]TagInfo, error) {
 	url := "https://" + source + ".git"
-	return foundry.RemoteTags(url, subpath, p.GitRunner)
+	tags, err := foundry.RemoteTags(url, subpath, p.GitRunner)
+	if err != nil {
+		return nil, err
+	}
+
+	var reader foundry.MoldVersionReader
+	if strings.Trim(subpath, "/") != "" {
+		if r, rerr := p.moldVersionReader(source, subpath); rerr == nil {
+			reader = r
+		}
+	}
+
+	out := make(map[string]TagInfo, len(tags))
+	for tag, sha := range tags {
+		info := TagInfo{SHA: sha}
+		if reader != nil {
+			mv, found := reader(tag)
+			if !found {
+				continue // mold manifest absent at this tag
+			}
+			info.MoldVersion = mv
+		}
+		out[tag] = info
+	}
+	return out, nil
+}
+
+// moldVersionReader builds a foundry.MoldVersionReader for the given
+// source+subpath, backed by a bare clone.
+func (p *ProdFetcher) moldVersionReader(source, subpath string) (foundry.MoldVersionReader, error) {
+	ref, err := foundry.ParseReference(source)
+	if err != nil {
+		return nil, err
+	}
+	ref.Subpath = subpath
+	fetcher, err := foundry.NewFetcher(p.GitRunner)
+	if err != nil {
+		return nil, err
+	}
+	return fetcher.MoldVersionReaderFor(ref)
 }
 
 // refToRaw renders a Reference back to a raw string suitable for

--- a/pkg/foundry/fetcher.go
+++ b/pkg/foundry/fetcher.go
@@ -6,6 +6,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+
+	"github.com/goccy/go-yaml"
 )
 
 // Fetcher clones and checks out mold versions from git repositories.
@@ -44,6 +47,54 @@ func (f *Fetcher) Fetch(ref *Reference, resolved *ResolvedVersion) (fs.FS, strin
 	}
 
 	return f.navigateSubpath(ref, resolved)
+}
+
+// MoldVersionReaderFor returns a MoldVersionReader that reads the `version:`
+// field of the reference's mold.yaml at any given git tag. It ensures the
+// bare clone exists once, then serves each lookup with `git show <tag>:<path>`
+// against the local clone — cheap and offline. Results are memoised per tag.
+//
+// The reader reports found=false when no mold manifest exists at a tag (the
+// caller excludes that candidate), and found=true with an empty version when
+// the manifest exists but declares no version (the caller falls back to the
+// tag-embedded semver).
+func (f *Fetcher) MoldVersionReaderFor(ref *Reference) (MoldVersionReader, error) {
+	if err := f.ensureBareClone(ref); err != nil {
+		return nil, fmt.Errorf("ensuring bare clone: %w", err)
+	}
+	bareDir := BareCloneDir(f.cacheDir, ref)
+
+	manifestPath := "mold.yaml"
+	if sp := strings.Trim(ref.Subpath, "/"); sp != "" {
+		manifestPath = sp + "/mold.yaml" // git object paths are always forward-slash
+	}
+
+	type result struct {
+		version string
+		found   bool
+	}
+	var mu sync.Mutex
+	cache := map[string]result{}
+
+	return func(tag string) (string, bool) {
+		mu.Lock()
+		defer mu.Unlock()
+		if r, ok := cache[tag]; ok {
+			return r.version, r.found
+		}
+		out, err := f.git("-C", bareDir, "show", tag+":"+manifestPath)
+		r := result{found: err == nil}
+		if r.found {
+			var m struct {
+				Version string `yaml:"version"`
+			}
+			if yaml.Unmarshal(out, &m) == nil {
+				r.version = m.Version
+			}
+		}
+		cache[tag] = r
+		return r.version, r.found
+	}, nil
 }
 
 // ensureBareClone creates or updates the bare clone for the reference.

--- a/pkg/foundry/fetcher_test.go
+++ b/pkg/foundry/fetcher_test.go
@@ -238,3 +238,54 @@ func TestFetcher_Fetch_CacheHit(t *testing.T) {
 		t.Errorf("expected cached content, got %q", got)
 	}
 }
+
+func TestMoldVersionReaderFor(t *testing.T) {
+	cacheDir := t.TempDir()
+	ref := &Reference{Host: "github.com", Owner: "o", Repo: "foundry", Subpath: "molds/launch"}
+
+	shows := 0
+	git := func(args ...string) ([]byte, error) {
+		// clone --bare <url> <bareDir>
+		if len(args) >= 4 && args[0] == "clone" && args[1] == "--bare" {
+			if err := os.MkdirAll(args[3], 0750); err != nil {
+				return nil, err
+			}
+			return nil, os.WriteFile(filepath.Join(args[3], "HEAD"), []byte("ref: refs/heads/main"), 0644)
+		}
+		// -C <bareDir> show <tag>:molds/launch/mold.yaml
+		if len(args) == 4 && args[0] == "-C" && args[2] == "show" {
+			shows++
+			switch args[3] {
+			case "launch-v0.7.1:molds/launch/mold.yaml":
+				return []byte("name: replicated-launch\nversion: 0.2.1\n"), nil
+			case "launch-v0.6.0:molds/launch/mold.yaml":
+				return []byte("name: replicated-launch\n"), nil // manifest present, no version
+			default:
+				return nil, fmt.Errorf("fatal: path does not exist")
+			}
+		}
+		return nil, fmt.Errorf("unexpected git call: %v", args)
+	}
+
+	reader, err := NewFetcherWithCacheDir(git, cacheDir).MoldVersionReaderFor(ref)
+	if err != nil {
+		t.Fatalf("MoldVersionReaderFor: %v", err)
+	}
+
+	if v, found := reader("launch-v0.7.1"); !found || v != "0.2.1" {
+		t.Errorf("launch-v0.7.1 = (%q, %v), want (0.2.1, true)", v, found)
+	}
+	if v, found := reader("launch-v0.6.0"); !found || v != "" {
+		t.Errorf("launch-v0.6.0 = (%q, %v), want (\"\", true) — manifest present, no version", v, found)
+	}
+	if v, found := reader("launch-v0.5.0"); found || v != "" {
+		t.Errorf("launch-v0.5.0 = (%q, %v), want (\"\", false) — manifest absent", v, found)
+	}
+
+	// Results are memoised per tag: a repeat lookup issues no new git show.
+	before := shows
+	reader("launch-v0.7.1")
+	if shows != before {
+		t.Errorf("repeat lookup issued %d extra git show calls, want 0", shows-before)
+	}
+}

--- a/pkg/foundry/foundry.go
+++ b/pkg/foundry/foundry.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -168,6 +169,20 @@ func ResolveWithMetadata(rawRef string, opts ...ResolveOption) (fs.FS, *ResolveR
 	return fsys, result, nil
 }
 
+// ResolveReferenceWithMetadata is like ResolveWithMetadata but takes an
+// already-parsed *Reference. Use this when the caller has set Type explicitly
+// (e.g. pinning an exact tag): round-tripping through a raw string would
+// re-run classifyVersion and could misclassify a monorepo-prefixed tag name
+// such as `launch-v0.7.1` as a branch.
+func ResolveReferenceWithMetadata(ref *Reference, opts ...ResolveOption) (fs.FS, *ResolveResult, error) {
+	git := DefaultGitRunner()
+	fsys, result, err := resolveWithMeta(ref, git, opts...)
+	if err != nil {
+		return nil, nil, err
+	}
+	return fsys, result, nil
+}
+
 // resolveWithMeta is the internal implementation; mirrors ResolveWith but also
 // returns the ResolvedVersion alongside the fs.FS.
 func resolveWithMeta(ref *Reference, git GitRunner, opts ...ResolveOption) (fs.FS, *ResolveResult, error) {
@@ -193,18 +208,27 @@ func resolveWithMeta(ref *Reference, git GitRunner, opts ...ResolveOption) (fs.F
 		}
 	}
 
+	fetcher, err := NewFetcher(git)
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating fetcher: %w", err)
+	}
+
 	if resolved == nil {
-		v, resolveErr := ResolveVersion(ref, git)
+		// Rank candidate tags by the dependency mold's declared mold.yaml
+		// version (release-train monorepos tag every mold with a shared
+		// train version). The reader is backed by the same bare clone the
+		// fetch below uses, so this adds no extra network round-trip.
+		reader, rerr := fetcher.MoldVersionReaderFor(ref)
+		if rerr != nil {
+			return nil, nil, fmt.Errorf("resolving version: %w", rerr)
+		}
+		v, resolveErr := ResolveVersionWithMoldReader(ref, git, reader)
 		if resolveErr != nil {
 			return nil, nil, fmt.Errorf("resolving version: %w", resolveErr)
 		}
 		resolved = v
 	}
 
-	fetcher, err := NewFetcher(git)
-	if err != nil {
-		return nil, nil, fmt.Errorf("creating fetcher: %w", err)
-	}
 	fsys, root, err := fetcher.Fetch(ref, resolved)
 	if err != nil {
 		return nil, nil, fmt.Errorf("fetching mold: %w", err)
@@ -230,16 +254,41 @@ func lockedSatisfies(ref *Reference, entry *LockEntry) bool {
 		if err != nil {
 			return false
 		}
-		v, err := semver.NewVersion(entry.Version)
-		if err != nil {
+		v := lockEntryVersion(entry)
+		if v == nil {
 			return false
 		}
 		return c.Check(v)
 	case Exact:
+		// On a release-train monorepo the exact version is the mold's own
+		// version; match it against the recorded mold version when present.
+		if entry.MoldVersion != "" {
+			want, e1 := semver.NewVersion(strings.TrimPrefix(ref.Version, "v"))
+			got, e2 := semver.NewVersion(entry.MoldVersion)
+			if e1 == nil && e2 == nil {
+				return want.Equal(got)
+			}
+		}
 		return entry.Version == ref.Version || entry.Version == "v"+ref.Version
 	default:
 		return false
 	}
+}
+
+// lockEntryVersion returns the semver a constraint should be checked against:
+// the recorded mold.yaml version when present (release-train monorepos), else
+// the tag-embedded version. Returns nil when neither parses (old locks with a
+// prefixed tag and no mold version simply re-resolve once).
+func lockEntryVersion(entry *LockEntry) *semver.Version {
+	if entry.MoldVersion != "" {
+		if v, err := semver.NewVersion(entry.MoldVersion); err == nil {
+			return v
+		}
+	}
+	if v, err := semver.NewVersion(entry.Version); err == nil {
+		return v
+	}
+	return nil
 }
 
 // updateLockAt reads, upserts, and writes the lock at the given path.
@@ -252,12 +301,13 @@ func updateLockAt(path string, ref *Reference, resolved *ResolvedVersion) error 
 		lock = &LockFile{APIVersion: "v1"}
 	}
 	lock.UpsertEntry(LockEntry{
-		Name:      ref.Repo,
-		Source:    ref.CacheKey(),
-		Version:   resolved.Tag,
-		Commit:    resolved.Commit,
-		Subpath:   ref.Subpath,
-		Timestamp: time.Now().UTC(),
+		Name:        ref.Repo,
+		Source:      ref.CacheKey(),
+		Version:     resolved.Tag,
+		Commit:      resolved.Commit,
+		MoldVersion: resolved.MoldVersion,
+		Subpath:     ref.Subpath,
+		Timestamp:   time.Now().UTC(),
 	})
 	return WriteLockFile(path, lock)
 }

--- a/pkg/foundry/foundry_test.go
+++ b/pkg/foundry/foundry_test.go
@@ -58,6 +58,30 @@ func TestLockedSatisfies(t *testing.T) {
 			want:  false,
 		},
 		{
+			name:  "constraint checked against mold version when recorded",
+			ref:   &Reference{Type: Constraint, Version: "^0.2.0"},
+			entry: &LockEntry{Version: "launch-v0.7.1", MoldVersion: "0.2.1"},
+			want:  true,
+		},
+		{
+			name:  "old lock without mold version re-resolves (prefixed tag unparseable)",
+			ref:   &Reference{Type: Constraint, Version: "^0.2.0"},
+			entry: &LockEntry{Version: "launch-v0.7.1"},
+			want:  false,
+		},
+		{
+			name:  "exact matched against mold version",
+			ref:   &Reference{Type: Exact, Version: "0.2.1"},
+			entry: &LockEntry{Version: "launch-v0.7.1", MoldVersion: "0.2.1"},
+			want:  true,
+		},
+		{
+			name:  "exact mismatched against mold version",
+			ref:   &Reference{Type: Exact, Version: "0.3.0"},
+			entry: &LockEntry{Version: "launch-v0.7.1", MoldVersion: "0.2.1"},
+			want:  false,
+		},
+		{
 			name:  "branch never satisfies",
 			ref:   &Reference{Type: Branch, Version: "main"},
 			entry: &LockEntry{Version: "main"},

--- a/pkg/foundry/index/temper.go
+++ b/pkg/foundry/index/temper.go
@@ -64,7 +64,10 @@ func Temper(path string, opts TemperOptions) (*TemperResult, error) {
 //  2. Schema validation via Index.Validate(). Failures here short-circuit
 //     remaining checks (returning a TemperResult with one finding).
 //  3. (network) Per direct mold: parse the source ref and resolve it on the
-//     remote via git ls-remote. Each failure is reported as a finding.
+//     remote via git ls-remote (no clone). Each failure is reported as a
+//     finding. Constraint checks here use the tag-embedded semver — temper
+//     stays clone-free, so for release-train monorepos (where constraints
+//     match the mold.yaml version) this is a conservative existence check.
 //  4. (network, unless NoRecurse) Per nested foundry: fetch the child index,
 //     run the same checks recursively. Cycles are silently broken via a
 //     visited-set keyed on canonical source URL.

--- a/pkg/foundry/lock.go
+++ b/pkg/foundry/lock.go
@@ -17,13 +17,18 @@ const LockFileName = "ailloy.lock"
 // on InstalledEntry, not here — that keeps uninstall working when the lock
 // is not opted into.
 type LockEntry struct {
-	Name      string    `yaml:"name"`
-	Source    string    `yaml:"source"`
-	Version   string    `yaml:"version"`
-	Commit    string    `yaml:"commit"`
-	Subpath   string    `yaml:"subpath,omitempty"`
-	Alias     string    `yaml:"alias,omitempty"` // populated when ore was installed --as <alias>
-	Timestamp time.Time `yaml:"timestamp"`
+	Name    string `yaml:"name"`
+	Source  string `yaml:"source"`
+	Version string `yaml:"version"`
+	Commit  string `yaml:"commit"`
+	// MoldVersion is the version declared in the mold's mold.yaml at Version.
+	// It differs from Version on release-train monorepos, where the git tag
+	// carries a shared train version. Constraint checks against the lock use
+	// this when present. Omitted for single-mold repos (tag == mold version).
+	MoldVersion string    `yaml:"moldVersion,omitempty"`
+	Subpath     string    `yaml:"subpath,omitempty"`
+	Alias       string    `yaml:"alias,omitempty"` // populated when ore was installed --as <alias>
+	Timestamp   time.Time `yaml:"timestamp"`
 }
 
 // LockFile is the on-disk lock file format.

--- a/pkg/foundry/resolver.go
+++ b/pkg/foundry/resolver.go
@@ -27,7 +27,24 @@ func DefaultGitRunner() GitRunner {
 type ResolvedVersion struct {
 	Tag    string // semver tag (e.g. "v1.2.3"), or branch name for branch pins
 	Commit string // full commit SHA
+	// MoldVersion is the version declared in the mold's mold.yaml at Tag.
+	// Empty when no MoldVersionReader was supplied or the mold declared no
+	// parseable version (in which case the constraint was matched against
+	// the tag-embedded semver).
+	MoldVersion string
 }
+
+// MoldVersionReader reports the version declared in a mold's mold.yaml at a
+// given git tag. found=false means no mold manifest exists at that tag (the
+// candidate tag is then excluded). found=true with an empty version means the
+// manifest exists but declares no parseable version, so callers fall back to
+// the tag-embedded semver.
+//
+// Release-train monorepos tag every mold with a shared train version
+// (`launch-v0.7.1`, `ce-v0.7.1`, ...) while each mold carries its own semver
+// in mold.yaml. A reader lets the resolver rank candidates by the mold's own
+// version rather than the train version baked into the tag name.
+type MoldVersionReader func(tag string) (version string, found bool)
 
 // tagRef matches a line from git ls-remote --tags, e.g.:
 // abc123\trefs/tags/v1.0.0
@@ -55,16 +72,49 @@ func parseSemverTag(tag string) (prefix, normalized string, ok bool) {
 	return "", "", false
 }
 
+// RankVersion returns the semver used to rank a candidate tag against a
+// version constraint. When moldVersion is non-empty it is authoritative — the
+// mold declares its own version in mold.yaml, which on a release-train
+// monorepo differs from the version baked into the tag name. Otherwise the
+// version embedded in the tag name is used as a fallback (single-mold repos,
+// or molds with no parseable version field).
+func RankVersion(tag, moldVersion string) (*semver.Version, bool) {
+	if moldVersion != "" {
+		if v, err := semver.NewVersion(moldVersion); err == nil {
+			return v, true
+		}
+	}
+	_, normalized, ok := parseSemverTag(tag)
+	if !ok {
+		return nil, false
+	}
+	v, err := semver.NewVersion(normalized)
+	if err != nil {
+		return nil, false
+	}
+	return v, true
+}
+
 // ResolveVersion resolves a Reference to a concrete tag + commit SHA using
-// git ls-remote. It does not require a local clone.
+// git ls-remote. It does not require a local clone, and ranks candidate tags
+// by their tag-embedded semver. For release-train monorepos use
+// ResolveVersionWithMoldReader.
 func ResolveVersion(ref *Reference, git GitRunner) (*ResolvedVersion, error) {
+	return ResolveVersionWithMoldReader(ref, git, nil)
+}
+
+// ResolveVersionWithMoldReader is like ResolveVersion but ranks candidate
+// tags by the dependency mold's declared mold.yaml version (supplied by
+// reader) instead of the tag-embedded semver. A nil reader behaves exactly
+// like ResolveVersion.
+func ResolveVersionWithMoldReader(ref *Reference, git GitRunner, reader MoldVersionReader) (*ResolvedVersion, error) {
 	switch ref.Type {
 	case Latest:
-		return resolveLatest(ref, git)
+		return resolveLatest(ref, git, reader)
 	case Exact:
-		return resolveExact(ref, git)
+		return resolveExact(ref, git, reader)
 	case Constraint:
-		return resolveConstraint(ref, git)
+		return resolveConstraint(ref, git, reader)
 	case Branch:
 		return resolveBranch(ref, git)
 	case SHA:
@@ -176,25 +226,29 @@ func selectTagsForPrefix(all map[string]string, prefix string) map[string]string
 	return plain
 }
 
-// resolveLatest picks the highest semver tag, preferring monorepo-prefixed
-// tags (`<subpath>-v*`) when the reference has a Subpath.
-func resolveLatest(ref *Reference, git GitRunner) (*ResolvedVersion, error) {
+// resolveLatest picks the highest-versioned tag, preferring monorepo-prefixed
+// tags (`<subpath>-v*`) when the reference has a Subpath. With a reader,
+// candidates are ranked by their mold.yaml version.
+func resolveLatest(ref *Reference, git GitRunner, reader MoldVersionReader) (*ResolvedVersion, error) {
 	all, err := remoteTags(ref.CloneURL(), git)
 	if err != nil {
 		return nil, err
 	}
 	tags := selectTagsForPrefix(all, ref.ReleasePrefix())
-	tag, sha, err := highestVersion(tags, nil)
+	tag, sha, moldVersion, err := highestVersion(tags, nil, reader)
 	if err != nil {
 		return nil, fmt.Errorf("no semver tags found for %s", ref.CacheKey())
 	}
-	return &ResolvedVersion{Tag: tag, Commit: sha}, nil
+	return &ResolvedVersion{Tag: tag, Commit: sha, MoldVersion: moldVersion}, nil
 }
 
 // resolveExact finds the exact tag matching the specified version. When the
 // reference has a Subpath, prefixed candidates (`<prefix>-v1.2.3`) are tried
-// before plain ones.
-func resolveExact(ref *Reference, git GitRunner) (*ResolvedVersion, error) {
+// before plain ones. With a reader, an exact version that matches no literal
+// tag name is matched against the declared mold.yaml versions instead — on a
+// release-train monorepo `@0.2.1` is the mold's own version, which lives at a
+// differently-named tag (e.g. `launch-v0.7.1`).
+func resolveExact(ref *Reference, git GitRunner, reader MoldVersionReader) (*ResolvedVersion, error) {
 	tags, err := remoteTags(ref.CloneURL(), git)
 	if err != nil {
 		return nil, err
@@ -217,13 +271,49 @@ func resolveExact(ref *Reference, git GitRunner) (*ResolvedVersion, error) {
 			return &ResolvedVersion{Tag: tag, Commit: sha}, nil
 		}
 	}
+
+	if reader != nil {
+		if rv, ok := resolveExactByMoldVersion(ref, tags, reader); ok {
+			return rv, nil
+		}
+	}
 	return nil, fmt.Errorf("tag %q not found in %s", ref.Version, ref.CacheKey())
+}
+
+// resolveExactByMoldVersion finds the tag whose mold.yaml version equals the
+// reference's exact version. When several tags carry the same mold version
+// (the mold was unchanged across release-train releases) the one with the
+// highest tag-embedded semver wins, so the newest checkout pointer is used.
+func resolveExactByMoldVersion(ref *Reference, all map[string]string, reader MoldVersionReader) (*ResolvedVersion, bool) {
+	want, err := semver.NewVersion(strings.TrimPrefix(ref.Version, "v"))
+	if err != nil {
+		return nil, false
+	}
+	tags := selectTagsForPrefix(all, ref.ReleasePrefix())
+	var best *ResolvedVersion
+	var bestRank *semver.Version
+	for tag, sha := range tags {
+		mv, found := reader(tag)
+		if !found || mv == "" {
+			continue
+		}
+		v, err := semver.NewVersion(mv)
+		if err != nil || !v.Equal(want) {
+			continue
+		}
+		rank, ok := RankVersion(tag, "")
+		if best == nil || (ok && bestRank != nil && bestRank.LessThan(rank)) {
+			best = &ResolvedVersion{Tag: tag, Commit: sha, MoldVersion: mv}
+			bestRank = rank
+		}
+	}
+	return best, best != nil
 }
 
 // resolveConstraint matches a semver constraint against available tags. When
 // the reference has a Subpath, the constraint is evaluated against the
 // monorepo-prefixed tags for that subpath when any exist.
-func resolveConstraint(ref *Reference, git GitRunner) (*ResolvedVersion, error) {
+func resolveConstraint(ref *Reference, git GitRunner, reader MoldVersionReader) (*ResolvedVersion, error) {
 	c, err := semver.NewConstraint(ref.Version)
 	if err != nil {
 		return nil, fmt.Errorf("invalid semver constraint %q: %w", ref.Version, err)
@@ -235,11 +325,11 @@ func resolveConstraint(ref *Reference, git GitRunner) (*ResolvedVersion, error) 
 	}
 	tags := selectTagsForPrefix(all, ref.ReleasePrefix())
 
-	tag, sha, err := highestVersion(tags, c)
+	tag, sha, moldVersion, err := highestVersion(tags, c, reader)
 	if err != nil {
 		return nil, fmt.Errorf("no tag matching %q for %s", ref.Version, ref.CacheKey())
 	}
-	return &ResolvedVersion{Tag: tag, Commit: sha}, nil
+	return &ResolvedVersion{Tag: tag, Commit: sha, MoldVersion: moldVersion}, nil
 }
 
 // resolveBranch resolves a branch pin to its HEAD commit.
@@ -264,39 +354,65 @@ func resolveBranch(ref *Reference, git GitRunner) (*ResolvedVersion, error) {
 	return nil, fmt.Errorf("branch %q not found in %s", ref.Version, ref.CacheKey())
 }
 
-// highestVersion picks the highest semver version from a tag map, optionally
-// filtered by a constraint. Returns the tag name, SHA, and nil error on success.
-func highestVersion(tags map[string]string, c *semver.Constraints) (string, string, error) {
+// highestVersion picks the highest-versioned tag from a tag map, optionally
+// filtered by a constraint. Candidates are ranked by their mold.yaml version
+// when reader is non-nil; tags whose mold manifest is absent (reader reports
+// found=false) are excluded. Returns the tag name, SHA, the mold version used
+// for ranking (empty when ranked by the tag-embedded semver), and a nil error
+// on success.
+func highestVersion(tags map[string]string, c *semver.Constraints, reader MoldVersionReader) (string, string, string, error) {
 	type entry struct {
-		tag string
-		ver *semver.Version
-		sha string
+		tag         string
+		ver         *semver.Version // rank version (mold version when known)
+		tagVer      *semver.Version // tag-embedded version, for tie-breaking
+		sha         string
+		moldVersion string
 	}
 
 	var entries []entry
 	for tag, sha := range tags {
-		_, normalized, ok := parseSemverTag(tag)
-		if !ok {
-			continue
+		var moldVersion string
+		if reader != nil {
+			v, found := reader(tag)
+			if !found {
+				continue // mold manifest absent at this tag
+			}
+			moldVersion = v
 		}
-		v, err := semver.NewVersion(normalized)
-		if err != nil {
+		v, ok := RankVersion(tag, moldVersion)
+		if !ok {
 			continue
 		}
 		if c != nil && !c.Check(v) {
 			continue
 		}
-		entries = append(entries, entry{tag: tag, ver: v, sha: sha})
+		tagVer, _ := RankVersion(tag, "")
+		entries = append(entries, entry{tag: tag, ver: v, tagVer: tagVer, sha: sha, moldVersion: moldVersion})
 	}
 
 	if len(entries) == 0 {
-		return "", "", fmt.Errorf("no matching versions")
+		return "", "", "", fmt.Errorf("no matching versions")
 	}
 
 	sort.Slice(entries, func(i, j int) bool {
-		return entries[i].ver.LessThan(entries[j].ver)
+		return lessEntry(entries[i].ver, entries[i].tagVer, entries[i].tag,
+			entries[j].ver, entries[j].tagVer, entries[j].tag)
 	})
 
 	best := entries[len(entries)-1]
-	return best.tag, best.sha, nil
+	return best.tag, best.sha, best.moldVersion, nil
+}
+
+// lessEntry orders candidates by rank version, then by the tag-embedded
+// version as a tie-breaker (release-train monorepos share one mold version
+// across many tags — the newest tag is the right checkout pointer), then by
+// tag name for total determinism.
+func lessEntry(vi, ti *semver.Version, tagI string, vj, tj *semver.Version, tagJ string) bool {
+	if !vi.Equal(vj) {
+		return vi.LessThan(vj)
+	}
+	if ti != nil && tj != nil && !ti.Equal(tj) {
+		return ti.LessThan(tj)
+	}
+	return tagI < tagJ
 }

--- a/pkg/foundry/resolver_test.go
+++ b/pkg/foundry/resolver_test.go
@@ -207,7 +207,7 @@ func TestHighestVersion(t *testing.T) {
 		"v0.9.0": "sha4",
 	}
 
-	tag, sha, err := highestVersion(tags, nil)
+	tag, sha, _, err := highestVersion(tags, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -220,7 +220,7 @@ func TestHighestVersion(t *testing.T) {
 }
 
 func TestHighestVersion_Empty(t *testing.T) {
-	_, _, err := highestVersion(map[string]string{}, nil)
+	_, _, _, err := highestVersion(map[string]string{}, nil, nil)
 	if err == nil {
 		t.Fatal("expected error for empty tags")
 	}
@@ -370,5 +370,124 @@ func TestReference_ReleasePrefix(t *testing.T) {
 		if got := ref.ReleasePrefix(); got != tc.want {
 			t.Errorf("ReleasePrefix(subpath=%q) = %q, want %q", tc.subpath, got, tc.want)
 		}
+	}
+}
+
+// trainTagsOutput models a release-train monorepo: every mold is tagged with
+// the foundry's shared train version on each release, so `launch-v*` tags do
+// not encode the launch mold's own version (which lives in mold.yaml).
+const trainTagsOutput = `1111111111111111111111111111111111111111	refs/tags/launch-v0.5.0
+2222222222222222222222222222222222222222	refs/tags/launch-v0.6.0
+3333333333333333333333333333333333333333	refs/tags/launch-v0.7.0
+4444444444444444444444444444444444444444	refs/tags/launch-v0.7.1
+5555555555555555555555555555555555555555	refs/tags/ce-v0.7.1
+`
+
+// launchMoldVersions is a MoldVersionReader for the launch mold: it exists
+// from launch-v0.6.0 onward, always declaring version 0.2.1. launch-v0.5.0
+// predates the mold and ce-v0.7.1 carries a different mold entirely.
+func launchMoldVersions(tag string) (string, bool) {
+	switch tag {
+	case "launch-v0.6.0", "launch-v0.7.0", "launch-v0.7.1":
+		return "0.2.1", true
+	default:
+		return "", false // mold manifest absent at this tag
+	}
+}
+
+func trainGit(t *testing.T) GitRunner {
+	t.Helper()
+	return mockGitRunner(map[string]string{
+		"[ls-remote --tags https://github.com/replicated-collab/foundry.git]": trainTagsOutput,
+	})
+}
+
+func launchRef(version string, typ RefType) *Reference {
+	return &Reference{
+		Host: "github.com", Owner: "replicated-collab", Repo: "foundry",
+		Subpath: "molds/launch", Version: version, Type: typ,
+	}
+}
+
+// TestResolveConstraint_MoldVersion is the issue #228 scenario: `^0.2.0` is
+// matched against the launch mold's declared version (0.2.1), not the version
+// in the tag name. Three tags carry mold version 0.2.1 — the newest train tag
+// wins the tie-break.
+func TestResolveConstraint_MoldVersion(t *testing.T) {
+	ref := launchRef("^0.2.0", Constraint)
+	resolved, err := ResolveVersionWithMoldReader(ref, trainGit(t), launchMoldVersions)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resolved.Tag != "launch-v0.7.1" {
+		t.Errorf("Tag = %q, want launch-v0.7.1", resolved.Tag)
+	}
+	if resolved.MoldVersion != "0.2.1" {
+		t.Errorf("MoldVersion = %q, want 0.2.1", resolved.MoldVersion)
+	}
+}
+
+func TestResolveConstraint_MoldVersion_NoMatch(t *testing.T) {
+	ref := launchRef("^0.3.0", Constraint)
+	if _, err := ResolveVersionWithMoldReader(ref, trainGit(t), launchMoldVersions); err == nil {
+		t.Fatal("expected error: no mold version satisfies ^0.3.0")
+	}
+}
+
+func TestResolveLatest_MoldVersion(t *testing.T) {
+	ref := launchRef("", Latest)
+	resolved, err := ResolveVersionWithMoldReader(ref, trainGit(t), launchMoldVersions)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// All present tags share mold version 0.2.1; the newest train tag wins.
+	if resolved.Tag != "launch-v0.7.1" {
+		t.Errorf("Tag = %q, want launch-v0.7.1", resolved.Tag)
+	}
+}
+
+func TestResolveExact_ByMoldVersion(t *testing.T) {
+	ref := launchRef("0.2.1", Exact)
+	resolved, err := ResolveVersionWithMoldReader(ref, trainGit(t), launchMoldVersions)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resolved.Tag != "launch-v0.7.1" {
+		t.Errorf("Tag = %q, want launch-v0.7.1 (mold version 0.2.1)", resolved.Tag)
+	}
+	if resolved.MoldVersion != "0.2.1" {
+		t.Errorf("MoldVersion = %q, want 0.2.1", resolved.MoldVersion)
+	}
+}
+
+func TestResolveExact_ByMoldVersion_NoMatch(t *testing.T) {
+	ref := launchRef("9.9.9", Exact)
+	if _, err := ResolveVersionWithMoldReader(ref, trainGit(t), launchMoldVersions); err == nil {
+		t.Fatal("expected error: no tag declares mold version 9.9.9")
+	}
+}
+
+// TestResolveConstraint_FallbackEmptyMoldVersion verifies that when a mold
+// manifest exists but declares no version, the resolver falls back to ranking
+// by the tag-embedded semver.
+func TestResolveConstraint_FallbackEmptyMoldVersion(t *testing.T) {
+	emptyReader := func(tag string) (string, bool) { return "", true }
+	ref := launchRef(">=0.6.0", Constraint)
+	resolved, err := ResolveVersionWithMoldReader(ref, trainGit(t), emptyReader)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resolved.Tag != "launch-v0.7.1" {
+		t.Errorf("Tag = %q, want launch-v0.7.1 (ranked by tag-embedded version)", resolved.Tag)
+	}
+}
+
+// TestResolveConstraint_NilReaderUsesTagVersion confirms the nil-reader path
+// (plain ResolveVersion) is unchanged: constraints match the tag-embedded
+// version, so a mold-version constraint like ^0.2.0 finds nothing here.
+func TestResolveConstraint_NilReaderUsesTagVersion(t *testing.T) {
+	ref := launchRef("^0.2.0", Constraint)
+	if _, err := ResolveVersion(ref, trainGit(t)); err == nil {
+		t.Fatal("expected error: tag-embedded versions are 0.5-0.7, not ^0.2.0")
 	}
 }


### PR DESCRIPTION
## Description

Mold dependency version constraints now resolve against the dependency mold's declared `mold.yaml` `version:` field instead of the version embedded in the git tag name, with a fallback to the tag-embedded semver for single-mold repos. This fixes resolution for release-train monorepos, where every mold is tagged with a shared train version (e.g. `launch-v0.7.1`) while each mold carries its own semver in `mold.yaml`. The change also fixes two latent bugs in the transitive-dep path it exposed: `ProdFetcher.Fetch` double-applied the subpath when loading `mold.yaml`, and `resolveAll`'s re-fetch lost the exact `Type` by round-tripping a `Reference` through a raw string (misclassifying a prefixed tag as a branch).

## Related Issue

Fixes #228

## Testing

Added unit tests in `resolver_test.go`, `fetcher_test.go`, `foundry_test.go`, and `depgraph_test.go` covering mold-version constraint/latest/exact resolution, the tag-embedded fallback, the tie-break across release-train tags, and lock-entry mold-version matching. Verified `go build ./...`, `go vet`, `gofmt`, `golangci-lint`, and the full `go test ./...` suite all pass.

## UAT

Run `ailloy cast github.com/replicated-collab/foundry//molds/support-sandbox` in an empty directory: it should now succeed, resolving `launch` (`^0.2.0`) to `launch-v0.7.1` and `replicated-cli` (`^0.1.0`) to `replicated-cli-v0.2.0`.

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests (if applicable)
- [x] I have updated documentation (if applicable)
- [x] My commits have DCO sign-off (`git commit -s`)