### PR TITLE
fix: remove component from release-please title pattern

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "pull-request-title-pattern": "release: ${component} v${version}",
+  "pull-request-title-pattern": "release: v${version}",
   "packages": {
     ".": {
       "release-type": "go",


### PR DESCRIPTION
\`\${component}\` renders as empty for the root \`.\` package, producing a double space in \`release:  vX.Y.Z\` that fails conform's \`case: lower\` check (description starts with a space, not a lowercase letter).

## Changes
- \`release-please-config.json\`: pattern changed from \`release: \${component} v\${version}\` → \`release: v\${version}\`

## Effect on PR #251
This fixes future release PRs. PR #251 still has the old commit message — release-please will need to regenerate it (closing and reopening, or a new release cycle) to pick up the new pattern.