### PR TITLE
fix: gofmt pkg/smelt/deps_test.go

### DIFF
--- a/pkg/smelt/deps_test.go
+++ b/pkg/smelt/deps_test.go
@@ -17,8 +17,8 @@ import (
 // Fetch populates an in-memory cache keyed on ref.CacheKey(); CacheEntry reads
 // it back so collectDepsWith can retrieve the FS after Build.
 type fakeSmeltFetcher struct {
-	molds map[string]*mold.Mold    // CacheKey -> mold
-	fss   map[string]fs.FS         // CacheKey -> mold FS
+	molds map[string]*mold.Mold // CacheKey -> mold
+	fss   map[string]fs.FS      // CacheKey -> mold FS
 	cache map[depgraph.NodeKey]*depgraph.ProdFetchCacheEntry
 }
 


### PR DESCRIPTION
Fixes gofmt formatting issue in `pkg/smelt/deps_test.go` introduced by the ai-gnd smelt dep-bundling merge, which broke CI on main.

## Changes
- Run `gofmt -w` on `pkg/smelt/deps_test.go` (2 lines reformatted)