### PR TITLE
fix: serve embedded mold deps offline via LookupEmbeddedArtifact

### DIFF
--- a/pkg/smelt/embedded_fetcher.go
+++ b/pkg/smelt/embedded_fetcher.go
@@ -121,10 +121,10 @@ func (e *EmbeddedDepFetcher) CacheEntry(key depgraph.NodeKey) *depgraph.ProdFetc
 	return e.cache[key]
 }
 
-// LookupEmbeddedArtifact checks whether the current binary has an ore or
-// ingot dep embedded that matches (source, subpath). Returns (fs.FS, version,
-// commit, true) when found. The returned FS is rooted at the artifact
-// directory so ore.yaml / ingot.yaml is at the root.
+// LookupEmbeddedArtifact checks whether the current binary has a mold, ore,
+// or ingot dep embedded that matches (source, subpath). Returns (fs.FS,
+// version, commit, true) when found. The returned FS is rooted at the
+// artifact directory so mold.yaml / ore.yaml / ingot.yaml is at the root.
 func LookupEmbeddedArtifact(source, subpath string) (fsys fs.FS, version, commit string, ok bool) {
 	if !HasEmbeddedMold() {
 		return nil, "", "", false
@@ -141,7 +141,14 @@ func LookupEmbeddedArtifact(source, subpath string) (fsys fs.FS, version, commit
 	if err := json.Unmarshal(data, &manifest); err != nil {
 		return nil, "", "", false
 	}
+	return lookupArtifactInFS(embFS, &manifest, source, subpath)
+}
 
+// lookupArtifactInFS searches embFS for a mold/ore/ingot matching (source,
+// subpath). Molds are checked before ores so that a mold dep in the consumer's
+// dependency list is served from the embedded tree rather than falling through
+// to a network fetch.
+func lookupArtifactInFS(embFS fs.FS, manifest *DepManifest, source, subpath string) (fsys fs.FS, version, commit string, ok bool) {
 	lookup := func(entries []DepEntry, kind string) (fs.FS, string, string, bool) {
 		for _, e := range entries {
 			if e.Source == source && e.Subpath == subpath {
@@ -156,6 +163,9 @@ func LookupEmbeddedArtifact(source, subpath string) (fsys fs.FS, version, commit
 		return nil, "", "", false
 	}
 
+	if f, v, c, found := lookup(manifest.Molds, "molds"); found {
+		return f, v, c, true
+	}
 	if f, v, c, found := lookup(manifest.Ores, "ores"); found {
 		return f, v, c, true
 	}

--- a/pkg/smelt/embedded_fetcher_test.go
+++ b/pkg/smelt/embedded_fetcher_test.go
@@ -172,6 +172,102 @@ func TestLookupEmbeddedArtifact_NotSmelted(t *testing.T) {
 	}
 }
 
+// TestLookupArtifactInFS_Mold verifies that lookupArtifactInFS finds an
+// embedded mold dep by (source, subpath). This exercises the cast-side fix
+// that allows ResolveDepsEphemeral to serve a mold: dep from the smelted
+// binary's embedded tree without a network round-trip.
+func TestLookupArtifactInFS_Mold(t *testing.T) {
+	source := "github.com/acme/release-train"
+	subpath := "molds/leaf"
+	embFS := fstest.MapFS{
+		"deps/manifest.json": &fstest.MapFile{
+			Data: makeManifestJSON(t, DepManifest{
+				Molds: []DepEntry{{
+					Source:      source,
+					Subpath:     subpath,
+					Version:     "leaf-v1.2.3",
+					Commit:      "deadbeef",
+					MoldVersion: "0.1.0",
+				}},
+			}),
+		},
+		"deps/molds/" + source + "/" + subpath + "/mold.yaml": &fstest.MapFile{
+			Data: []byte("apiVersion: v1\nkind: mold\nname: leaf\nversion: 0.1.0\n"),
+		},
+	}
+
+	var manifest DepManifest
+	if data, err := fs.ReadFile(embFS, "deps/manifest.json"); err == nil {
+		if jerr := json.Unmarshal(data, &manifest); jerr != nil {
+			t.Fatalf("parse manifest: %v", jerr)
+		}
+	}
+
+	fsys, version, commit, ok := lookupArtifactInFS(embFS, &manifest, source, subpath)
+	if !ok {
+		t.Fatal("expected ok=true for embedded mold dep")
+	}
+	if version != "leaf-v1.2.3" {
+		t.Errorf("version = %q, want leaf-v1.2.3", version)
+	}
+	if commit != "deadbeef" {
+		t.Errorf("commit = %q, want deadbeef", commit)
+	}
+	if _, err := fs.Stat(fsys, "mold.yaml"); err != nil {
+		t.Errorf("mold.yaml not accessible from returned FS: %v", err)
+	}
+}
+
+// TestLookupArtifactInFS_MoldBeforeOre verifies that a mold entry is found
+// even when the manifest also contains an ore entry with the same source/subpath
+// key — molds are checked first.
+func TestLookupArtifactInFS_MoldBeforeOre(t *testing.T) {
+	source := "github.com/acme/repo"
+	subpath := ""
+	embFS := fstest.MapFS{
+		"deps/manifest.json": &fstest.MapFile{
+			Data: makeManifestJSON(t, DepManifest{
+				Molds: []DepEntry{{Source: source, Version: "v1.0.0", Commit: "cafe0001"}},
+				Ores:  []DepEntry{{Source: source, Version: "v2.0.0", Commit: "cafe0002"}},
+			}),
+		},
+		"deps/molds/" + source + "/mold.yaml": &fstest.MapFile{
+			Data: []byte("apiVersion: v1\nkind: mold\nname: repo\nversion: 1.0.0\n"),
+		},
+		"deps/ores/" + source + "/ore.yaml": &fstest.MapFile{
+			Data: []byte("apiVersion: v1\nkind: ore\nname: repo\n"),
+		},
+	}
+
+	var manifest DepManifest
+	if data, err := fs.ReadFile(embFS, "deps/manifest.json"); err == nil {
+		_ = json.Unmarshal(data, &manifest)
+	}
+
+	_, version, _, ok := lookupArtifactInFS(embFS, &manifest, source, subpath)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if version != "v1.0.0" {
+		t.Errorf("version = %q, want v1.0.0 (mold wins over ore)", version)
+	}
+}
+
+// TestLookupArtifactInFS_NotFound verifies that a lookup for an absent
+// (source, subpath) returns ok=false without panicking.
+func TestLookupArtifactInFS_NotFound(t *testing.T) {
+	embFS := fstest.MapFS{
+		"deps/manifest.json": &fstest.MapFile{
+			Data: makeManifestJSON(t, DepManifest{}),
+		},
+	}
+	manifest := DepManifest{}
+	_, _, _, ok := lookupArtifactInFS(embFS, &manifest, "github.com/missing/repo", "")
+	if ok {
+		t.Error("expected ok=false for absent dep")
+	}
+}
+
 // TestEmbeddedDepFetcher_CacheEntry_missingKey verifies CacheEntry returns nil
 // for an unknown key without panicking.
 func TestEmbeddedDepFetcher_CacheEntry_missingKey(t *testing.T) {


### PR DESCRIPTION
closes #255

## Summary
`ResolveDepsEphemeral` in `cast.go` validates every dep in the root mold's dependency list, including `mold:` deps, by calling `resolveDepFS`. Previously `LookupEmbeddedArtifact` only checked `manifest.Ores` and `manifest.Ingots`, so a `mold:` dep always fell through to `foundry.ResolveWithMetadata` — which in offline cast mode called `ensureBareClone` and failed with "no cached clone".

This PR extends `LookupEmbeddedArtifact` (refactored into a testable `lookupArtifactInFS` helper) to check `manifest.Molds` first, so the embedded mold FS is returned and `ResolveDepsEphemeral` can validate the mold manifest without any network access.

## Changes
- `LookupEmbeddedArtifact`: now checks `manifest.Molds` before ores/ingots
- Refactored the lookup closure into `lookupArtifactInFS` for unit testability
- Added `TestLookupArtifactInFS_Mold`, `TestLookupArtifactInFS_MoldBeforeOre`, `TestLookupArtifactInFS_NotFound`

## UAT
1. Smelt a mold that has a remote `mold:` dep with a subpath (`//molds/leaf`) and a `^`-constraint version
2. Run `./smelted-binary cast` on an air-gapped machine (no git bare clone cached)
3. Verify cast succeeds and all skills are available offline