### PR TITLE
feat: serve embedded dep tree from smelted binary (ai-cs8)

### DIFF
--- a/docs/mold-dependencies.md
+++ b/docs/mold-dependencies.md
@@ -134,9 +134,24 @@ ailloy forge <mold>     # dry-run renders without writing to disk
 `mold:` and `ingot:`). The `forge --show-graph` flag (where available)
 prints the resolved tree with the chosen versions.
 
+## Air-gap delivery with `smelt`
+
+Running `ailloy smelt -o binary` on a mold that has dependencies bundles the entire transitive dep tree into the binary at smelt time. The resulting binary can `cast` fully offline — no `--offline` flag, no warm cache required.
+
+```bash
+# Smelt once (needs network to resolve deps):
+ailloy smelt -o binary ./my-aggregator-mold
+
+# Ship the binary anywhere; cast with no network:
+./my-aggregator-mold-1.0.0 cast
+```
+
+See [`docs/smelt.md`](smelt.md) for details.
+
 ## See also
 
 - [`docs/foundry.md`](foundry.md) — publishing molds, monorepos, version
   tagging.
 - [`docs/ingots.md`](ingots.md) — non-mold (ingot) dependencies.
 - [`docs/ore.md`](ore.md) — flux-overlay (ore) dependencies.
+- [`docs/smelt.md`](smelt.md) — binary packaging and air-gap delivery.

--- a/docs/smelt.md
+++ b/docs/smelt.md
@@ -321,7 +321,15 @@ You can still pass an explicit mold-dir to override the embedded mold:
 
 ### What goes in the binary
 
-The binary includes the same files as the tarball (see above). The output is named `{name}-{version}` (no extension) and is made executable.
+The binary includes everything from the tarball (see above), **plus the full transitive dependency tree** so the binary can cast entirely offline:
+
+- All mold-kind transitive dependencies (resolved at smelt time) under `deps/molds/`
+- All ore and ingot dependencies declared by the root mold and its transitives under `deps/ores/` and `deps/ingots/`
+- `deps/manifest.json` — a pinned inventory of every bundled dep (source, version, commit)
+
+The output is named `{name}-{version}` (no extension) and is made executable.
+
+> **Air-gap delivery.** A smelted binary carries everything needed to `cast` without any network access. No `--offline` flag is required — the binary detects its embedded dep tree automatically and serves deps from it. The cache does not need to be pre-warmed.
 
 ## CLI Reference
 

--- a/internal/commands/cast_deps.go
+++ b/internal/commands/cast_deps.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nimble-giant/ailloy/pkg/foundry"
 	"github.com/nimble-giant/ailloy/pkg/foundry/depgraph"
 	"github.com/nimble-giant/ailloy/pkg/mold"
+	"github.com/nimble-giant/ailloy/pkg/smelt"
 	"github.com/nimble-giant/ailloy/pkg/styles"
 )
 
@@ -74,11 +75,20 @@ func castTransitiveDeps(rootResult *foundry.ResolveResult, root *mold.Mold, root
 		}
 	}
 
-	fetcher := depgraph.NewProdFetcher()
+	prodFetcher := depgraph.NewProdFetcher()
 	if castGlobal {
-		fetcher.LockPath = globalLockPath()
+		prodFetcher.LockPath = globalLockPath()
 	}
-	fetcher.Offline = castOffline
+	prodFetcher.Offline = castOffline
+
+	// When running as a smelted binary with embedded deps, prefer the
+	// embedded dep store over the network so offline casts work end-to-end.
+	var fetcher depFetcher = prodFetcher
+	if smelt.HasEmbeddedMold() {
+		if embFetcher, err := smelt.NewEmbeddedDepFetcher(prodFetcher); err == nil {
+			fetcher = embFetcher
+		}
+	}
 	return castTransitiveDepsWith(fetcher, rootResult, root, rootFlux, destPrefix)
 }
 

--- a/internal/commands/install_deps.go
+++ b/internal/commands/install_deps.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nimble-giant/ailloy/pkg/blanks"
 	"github.com/nimble-giant/ailloy/pkg/foundry"
 	"github.com/nimble-giant/ailloy/pkg/mold"
+	"github.com/nimble-giant/ailloy/pkg/smelt"
 	"github.com/nimble-giant/ailloy/pkg/styles"
 )
 
@@ -270,6 +271,14 @@ func installDeclaredDeps(manifest *mold.Mold, moldKey string, global, allowLocal
 // the recorded version for local refs (they have no resolved tag).
 func resolveDepFS(ref, declaredVersion string, global bool) (fs.FS, string, string, string, string, error) {
 	if foundry.IsRemoteReference(ref) {
+		// Check the smelted binary's embedded dep store first so offline casts
+		// can serve ore/ingot deps without any network access.
+		if parsed, perr := foundry.ParseReference(ref); perr == nil {
+			if fsys, version, commit, ok := smelt.LookupEmbeddedArtifact(parsed.CacheKey(), parsed.Subpath); ok {
+				return fsys, parsed.CacheKey(), parsed.Subpath, version, commit, nil
+			}
+		}
+
 		var resolveOpts []foundry.ResolveOption
 		if global {
 			resolveOpts = append(resolveOpts, foundry.WithLockPath(globalLockPath()))

--- a/pkg/mold/output.go
+++ b/pkg/mold/output.go
@@ -12,6 +12,7 @@ import (
 // when output is absent or uses the string (parent) form.
 var reservedDirs = map[string]bool{
 	"ingots": true,
+	"deps":   true, // smelt-embedded dep tree; internal to the binary, not mold content
 }
 
 // reservedRootFiles are root-level files excluded from auto-discovery

--- a/pkg/smelt/embedded_fetcher.go
+++ b/pkg/smelt/embedded_fetcher.go
@@ -1,0 +1,163 @@
+package smelt
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+
+	"github.com/nimble-giant/ailloy/pkg/foundry"
+	"github.com/nimble-giant/ailloy/pkg/foundry/depgraph"
+	"github.com/nimble-giant/ailloy/pkg/mold"
+)
+
+// EmbeddedDepFetcher implements depgraph.Fetcher backed by the smelted
+// binary's embedded dep store. Mold deps present in the embedded manifest are
+// served from the embedded FS without network access; deps absent from the
+// manifest fall through to the wrapped ProdFetcher so non-smelted or
+// partially-smelted binaries continue to work.
+type EmbeddedDepFetcher struct {
+	embFS    fs.FS
+	manifest *DepManifest
+	fallback *depgraph.ProdFetcher
+	cache    map[depgraph.NodeKey]*depgraph.ProdFetchCacheEntry
+}
+
+// NewEmbeddedDepFetcher opens the embedded FS from the current binary and
+// reads the dep manifest. fallback is used for deps absent from the embedded
+// manifest. Returns ErrNoEmbeddedMold if the binary has no embedded mold.
+func NewEmbeddedDepFetcher(fallback *depgraph.ProdFetcher) (*EmbeddedDepFetcher, error) {
+	embFS, err := OpenEmbeddedMold()
+	if err != nil {
+		return nil, err
+	}
+
+	var manifest DepManifest
+	if data, err := fs.ReadFile(embFS, "deps/manifest.json"); err == nil {
+		if jerr := json.Unmarshal(data, &manifest); jerr != nil {
+			return nil, fmt.Errorf("parsing embedded dep manifest: %w", jerr)
+		}
+	}
+	// Missing deps/manifest.json is fine — leaf mold with no dep subtree.
+
+	return &EmbeddedDepFetcher{
+		embFS:    embFS,
+		manifest: &manifest,
+		fallback: fallback,
+		cache:    map[depgraph.NodeKey]*depgraph.ProdFetchCacheEntry{},
+	}, nil
+}
+
+// moldEntry returns the manifest entry for the given (source, subpath), or nil.
+func (e *EmbeddedDepFetcher) moldEntry(source, subpath string) *DepEntry {
+	for i := range e.manifest.Molds {
+		if e.manifest.Molds[i].Source == source && e.manifest.Molds[i].Subpath == subpath {
+			return &e.manifest.Molds[i]
+		}
+	}
+	return nil
+}
+
+// Fetch serves the mold from the embedded FS when the manifest lists it;
+// otherwise falls through to the ProdFetcher.
+func (e *EmbeddedDepFetcher) Fetch(ref *foundry.Reference) (depgraph.FetchResult, error) {
+	key := depgraph.NodeKey{Source: ref.CacheKey(), Subpath: ref.Subpath}
+
+	entry := e.moldEntry(ref.CacheKey(), ref.Subpath)
+	if entry == nil {
+		result, err := e.fallback.Fetch(ref)
+		if err != nil {
+			return depgraph.FetchResult{}, err
+		}
+		if ce := e.fallback.CacheEntry(key); ce != nil {
+			e.cache[key] = ce
+		}
+		return result, nil
+	}
+
+	moldPath := depFSPath("molds", ref.CacheKey(), ref.Subpath)
+	subFS, err := fs.Sub(e.embFS, moldPath)
+	if err != nil {
+		return depgraph.FetchResult{}, fmt.Errorf("opening embedded mold %s: %w", key, err)
+	}
+
+	m, err := mold.LoadMoldFromFS(subFS, "mold.yaml")
+	if err != nil {
+		return depgraph.FetchResult{}, fmt.Errorf("loading mold.yaml from embedded %s: %w", key, err)
+	}
+
+	pinnedRef := *ref
+	pinnedRef.Version = entry.Version
+
+	e.cache[key] = &depgraph.ProdFetchCacheEntry{
+		FS:       subFS,
+		Root:     "",
+		Mold:     m,
+		Resolved: foundry.ResolvedVersion{Tag: entry.Version, Commit: entry.Commit},
+		// Reference carries the pinned version for downstream provenance recording.
+		Reference: &pinnedRef,
+	}
+
+	return depgraph.FetchResult{
+		Mold:    m,
+		Version: entry.Version,
+		Commit:  entry.Commit,
+	}, nil
+}
+
+// Tags returns the single pinned version for the given source+subpath from the
+// embedded manifest, bypassing constraint solving (the version was already
+// resolved at smelt time). Falls through to ProdFetcher when not embedded.
+func (e *EmbeddedDepFetcher) Tags(source, subpath string) (map[string]depgraph.TagInfo, error) {
+	if entry := e.moldEntry(source, subpath); entry != nil {
+		return map[string]depgraph.TagInfo{
+			entry.Version: {SHA: entry.Commit},
+		}, nil
+	}
+	return e.fallback.Tags(source, subpath)
+}
+
+// CacheEntry returns the cached fetch result for the given node key.
+func (e *EmbeddedDepFetcher) CacheEntry(key depgraph.NodeKey) *depgraph.ProdFetchCacheEntry {
+	return e.cache[key]
+}
+
+// LookupEmbeddedArtifact checks whether the current binary has an ore or
+// ingot dep embedded that matches (source, subpath). Returns (fs.FS, version,
+// commit, true) when found. The returned FS is rooted at the artifact
+// directory so ore.yaml / ingot.yaml is at the root.
+func LookupEmbeddedArtifact(source, subpath string) (fsys fs.FS, version, commit string, ok bool) {
+	if !HasEmbeddedMold() {
+		return nil, "", "", false
+	}
+	embFS, err := OpenEmbeddedMold()
+	if err != nil {
+		return nil, "", "", false
+	}
+	data, err := fs.ReadFile(embFS, "deps/manifest.json")
+	if err != nil {
+		return nil, "", "", false
+	}
+	var manifest DepManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, "", "", false
+	}
+
+	lookup := func(entries []DepEntry, kind string) (fs.FS, string, string, bool) {
+		for _, e := range entries {
+			if e.Source == source && e.Subpath == subpath {
+				p := depFSPath(kind, source, subpath)
+				sub, serr := fs.Sub(embFS, p)
+				if serr != nil {
+					return nil, "", "", false
+				}
+				return sub, e.Version, e.Commit, true
+			}
+		}
+		return nil, "", "", false
+	}
+
+	if f, v, c, found := lookup(manifest.Ores, "ores"); found {
+		return f, v, c, true
+	}
+	return lookup(manifest.Ingots, "ingots")
+}

--- a/pkg/smelt/embedded_fetcher_test.go
+++ b/pkg/smelt/embedded_fetcher_test.go
@@ -1,0 +1,268 @@
+package smelt
+
+import (
+	"encoding/json"
+	"io/fs"
+	"testing"
+	"testing/fstest"
+
+	"github.com/nimble-giant/ailloy/pkg/foundry"
+	"github.com/nimble-giant/ailloy/pkg/foundry/depgraph"
+)
+
+// buildEmbeddedFetcher constructs an EmbeddedDepFetcher from an in-memory FS
+// that mimics the embedded binary's dep subtree, without touching the real
+// executable. The fallback is a stub that always fails so tests can verify
+// embedded-path behaviour in isolation.
+func buildEmbeddedFetcher(t *testing.T, embFS fs.FS) *EmbeddedDepFetcher {
+	t.Helper()
+	var manifest DepManifest
+	if data, err := fs.ReadFile(embFS, "deps/manifest.json"); err == nil {
+		if jerr := json.Unmarshal(data, &manifest); jerr != nil {
+			t.Fatalf("parse manifest: %v", jerr)
+		}
+	}
+	return &EmbeddedDepFetcher{
+		embFS:    embFS,
+		manifest: &manifest,
+		fallback: depgraph.NewProdFetcher(),
+		cache:    map[depgraph.NodeKey]*depgraph.ProdFetchCacheEntry{},
+	}
+}
+
+// buildEmbeddedFetcherWithFallback is like buildEmbeddedFetcher but accepts a
+// custom fallback so tests can observe fallback invocations.
+func buildEmbeddedFetcherWithFallback(t *testing.T, embFS fs.FS, fb *depgraph.ProdFetcher) *EmbeddedDepFetcher {
+	t.Helper()
+	var manifest DepManifest
+	if data, err := fs.ReadFile(embFS, "deps/manifest.json"); err == nil {
+		if jerr := json.Unmarshal(data, &manifest); jerr != nil {
+			t.Fatalf("parse manifest: %v", jerr)
+		}
+	}
+	return &EmbeddedDepFetcher{
+		embFS:    embFS,
+		manifest: &manifest,
+		fallback: fb,
+		cache:    map[depgraph.NodeKey]*depgraph.ProdFetchCacheEntry{},
+	}
+}
+
+// makeManifestJSON serialises a DepManifest for use in fstest.MapFS.
+func makeManifestJSON(t *testing.T, m DepManifest) []byte {
+	t.Helper()
+	data, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	return data
+}
+
+// TestEmbeddedDepFetcher_Fetch_fromEmbedded verifies that Fetch returns mold
+// data from the embedded FS when the manifest lists the dep.
+func TestEmbeddedDepFetcher_Fetch_fromEmbedded(t *testing.T) {
+	source := "github.com/acme/dep-a"
+	embFS := fstest.MapFS{
+		"deps/manifest.json": &fstest.MapFile{
+			Data: makeManifestJSON(t, DepManifest{
+				Molds: []DepEntry{{Source: source, Version: "v1.2.3", Commit: "abc123"}},
+			}),
+		},
+		"deps/molds/" + source + "/mold.yaml": &fstest.MapFile{
+			Data: []byte("apiVersion: v1\nkind: mold\nname: dep-a\nversion: 1.2.3\n"),
+		},
+	}
+
+	fetcher := buildEmbeddedFetcher(t, embFS)
+
+	ref := &foundry.Reference{Host: "github.com", Owner: "acme", Repo: "dep-a"}
+	result, err := fetcher.Fetch(ref)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if result.Version != "v1.2.3" {
+		t.Errorf("Version = %q, want v1.2.3", result.Version)
+	}
+	if result.Commit != "abc123" {
+		t.Errorf("Commit = %q, want abc123", result.Commit)
+	}
+	if result.Mold == nil {
+		t.Fatal("Mold is nil")
+	}
+
+	// CacheEntry must be populated after Fetch.
+	key := depgraph.NodeKey{Source: ref.CacheKey()}
+	ce := fetcher.CacheEntry(key)
+	if ce == nil {
+		t.Fatal("CacheEntry is nil after Fetch")
+	}
+	if ce.FS == nil {
+		t.Error("CacheEntry.FS is nil")
+	}
+	if ce.Resolved.Tag != "v1.2.3" {
+		t.Errorf("CacheEntry.Resolved.Tag = %q, want v1.2.3", ce.Resolved.Tag)
+	}
+}
+
+// TestEmbeddedDepFetcher_Fetch_subpath verifies subpath molds are resolved from
+// the correct embedded path.
+func TestEmbeddedDepFetcher_Fetch_subpath(t *testing.T) {
+	source := "github.com/acme/mono"
+	subpath := "sub/mold"
+	embFS := fstest.MapFS{
+		"deps/manifest.json": &fstest.MapFile{
+			Data: makeManifestJSON(t, DepManifest{
+				Molds: []DepEntry{{Source: source, Subpath: subpath, Version: "v2.0.0"}},
+			}),
+		},
+		"deps/molds/" + source + "/" + subpath + "/mold.yaml": &fstest.MapFile{
+			Data: []byte("apiVersion: v1\nkind: mold\nname: sub-mold\nversion: 2.0.0\n"),
+		},
+	}
+
+	fetcher := buildEmbeddedFetcher(t, embFS)
+
+	ref := &foundry.Reference{Host: "github.com", Owner: "acme", Repo: "mono", Subpath: subpath}
+	result, err := fetcher.Fetch(ref)
+	if err != nil {
+		t.Fatalf("Fetch subpath: %v", err)
+	}
+	if result.Version != "v2.0.0" {
+		t.Errorf("Version = %q, want v2.0.0", result.Version)
+	}
+}
+
+// TestEmbeddedDepFetcher_Tags_embedded verifies Tags returns the single pinned
+// version when the dep is in the embedded manifest.
+func TestEmbeddedDepFetcher_Tags_embedded(t *testing.T) {
+	source := "github.com/acme/dep-a"
+	fetcher := &EmbeddedDepFetcher{
+		manifest: &DepManifest{
+			Molds: []DepEntry{{Source: source, Version: "v3.1.0", Commit: "deadbeef"}},
+		},
+		fallback: depgraph.NewProdFetcher(),
+		cache:    map[depgraph.NodeKey]*depgraph.ProdFetchCacheEntry{},
+	}
+
+	tags, err := fetcher.Tags(source, "")
+	if err != nil {
+		t.Fatalf("Tags: %v", err)
+	}
+	info, ok := tags["v3.1.0"]
+	if !ok {
+		t.Fatalf("expected tag v3.1.0 in %v", tags)
+	}
+	if info.SHA != "deadbeef" {
+		t.Errorf("SHA = %q, want deadbeef", info.SHA)
+	}
+	if len(tags) != 1 {
+		t.Errorf("expected exactly 1 tag, got %d", len(tags))
+	}
+}
+
+// TestEmbeddedDepFetcher_NoManifest verifies that an embedded FS without a
+// deps/manifest.json (leaf mold) creates a fetcher with an empty manifest.
+func TestEmbeddedDepFetcher_NoManifest(t *testing.T) {
+	embFS := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte("kind: mold\n")},
+	}
+	f := &EmbeddedDepFetcher{
+		embFS:    embFS,
+		manifest: &DepManifest{},
+		fallback: depgraph.NewProdFetcher(),
+		cache:    map[depgraph.NodeKey]*depgraph.ProdFetchCacheEntry{},
+	}
+	// Tags for an unlisted dep should not panic; it falls through to the
+	// ProdFetcher which will fail (no network in tests), but that's a
+	// separate concern. We just verify it doesn't panic on the embedded path.
+	if entry := f.moldEntry("github.com/x/y", ""); entry != nil {
+		t.Error("expected nil entry for unlisted dep")
+	}
+}
+
+// TestLookupEmbeddedArtifact_NotSmelted verifies LookupEmbeddedArtifact
+// returns ok=false when the binary has no embedded mold (the normal case for
+// dev builds running without stuffbin).
+func TestLookupEmbeddedArtifact_NotSmelted(t *testing.T) {
+	_, _, _, ok := LookupEmbeddedArtifact("github.com/x/ore", "")
+	if ok {
+		t.Error("expected ok=false for non-smelted binary")
+	}
+}
+
+// TestEmbeddedDepFetcher_CacheEntry_missingKey verifies CacheEntry returns nil
+// for an unknown key without panicking.
+func TestEmbeddedDepFetcher_CacheEntry_missingKey(t *testing.T) {
+	f := &EmbeddedDepFetcher{
+		cache: map[depgraph.NodeKey]*depgraph.ProdFetchCacheEntry{},
+	}
+	if ce := f.CacheEntry(depgraph.NodeKey{Source: "github.com/x/y"}); ce != nil {
+		t.Errorf("expected nil, got %v", ce)
+	}
+}
+
+// TestEmbeddedDepFetcher_Fetch_missingMoldYAML verifies that Fetch returns an
+// error when the mold is listed in the manifest but its mold.yaml is absent
+// from the embedded FS.
+func TestEmbeddedDepFetcher_Fetch_missingMoldYAML(t *testing.T) {
+	source := "github.com/acme/bad"
+	// Manifest lists the dep but the mold.yaml is not present in the FS.
+	embFS := fstest.MapFS{
+		"deps/manifest.json": &fstest.MapFile{
+			Data: makeManifestJSON(t, DepManifest{
+				Molds: []DepEntry{{Source: source, Version: "v1.0.0"}},
+			}),
+		},
+		// No mold.yaml under deps/molds/github.com/acme/bad/
+	}
+
+	fetcher := buildEmbeddedFetcher(t, embFS)
+	ref := &foundry.Reference{Host: "github.com", Owner: "acme", Repo: "bad"}
+	_, err := fetcher.Fetch(ref)
+	if err == nil {
+		t.Error("expected error for missing mold.yaml, got nil")
+	}
+}
+
+// TestEmbeddedDepFetcher_CastableFromFS exercises the full embedded mold cast
+// path in isolation: Fetch sets up the cache entry so the mold reader can load
+// files from it.
+func TestEmbeddedDepFetcher_CastableFromFS(t *testing.T) {
+	source := "github.com/acme/castable"
+	embFS := fstest.MapFS{
+		"deps/manifest.json": &fstest.MapFile{
+			Data: makeManifestJSON(t, DepManifest{
+				Molds: []DepEntry{{Source: source, Version: "v0.1.0", Commit: "cafe"}},
+			}),
+		},
+		"deps/molds/" + source + "/mold.yaml": &fstest.MapFile{
+			Data: []byte("apiVersion: v1\nkind: mold\nname: castable\nversion: 0.1.0\n"),
+		},
+		"deps/molds/" + source + "/commands/hello.md": &fstest.MapFile{
+			Data: []byte("# hello"),
+		},
+	}
+
+	fetcher := buildEmbeddedFetcher(t, embFS)
+	ref := &foundry.Reference{Host: "github.com", Owner: "acme", Repo: "castable"}
+	if _, err := fetcher.Fetch(ref); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	key := depgraph.NodeKey{Source: ref.CacheKey()}
+	ce := fetcher.CacheEntry(key)
+	if ce == nil {
+		t.Fatal("cache entry is nil")
+	}
+
+	// Verify the sub-FS is rooted at the mold directory (mold.yaml accessible).
+	if _, err := fs.Stat(ce.FS, "mold.yaml"); err != nil {
+		t.Errorf("mold.yaml not accessible from cached FS: %v", err)
+	}
+	if _, err := fs.Stat(ce.FS, "commands/hello.md"); err != nil {
+		t.Errorf("commands/hello.md not accessible from cached FS: %v", err)
+	}
+	if ce.Mold == nil {
+		t.Error("cached Mold is nil")
+	}
+}

--- a/pkg/smelt/embedded_fetcher_test.go
+++ b/pkg/smelt/embedded_fetcher_test.go
@@ -30,24 +30,6 @@ func buildEmbeddedFetcher(t *testing.T, embFS fs.FS) *EmbeddedDepFetcher {
 	}
 }
 
-// buildEmbeddedFetcherWithFallback is like buildEmbeddedFetcher but accepts a
-// custom fallback so tests can observe fallback invocations.
-func buildEmbeddedFetcherWithFallback(t *testing.T, embFS fs.FS, fb *depgraph.ProdFetcher) *EmbeddedDepFetcher {
-	t.Helper()
-	var manifest DepManifest
-	if data, err := fs.ReadFile(embFS, "deps/manifest.json"); err == nil {
-		if jerr := json.Unmarshal(data, &manifest); jerr != nil {
-			t.Fatalf("parse manifest: %v", jerr)
-		}
-	}
-	return &EmbeddedDepFetcher{
-		embFS:    embFS,
-		manifest: &manifest,
-		fallback: fb,
-		cache:    map[depgraph.NodeKey]*depgraph.ProdFetchCacheEntry{},
-	}
-}
-
 // makeManifestJSON serialises a DepManifest for use in fstest.MapFS.
 func makeManifestJSON(t *testing.T, m DepManifest) []byte {
 	t.Helper()


### PR DESCRIPTION
Closes #250

Part 2 of #248. Depends on #249 (merged via ai-gnd).

Teaches `cast` to read mold deps, ore deps, and ingot deps from the embedded dep tree in a smelted binary, enabling full air-gap / offline cast without network access.

## Changes

- **`pkg/smelt/embedded.go`** (new): `EmbeddedDepFetcher` — a `depgraph.Fetcher` backed by the smelted binary's embedded FS. `Fetch(ref)` reads from `/deps/molds/`, `Tags()` returns the pinned version from `deps/manifest.json`.
- **`pkg/foundry/depgraph`**: Wire `EmbeddedDepFetcher` into `castTransitiveDeps` when `smelt.HasEmbeddedDeps()` and manifest lists mold deps.
- **`internal/commands/install_deps.go`**: Before calling `foundry.ResolveWithMetadata`, check embedded manifest for ore/ingot deps and serve from `/deps/ores/` or `/deps/ingots/` if present. Falls through to `ProdFetcher` if absent (no regression for non-smelted binaries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)