### PR TITLE
feat(cast): add --offline flag for air-gapped / no-egress builds

### DIFF
--- a/internal/commands/cast.go
+++ b/internal/commands/cast.go
@@ -120,6 +120,12 @@ func runCast(_ *cobra.Command, args []string) error {
 	if err := validatePluginFlags(); err != nil {
 		return err
 	}
+	// A smelted binary carries its mold embedded; network resolution of
+	// transitive deps is unnecessary and breaks air-gapped environments.
+	// Auto-enable offline mode so the binary works without --offline.
+	if len(args) == 0 && smelt.HasEmbeddedMold() {
+		castOffline = true
+	}
 	reader, source, err := resolveMoldReader(args)
 	if err != nil {
 		return err

--- a/internal/commands/cast.go
+++ b/internal/commands/cast.go
@@ -58,6 +58,10 @@ var (
 	// branch HEAD when the foundry has no semver tags. Skips the interactive
 	// prompt; intended for CI contexts.
 	castLatestOnNoTags bool
+	// castOffline, when true, disables all network operations. Tag resolution
+	// and bare-clone fetches are served from the local cache; fails with an
+	// actionable error if the cache is cold. Intended for air-gapped builds.
+	castOffline bool
 )
 
 // copyOpts configures copyResolvedFiles. Centralising these as a struct lets
@@ -106,6 +110,10 @@ func init() {
 		"latest-on-no-tags",
 		false,
 		"cast from default branch HEAD when the foundry has no semver tags (skips interactive prompt; intended for CI)")
+	castCmd.Flags().BoolVar(&castOffline,
+		"offline",
+		false,
+		"resolve all dependencies from the local cache only; fails if the cache is cold (run without --offline first to warm it)")
 }
 
 func runCast(_ *cobra.Command, args []string) error {
@@ -200,6 +208,9 @@ func resolveMoldReader(args []string) (*blanks.MoldReader, string, error) {
 			var resolveOpts []foundry.ResolveOption
 			if castGlobal {
 				resolveOpts = append(resolveOpts, foundry.WithLockPath(globalLockPath()))
+			}
+			if castOffline {
+				resolveOpts = append(resolveOpts, foundry.WithOffline())
 			}
 			fsys, result, err := foundry.ResolveWithMetadata(args[0], resolveOpts...)
 			if err != nil {

--- a/internal/commands/cast_deps.go
+++ b/internal/commands/cast_deps.go
@@ -78,6 +78,7 @@ func castTransitiveDeps(rootResult *foundry.ResolveResult, root *mold.Mold, root
 	if castGlobal {
 		fetcher.LockPath = globalLockPath()
 	}
+	fetcher.Offline = castOffline
 	return castTransitiveDepsWith(fetcher, rootResult, root, rootFlux, destPrefix)
 }
 

--- a/internal/commands/install_deps.go
+++ b/internal/commands/install_deps.go
@@ -274,6 +274,9 @@ func resolveDepFS(ref, declaredVersion string, global bool) (fs.FS, string, stri
 		if global {
 			resolveOpts = append(resolveOpts, foundry.WithLockPath(globalLockPath()))
 		}
+		if castOffline {
+			resolveOpts = append(resolveOpts, foundry.WithOffline())
+		}
 		fsys, result, err := foundry.ResolveWithMetadata(ref, resolveOpts...)
 		if err != nil {
 			return nil, "", "", "", "", err

--- a/pkg/foundry/depgraph/prod_fetcher.go
+++ b/pkg/foundry/depgraph/prod_fetcher.go
@@ -18,6 +18,9 @@ type ProdFetcher struct {
 	// LockPath is forwarded to ResolveWithMetadata so transitive fetches
 	// participate in the same lockfile as the root cast.
 	LockPath string
+	// Offline disables all network operations; tag listing and bare-clone
+	// fetches are served from the local cache. Set by --offline on cast.
+	Offline bool
 
 	cache map[NodeKey]*ProdFetchCacheEntry
 }
@@ -62,6 +65,9 @@ func (p *ProdFetcher) Fetch(ref *foundry.Reference) (FetchResult, error) {
 	if p.LockPath != "" {
 		opts = append(opts, foundry.WithLockPath(p.LockPath))
 	}
+	if p.Offline {
+		opts = append(opts, foundry.WithOffline())
+	}
 	// Resolve from the *Reference directly so an explicitly-set Type (e.g. an
 	// exact pin to a monorepo-prefixed tag during constraint re-fetch) is not
 	// lost to a raw-string round-trip.
@@ -93,14 +99,19 @@ func (p *ProdFetcher) Fetch(ref *foundry.Reference) (FetchResult, error) {
 	}, nil
 }
 
-// Tags lists the semver tags for the given source+subpath via git ls-remote.
-// For monorepo subpath molds it also reads each tag's mold.yaml version so the
-// constraint solver ranks by the mold's own version rather than the shared
-// release-train version baked into the tag name. Tags whose mold manifest is
-// absent are dropped.
+// Tags lists the semver tags for the given source+subpath. When p.Offline is
+// true the listing is served from the local bare-clone cache instead of
+// git ls-remote. For monorepo subpath molds it also reads each tag's mold.yaml
+// version so the constraint solver ranks by the mold's own version rather than
+// the shared release-train version baked into the tag name. Tags whose mold
+// manifest is absent are dropped.
 func (p *ProdFetcher) Tags(source, subpath string) (map[string]TagInfo, error) {
+	git, err := p.effectiveGitRunner()
+	if err != nil {
+		return nil, err
+	}
 	url := "https://" + source + ".git"
-	tags, err := foundry.RemoteTags(url, subpath, p.GitRunner)
+	tags, err := foundry.RemoteTags(url, subpath, git)
 	if err != nil {
 		return nil, err
 	}
@@ -135,11 +146,30 @@ func (p *ProdFetcher) moldVersionReader(source, subpath string) (foundry.MoldVer
 		return nil, err
 	}
 	ref.Subpath = subpath
-	fetcher, err := foundry.NewFetcher(p.GitRunner)
+	git, err := p.effectiveGitRunner()
+	if err != nil {
+		return nil, err
+	}
+	fetcher, err := foundry.NewFetcher(git)
 	if err != nil {
 		return nil, err
 	}
 	return fetcher.MoldVersionReaderFor(ref)
+}
+
+// effectiveGitRunner returns the GitRunner to use for this fetch. When
+// p.Offline is true it wraps the real runner with the offline interceptor so
+// that network-requiring commands are served from (or blocked by) the local
+// cache.
+func (p *ProdFetcher) effectiveGitRunner() (foundry.GitRunner, error) {
+	if !p.Offline {
+		return p.GitRunner, nil
+	}
+	cacheDir, err := foundry.CacheDir()
+	if err != nil {
+		return nil, fmt.Errorf("offline mode: %w", err)
+	}
+	return foundry.NewOfflineGitRunner(p.GitRunner, cacheDir), nil
 }
 
 // refToRaw renders a Reference back to a raw string suitable for

--- a/pkg/foundry/foundry.go
+++ b/pkg/foundry/foundry.go
@@ -76,6 +76,10 @@ type resolveConfig struct {
 	// "using locked version" notices). Defaults to log.Default(). Callers
 	// running inside a TUI should pass a logger writing to io.Discard.
 	logger *log.Logger
+	// offline disables all network operations. Tag resolution and bare-clone
+	// fetches are served from the local cache; the cast fails if the cache is
+	// cold. Enabled by --offline on the cast command.
+	offline bool
 }
 
 // applyResolveDefaults sets the default lockPath. Exposed for tests.
@@ -102,6 +106,16 @@ func WithLockPath(path string) ResolveOption {
 func WithLogger(logger *log.Logger) ResolveOption {
 	return func(c *resolveConfig) {
 		c.logger = logger
+	}
+}
+
+// WithOffline disables all network operations during resolution. Tag listing
+// and bare-clone fetches are served from the local cache; resolution fails
+// with an actionable error if the cache is cold. Use for air-gapped or
+// no-egress builds once the cache has been warmed by a prior online cast.
+func WithOffline() ResolveOption {
+	return func(c *resolveConfig) {
+		c.offline = true
 	}
 }
 
@@ -206,6 +220,14 @@ func resolveWithMeta(ref *Reference, git GitRunner, opts ...ResolveOption) (fs.F
 				cfg.logger.Printf("using locked version %s@%s", ref.CacheKey(), entry.Version)
 			}
 		}
+	}
+
+	if cfg.offline {
+		cacheDir, cErr := CacheDir()
+		if cErr != nil {
+			return nil, nil, fmt.Errorf("offline mode: %w", cErr)
+		}
+		git = NewOfflineGitRunner(git, cacheDir)
 	}
 
 	fetcher, err := NewFetcher(git)

--- a/pkg/foundry/offline.go
+++ b/pkg/foundry/offline.go
@@ -1,0 +1,102 @@
+package foundry
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// NewOfflineGitRunner wraps a GitRunner so that network-requiring git commands
+// are intercepted and served from the local bare-clone cache instead. Commands
+// that already operate on local data (git archive, git show, git for-each-ref
+// with -C, etc.) pass through unchanged.
+//
+// Two commands are intercepted:
+//   - git ls-remote --tags <url>   → reads tags from the local bare clone
+//   - git -C <dir> fetch ...       → no-op if the bare clone exists, error if not
+//
+// Any other network-requiring command (ls-remote for a branch, clone --bare)
+// returns an actionable error that names --offline as the cause.
+func NewOfflineGitRunner(git GitRunner, cacheDir string) GitRunner {
+	return func(args ...string) ([]byte, error) {
+		// git ls-remote --tags <url>
+		if len(args) >= 3 && args[0] == "ls-remote" && args[1] == "--tags" {
+			url := args[2]
+			bareDir := bareDirForURL(url, cacheDir)
+			return localTagsOutput(bareDir, git)
+		}
+
+		// git -C <dir> fetch ...  →  no-op (skip network fetch of bare clone)
+		if len(args) >= 3 && args[0] == "-C" && args[2] == "fetch" {
+			bareDir := args[1]
+			if _, err := os.Stat(filepath.Join(bareDir, "HEAD")); err != nil {
+				return nil, fmt.Errorf("offline mode: no cached clone at %s; run without --offline to fetch it", bareDir)
+			}
+			return nil, nil
+		}
+
+		// git clone --bare <url> <dir>  →  error (can't create new bare clone offline)
+		if len(args) >= 2 && args[0] == "clone" {
+			for _, a := range args {
+				if a == "--bare" {
+					url := ""
+					for i, a2 := range args {
+						if a2 == "--bare" && i+1 < len(args) {
+							url = args[i+1]
+						}
+					}
+					return nil, fmt.Errorf("offline mode: no cached clone for %q; run without --offline to fetch it", url)
+				}
+			}
+		}
+
+		// git ls-remote <url> refs/heads/<branch>  →  error (branch resolution needs network)
+		if len(args) >= 1 && args[0] == "ls-remote" {
+			return nil, fmt.Errorf("offline mode: cannot fetch remote refs; run without --offline")
+		}
+
+		// All other commands (git show, git archive, git for-each-ref, etc.) pass through.
+		return git(args...)
+	}
+}
+
+// bareDirForURL derives the local bare-clone path for a remote clone URL.
+// "https://github.com/owner/repo.git" → "<cacheDir>/github.com/owner/repo/git"
+func bareDirForURL(url, cacheDir string) string {
+	key := strings.TrimSuffix(strings.TrimPrefix(url, "https://"), ".git")
+	return filepath.Join(cacheDir, filepath.FromSlash(key), "git")
+}
+
+// localTagsOutput reads semver tags from a local bare clone and returns bytes
+// in the same format as "git ls-remote --tags", suitable for parseLsRemoteTags.
+//
+// Two for-each-ref calls are combined:
+//  1. Plain lines:  <sha>	refs/tags/<name>
+//  2. Deref lines: <sha>	refs/tags/<name>^{}   (non-empty only for annotated tags)
+//
+// The deref lines let parseLsRemoteTags correctly resolve annotated tags to
+// their underlying commit SHA (matching the ls-remote behaviour exactly).
+func localTagsOutput(bareDir string, git GitRunner) ([]byte, error) {
+	if _, err := os.Stat(filepath.Join(bareDir, "HEAD")); err != nil {
+		return nil, fmt.Errorf("offline mode: no cached clone at %s; run without --offline to fetch it", bareDir)
+	}
+
+	plain, err := git("-C", bareDir, "for-each-ref", "refs/tags",
+		"--format=%(objectname)\trefs/tags/%(refname:short)")
+	if err != nil {
+		return nil, fmt.Errorf("offline mode: listing local tags: %w", err)
+	}
+
+	// %(*objectname) is empty for lightweight tags; parseLsRemoteTags skips
+	// those blank-SHA lines, so combining them here is safe.
+	deref, err := git("-C", bareDir, "for-each-ref", "refs/tags",
+		"--format=%(*objectname)\trefs/tags/%(refname:short)^{}")
+	if err != nil {
+		return nil, fmt.Errorf("offline mode: listing local tag derefs: %w", err)
+	}
+
+	combined := append(plain, '\n')
+	combined = append(combined, deref...)
+	return combined, nil
+}


### PR DESCRIPTION
closes #245

## Summary

Adds \`--offline\` to \`ailloy cast\` for air-gapped / no-egress builds, and **auto-enables offline mode when running from a smelted binary** (embedded mold) so no flag is needed in that case.

## Changes

- **\`pkg/foundry/offline.go\`** (new): \`NewOfflineGitRunner\` — a \`GitRunner\` wrapper that intercepts the three network-requiring git commands without changing any function signatures:
  - \`git ls-remote --tags <url>\` → reads tags from the local bare clone via \`git for-each-ref\`, formatted identically so \`parseLsRemoteTags\` is reused unchanged
  - \`git -C <dir> fetch --all --tags\` → no-op when the bare clone exists; actionable error when cold
  - \`git clone --bare <url>\` → actionable error with "run without --offline to cache it first" hint
  - All other git commands (archive, show, for-each-ref) pass through unchanged

- **\`pkg/foundry/foundry.go\`**: Added \`offline bool\` to \`resolveConfig\` and \`WithOffline() ResolveOption\`. When offline, \`resolveWithMeta\` wraps the \`GitRunner\` with \`NewOfflineGitRunner\` before passing it to the fetcher and resolver.

- **\`pkg/foundry/depgraph/prod_fetcher.go\`**: Added \`Offline bool\` to \`ProdFetcher\`. \`Fetch()\` forwards \`WithOffline()\`; \`Tags()\` and \`moldVersionReader()\` use a new \`effectiveGitRunner()\` helper.

- **\`internal/commands/cast.go\`**:
  - Added \`castOffline bool\` var and \`--offline\` flag for explicit opt-in
  - **Auto-enables offline** when \`len(args) == 0 && smelt.HasEmbeddedMold()\` — smelted binaries no longer require \`--offline\` to work in air-gapped environments

- **\`internal/commands/cast_deps.go\`**: Sets \`fetcher.Offline = castOffline\` for transitive mold-on-mold resolution.

- **\`internal/commands/install_deps.go\`**: \`resolveDepFS\` appends \`WithOffline()\` for ingot/ore dep resolution when \`castOffline\` is set.

## UAT

**Explicit --offline flag (warm cache required):**
\`\`\`bash
ailloy cast github.com/your-org/your-aggregator-mold --no-animate
ailloy cast github.com/your-org/your-aggregator-mold --offline --no-animate
\`\`\`

**Smelted binary — no flag needed:**
\`\`\`bash
ailloy smelt ./molds/replicated-vendor -o ./replicated-vendor
./replicated-vendor   # works offline automatically
\`\`\`

**Actionable error when cache is cold:**
\`\`\`bash
rm -rf ~/.ailloy/cache/github.com/your-org/some-dep/git
ailloy cast github.com/your-org/your-aggregator-mold --offline
# → offline mode: no cached clone at <path>; run without --offline to fetch it
\`\`\`