### PR TITLE
fix(cast): stage embedded dep ingots/ to disk for offline IngotResolver

### DIFF
--- a/internal/commands/cast_deps.go
+++ b/internal/commands/cast_deps.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
+	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
@@ -121,7 +122,18 @@ func castTransitiveDepsWith(fetcher depFetcher, rootResult *foundry.ResolveResul
 		// foundry.Fetch already returns a per-mold fs rooted at the mold dir
 		// (subpath included), and entry.Root points at that dir on disk —
 		// mirror what runCast does for the root mold.
-		reader := blanks.NewMoldReaderFromFS(entry.FS, entry.Root)
+		//
+		// For embedded deps entry.Root is empty (no on-disk path). Stage the
+		// dep's ingots/ subtree to a temp dir so the disk-based IngotResolver
+		// used during template rendering can find them.
+		moldRoot := entry.Root
+		if moldRoot == "" {
+			if tmpDir, serr := stageIngotsFromFS(entry.FS); serr == nil && tmpDir != "" {
+				defer func() { _ = os.RemoveAll(tmpDir) }()
+				moldRoot = tmpDir
+			}
+		}
+		reader := blanks.NewMoldReaderFromFS(entry.FS, moldRoot)
 
 		manifest, err := reader.LoadManifest()
 		if err != nil {
@@ -296,6 +308,43 @@ func depAlias(node *depgraph.Node, manifest *mold.Mold) string {
 		return manifest.Name
 	}
 	return ""
+}
+
+// stageIngotsFromFS extracts the ingots/ subtree from fsys into a temporary
+// directory, returning the temp dir path. Used when casting a transitive dep
+// served from the embedded binary FS (entry.Root == "") so the disk-based
+// IngotResolver can locate ingots via the temp dir. Returns ("", nil) when
+// fsys has no ingots/ directory.
+func stageIngotsFromFS(fsys fs.FS) (string, error) {
+	if _, err := fs.Stat(fsys, "ingots"); err != nil {
+		return "", nil
+	}
+	tmpDir, err := os.MkdirTemp("", "ailloy-dep-ingots-*")
+	if err != nil {
+		return "", err
+	}
+	werr := fs.WalkDir(fsys, "ingots", func(path string, d fs.DirEntry, werr error) error {
+		if werr != nil {
+			return werr
+		}
+		dest := filepath.Join(tmpDir, path)
+		if d.IsDir() {
+			return os.MkdirAll(dest, 0750) // #nosec G301
+		}
+		if merr := os.MkdirAll(filepath.Dir(dest), 0750); merr != nil { // #nosec G301
+			return merr
+		}
+		data, rerr := fs.ReadFile(fsys, path)
+		if rerr != nil {
+			return rerr
+		}
+		return os.WriteFile(dest, data, 0644) // #nosec G306
+	})
+	if werr != nil {
+		_ = os.RemoveAll(tmpDir)
+		return "", werr
+	}
+	return tmpDir, nil
 }
 
 // hashFileForDeps duplicates cast.go's hashFile to avoid an import cycle on

--- a/internal/commands/cast_deps_test.go
+++ b/internal/commands/cast_deps_test.go
@@ -258,6 +258,123 @@ func TestCastTransitiveDeps_InstallsLeafAsTransitive(t *testing.T) {
 	}
 }
 
+// TestStageIngotsFromFS_NoIngotsDir verifies that stageIngotsFromFS is a no-op
+// when the FS has no ingots/ directory: it returns ("", nil) without creating
+// any temp directory.
+func TestStageIngotsFromFS_NoIngotsDir(t *testing.T) {
+	fsys := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte("kind: mold\n")},
+	}
+	dir, err := stageIngotsFromFS(fsys)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dir != "" {
+		t.Errorf("expected empty string for FS without ingots/, got %q", dir)
+	}
+}
+
+// TestStageIngotsFromFS_StagesToDisk verifies that a FS with an ingots/
+// subtree is correctly extracted to a temp directory so the disk-based
+// IngotResolver can find it.
+func TestStageIngotsFromFS_StagesToDisk(t *testing.T) {
+	fsys := fstest.MapFS{
+		"mold.yaml":                  &fstest.MapFile{Data: []byte("kind: mold\n")},
+		"ingots/my-ingot/ingot.yaml": &fstest.MapFile{Data: []byte("name: my-ingot\n")},
+		"ingots/my-ingot/content.md": &fstest.MapFile{Data: []byte("# ingot content\n")},
+	}
+	dir, err := stageIngotsFromFS(fsys)
+	if err != nil {
+		t.Fatalf("stageIngotsFromFS: %v", err)
+	}
+	if dir == "" {
+		t.Fatal("expected non-empty temp dir path")
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	// Ingot files must be accessible on disk under the staged temp dir.
+	if _, err := os.Stat(filepath.Join(dir, "ingots", "my-ingot", "ingot.yaml")); err != nil {
+		t.Errorf("ingot.yaml not staged: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "ingots", "my-ingot", "content.md")); err != nil {
+		t.Errorf("content.md not staged: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "ingots", "my-ingot", "ingot.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "name: my-ingot\n" {
+		t.Errorf("staged ingot.yaml content = %q; want \"name: my-ingot\\n\"", string(data))
+	}
+}
+
+// TestCastTransitiveDeps_EmbeddedDepWithIngots verifies that a transitive dep
+// served from the embedded binary FS (entry.Root == "") can resolve its
+// ingots/ subtree at cast time. stageIngotsFromFS must extract the ingots
+// to a temp dir so the disk-based IngotResolver finds them.
+func TestCastTransitiveDeps_EmbeddedDepWithIngots(t *testing.T) {
+	tmp := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	// Leaf FS with an ingots/ subtree — no on-disk root (mimics embedded dep).
+	leafFS := fstest.MapFS{
+		"mold.yaml":                &fstest.MapFile{Data: []byte("apiVersion: v1\nkind: mold\nname: leaf\nversion: 1.0.0\n")},
+		"flux.yaml":                &fstest.MapFile{Data: []byte("output:\n  readme.md: README.md\n")},
+		"readme.md":                &fstest.MapFile{Data: []byte("# leaf readme\n")},
+		"ingots/helper/ingot.yaml": &fstest.MapFile{Data: []byte("name: helper\n")},
+		"ingots/helper/body.md":    &fstest.MapFile{Data: []byte("helper body\n")},
+	}
+	leafMold := &mold.Mold{APIVersion: "v1", Kind: "mold", Name: "leaf", Version: "1.0.0"}
+
+	fetcher := newFakeDepFetcher()
+	// root = "" signals embedded dep (no on-disk path).
+	fetcher.addMold("github.com/x/leaf-with-ingots", "1.0.0", &moldFixture{
+		mold: leafMold,
+		fs:   leafFS,
+		root: "",
+	})
+
+	root := &mold.Mold{
+		APIVersion: "v1", Kind: "mold", Name: "root", Version: "1.0.0",
+		Dependencies: []mold.Dependency{
+			{Mold: "github.com/x/leaf-with-ingots", Version: "^1.0.0"},
+		},
+	}
+	rootRef := &foundry.Reference{Host: "local", Owner: "dir", Repo: "root"}
+	rootResult := &foundry.ResolveResult{Ref: rootRef}
+
+	manifest := &foundry.InstalledManifest{APIVersion: "v1", Molds: []foundry.InstalledEntry{}}
+	if err := foundry.WriteInstalledManifest(filepath.Join(tmp, ".ailloy", "installed.yaml"), manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := castTransitiveDepsWith(fetcher, rootResult, root, map[string]any{}, ""); err != nil {
+		t.Fatalf("castTransitiveDepsWith: %v", err)
+	}
+
+	// Leaf's plain readme.md output should land on disk.
+	if _, err := os.Stat(filepath.Join(tmp, "README.md")); err != nil {
+		t.Errorf("leaf README.md missing: %v", err)
+	}
+
+	// Ingot files should have been staged (and cleaned up by defer in impl,
+	// but the cast itself must not fail — if stageIngotsFromFS had not worked,
+	// the IngotResolver would have found no search path for "ingots" and any
+	// template that references an ingot would blow up during copyResolvedFiles).
+	got, err := foundry.ReadInstalledManifest(filepath.Join(tmp, ".ailloy", "installed.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.FindBySource("github.com/x/leaf-with-ingots", "") == nil {
+		t.Errorf("leaf-with-ingots not recorded in installed.yaml")
+	}
+}
+
 // TestCastTransitiveDeps_LocalDirSentinel verifies that a local-dir (or
 // embedded) cast with mold-kind dependencies resolves them correctly when
 // rootResult is synthesised from the local mold name (the behaviour added by


### PR DESCRIPTION
closes #260

## Summary

When a transitive mold is served from the smelted binary's embedded FS (`entry.Root == ""`), the disk-based `IngotResolver` had no search path and could not locate ingots declared by that dep. Template execution would fail with `ingot "X" not found (searched: ingots, .ailloy/ingots)` even in an otherwise-valid offline cast.

## Changes

- `castTransitiveDepsWith`: when `entry.Root == ""` (embedded dep), call new `stageIngotsFromFS` to extract the dep's `ingots/` subtree to a temp dir; use that temp dir as the `MoldReader`'s disk root so `buildIngotResolver` can locate ingots on disk
- `stageIngotsFromFS`: new helper that walks `ingots/` from an `fs.FS` into a `os.MkdirTemp` directory; returns `("", nil)` when no `ingots/` dir exists (no-op for leaf molds without ingots)
- Three new tests: `TestStageIngotsFromFS_NoIngotsDir`, `TestStageIngotsFromFS_StagesToDisk`, `TestCastTransitiveDeps_EmbeddedDepWithIngots`

## UAT

1. Clone https://github.com/kriscoleman/ailloy-smelt-ingot-repro
2. `ailloy smelt ./molds/agg -o binary --output /tmp/ingot-out --no-animate`
3. `GIT_SSH_COMMAND=/bin/false GIT_CONFIG_GLOBAL=/dev/null HOME=$(mktemp -d) /tmp/ingot-out/agg-0.1.0 cast --no-animate`
4. Verify `.claude/agents/leaf-agent.md` contains the `INGOT-MARKER` line — previously this step failed with `ingot "leaf-frag" not found`