### PR TITLE
feat: prompt user to cast from default branch HEAD when foundry has no semver tags (ai-h87)

### DIFF
--- a/internal/commands/cast.go
+++ b/internal/commands/cast.go
@@ -54,6 +54,10 @@ var (
 	// at cast time. Missing deps surface as errors instead of being fetched
 	// silently. Intended for CI; see --frozen flag.
 	castFrozen bool
+	// castLatestOnNoTags, when true, automatically casts from the default
+	// branch HEAD when the foundry has no semver tags. Skips the interactive
+	// prompt; intended for CI contexts.
+	castLatestOnNoTags bool
 )
 
 // copyOpts configures copyResolvedFiles. Centralising these as a struct lets
@@ -98,6 +102,10 @@ func init() {
 		"frozen",
 		false,
 		"fail (do not auto-install) when a declared ingot/ore dep is missing from .ailloy/; intended for CI")
+	castCmd.Flags().BoolVar(&castLatestOnNoTags,
+		"latest-on-no-tags",
+		false,
+		"cast from default branch HEAD when the foundry has no semver tags (skips interactive prompt; intended for CI)")
 }
 
 func runCast(_ *cobra.Command, args []string) error {
@@ -195,6 +203,9 @@ func resolveMoldReader(args []string) (*blanks.MoldReader, string, error) {
 			}
 			fsys, result, err := foundry.ResolveWithMetadata(args[0], resolveOpts...)
 			if err != nil {
+				if errors.Is(err, foundry.ErrNoSemverTags) {
+					return resolveMoldReaderWithDefaultBranch(args[0])
+				}
 				return nil, "", fmt.Errorf("resolving remote mold: %w", err)
 			}
 			resolvedRemote = result
@@ -211,6 +222,59 @@ func resolveMoldReader(args []string) (*blanks.MoldReader, string, error) {
 		return blanks.NewMoldReader(fsys), "", nil
 	}
 	return nil, "", fmt.Errorf("mold directory is required: ailloy cast <mold-dir>")
+}
+
+// resolveMoldReaderWithDefaultBranch handles the fallback path when a foundry
+// has no semver tags. It prompts the user interactively (or auto-accepts when
+// --latest-on-no-tags is set) then resolves the default branch HEAD commit and
+// fetches the mold from it.
+func resolveMoldReaderWithDefaultBranch(rawRef string) (*blanks.MoldReader, string, error) {
+	ref, err := foundry.ParseReference(rawRef)
+	if err != nil {
+		return nil, "", fmt.Errorf("parsing reference: %w", err)
+	}
+
+	if !castLatestOnNoTags {
+		var confirm bool
+		form := huh.NewForm(
+			huh.NewGroup(
+				huh.NewConfirm().
+					Title(fmt.Sprintf("No semver tags found for %s.", ref.CacheKey())).
+					Description("Cast from latest commit on default branch instead?").
+					Affirmative("Yes").
+					Negative("No").
+					Value(&confirm),
+			),
+		).WithTheme(ailloyTheme())
+		if err := form.Run(); err != nil {
+			return nil, "", fmt.Errorf("prompt failed: %w", err)
+		}
+		if !confirm {
+			return nil, "", fmt.Errorf(
+				"cast aborted: %s has no semver tags\n"+
+					"Add a version tag to the foundry, or use --latest-on-no-tags to cast from HEAD",
+				ref.CacheKey())
+		}
+	}
+
+	git := foundry.DefaultGitRunner()
+	resolved, err := foundry.ResolveDefaultBranchHead(ref, git)
+	if err != nil {
+		return nil, "", fmt.Errorf("resolving default branch HEAD: %w", err)
+	}
+
+	fetcher, err := foundry.NewFetcher(git)
+	if err != nil {
+		return nil, "", fmt.Errorf("creating fetcher: %w", err)
+	}
+	fsys, root, err := fetcher.Fetch(ref, resolved)
+	if err != nil {
+		return nil, "", fmt.Errorf("fetching mold: %w", err)
+	}
+
+	result := &foundry.ResolveResult{Ref: ref, Resolved: *resolved, Root: root}
+	resolvedRemote = result
+	return blanks.NewMoldReaderFromFS(fsys, root), ref.OverrideKey(), nil
 }
 
 // loadCastFlux loads layered flux values using Helm-style precedence:

--- a/pkg/foundry/resolver.go
+++ b/pkg/foundry/resolver.go
@@ -1,6 +1,7 @@
 package foundry
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os/exec"
@@ -10,6 +11,11 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 )
+
+// ErrNoSemverTags is returned by resolveLatest when the foundry has no semver
+// tags. Callers can detect this with errors.Is to offer a fallback (e.g. cast
+// from the default branch HEAD).
+var ErrNoSemverTags = errors.New("no semver tags found")
 
 // GitRunner executes a git command and returns its combined output.
 // It is injectable for testing.
@@ -237,7 +243,7 @@ func resolveLatest(ref *Reference, git GitRunner, reader MoldVersionReader) (*Re
 	tags := selectTagsForPrefix(all, ref.ReleasePrefix())
 	tag, sha, moldVersion, err := highestVersion(tags, nil, reader)
 	if err != nil {
-		return nil, fmt.Errorf("no semver tags found for %s", ref.CacheKey())
+		return nil, fmt.Errorf("%w for %s", ErrNoSemverTags, ref.CacheKey())
 	}
 	return &ResolvedVersion{Tag: tag, Commit: sha, MoldVersion: moldVersion}, nil
 }
@@ -352,6 +358,28 @@ func resolveBranch(ref *Reference, git GitRunner) (*ResolvedVersion, error) {
 		}
 	}
 	return nil, fmt.Errorf("branch %q not found in %s", ref.Version, ref.CacheKey())
+}
+
+// ResolveDefaultBranchHead resolves the HEAD commit on the default branch of a
+// foundry. It is used as a fallback when no semver tags are found. The
+// ResolvedVersion.Tag is set to the full commit SHA so the fetcher caches it
+// under a stable, content-addressed path.
+func ResolveDefaultBranchHead(ref *Reference, git GitRunner) (*ResolvedVersion, error) {
+	out, err := git("ls-remote", ref.CloneURL(), "HEAD")
+	if err != nil {
+		return nil, fmt.Errorf("git ls-remote %s HEAD: %w\n%s", ref.CloneURL(), err, out)
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) >= 2 && parts[1] == "HEAD" {
+			return &ResolvedVersion{Tag: parts[0], Commit: parts[0]}, nil
+		}
+	}
+	return nil, fmt.Errorf("could not resolve HEAD for %s", ref.CacheKey())
 }
 
 // highestVersion picks the highest-versioned tag from a tag map, optionally

--- a/pkg/foundry/resolver_test.go
+++ b/pkg/foundry/resolver_test.go
@@ -1,6 +1,7 @@
 package foundry
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 )
@@ -489,5 +490,48 @@ func TestResolveConstraint_NilReaderUsesTagVersion(t *testing.T) {
 	ref := launchRef("^0.2.0", Constraint)
 	if _, err := ResolveVersion(ref, trainGit(t)); err == nil {
 		t.Fatal("expected error: tag-embedded versions are 0.5-0.7, not ^0.2.0")
+	}
+}
+
+func TestResolveLatest_NoTagsReturnsErrNoSemverTags(t *testing.T) {
+	git := mockGitRunner(map[string]string{
+		"[ls-remote --tags https://github.com/owner/repo.git]": "",
+	})
+	ref := &Reference{Host: "github.com", Owner: "owner", Repo: "repo", Type: Latest}
+	_, err := ResolveVersion(ref, git)
+	if err == nil {
+		t.Fatal("expected error when no semver tags exist")
+	}
+	if !errors.Is(err, ErrNoSemverTags) {
+		t.Errorf("errors.Is(err, ErrNoSemverTags) = false; err = %v", err)
+	}
+}
+
+func TestResolveDefaultBranchHead(t *testing.T) {
+	const headSHA = "deadbeef1234567890abcdef1234567890abcdef"
+	git := mockGitRunner(map[string]string{
+		"[ls-remote https://github.com/owner/repo.git HEAD]": headSHA + "\tHEAD\n",
+	})
+	ref := &Reference{Host: "github.com", Owner: "owner", Repo: "repo", Type: Latest}
+	resolved, err := ResolveDefaultBranchHead(ref, git)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resolved.Commit != headSHA {
+		t.Errorf("Commit = %q, want %q", resolved.Commit, headSHA)
+	}
+	if resolved.Tag != headSHA {
+		t.Errorf("Tag = %q, want SHA (used as cache key)", resolved.Tag)
+	}
+}
+
+func TestResolveDefaultBranchHead_NoHEAD(t *testing.T) {
+	git := mockGitRunner(map[string]string{
+		"[ls-remote https://github.com/owner/repo.git HEAD]": "",
+	})
+	ref := &Reference{Host: "github.com", Owner: "owner", Repo: "repo", Type: Latest}
+	_, err := ResolveDefaultBranchHead(ref, git)
+	if err == nil {
+		t.Fatal("expected error when HEAD is not resolvable")
 	}
 }


### PR DESCRIPTION
## Summary

- Adds fallback behavior in `cast` command: when a foundry has no semver tags, prompts the user to cast from default branch HEAD instead of failing
- Extends `pkg/foundry/resolver.go` with `ResolveDefaultBranchHead` for HEAD resolution when no semver tags exist
- Adds tests covering the new behavior and error paths

Closes ai-h87

---
*Recovery push by ailloy/witness — chrome polecat completed work via gt done (local merge strategy) but branch was not pushed. All gates passed (build, vet, lint, race tests).*