### PR TITLE
fix: gofmt two test files broken by ai-lce merge (ai-xlm)

### DIFF
--- a/internal/commands/forge_ore_overlay_test.go
+++ b/internal/commands/forge_ore_overlay_test.go
@@ -31,4 +31,3 @@ func TestPrintForgeDebugProvenance_FormatsRowsByOrigin(t *testing.T) {
 		t.Errorf("missing dest/src paths: %s", out)
 	}
 }
-

--- a/pkg/mold/output_composite_test.go
+++ b/pkg/mold/output_composite_test.go
@@ -220,8 +220,8 @@ func TestResolveFilesWithOreSources_DestPathDedup_OreOreConflictErrors(t *testin
 // to the same DestPath: consumer-origin wins via DestPath deduplication.
 func TestResolveFilesWithOreSources_DestPathDedup_ConsumerWins(t *testing.T) {
 	moldFS := fstest.MapFS{
-		"mold.yaml":    &fstest.MapFile{Data: []byte("name: c\n")},
-		"consumer.md":  &fstest.MapFile{Data: []byte("# consumer\n")},
+		"mold.yaml":   &fstest.MapFile{Data: []byte("name: c\n")},
+		"consumer.md": &fstest.MapFile{Data: []byte("# consumer\n")},
 	}
 	oreFS := fstest.MapFS{"ore.md": &fstest.MapFile{Data: []byte("# ore\n")}}
 	output := map[string]any{"consumer.md": "out.md"}


### PR DESCRIPTION
## Summary

- Run `gofmt -w` on `internal/commands/forge_ore_overlay_test.go` and `pkg/mold/output_composite_test.go`
- `forge_ore_overlay_test.go`: removed trailing blank line
- `output_composite_test.go`: fixed map literal key alignment

Unblocks main CI after ai-lce merged without a PR.

## Test plan

- [ ] `gofmt -l` on both files returns empty (no issues)
- [ ] `go build ./...` passes
- [ ] CI green on main after merge

Refs: ai-xlm

🤖 Generated with [Claude Code](https://claude.com/claude-code)