### PR TITLE
ci: pin govulncheck to v1.1.3 to fix panic on generic types

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -34,7 +34,7 @@ jobs:
           cache: true
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.3
 
       - name: Run govulncheck
         env:


### PR DESCRIPTION
## Summary

- Pins `govulncheck` from `@latest` to `@v1.1.3` in `.github/workflows/security.yml`
- `golang.org/x/vuln@v1.4.0` (current `@latest`) panics with `ForEachElement called on type containing *types.TypeParam` when scanning Go code that uses generics
- `v1.1.3` is stable and handles generic types without panicking

Closes ai-vuu

## Test plan

- [ ] Confirm the Security / Vulnerability Check CI job runs without panicking on this PR
- [ ] Verify `govulncheck` completes successfully with the pinned version

🤖 Generated with [Claude Code](https://claude.com/claude-code)