### PR TITLE
fix: resolve ore/ingot dep versions on component-prefixed monorepos (#263)

### DIFF
--- a/internal/commands/install_deps.go
+++ b/internal/commands/install_deps.go
@@ -271,6 +271,15 @@ func installDeclaredDeps(manifest *mold.Mold, moldKey string, global, allowLocal
 // the recorded version for local refs (they have no resolved tag).
 func resolveDepFS(ref, declaredVersion string, global bool) (fs.FS, string, string, string, string, error) {
 	if foundry.IsRemoteReference(ref) {
+		// Fold the dependency's declared version constraint into the reference.
+		// An ore/ingot source string carries no @version (the constraint lives
+		// in the dep's separate `version:` field), so without this the ref
+		// resolves as Latest. On a release-train monorepo whose subpath is
+		// tagged with component-prefixed tags (`<component>-vX.Y.Z`), Latest
+		// resolution fails with "no semver tags found"; embedding the
+		// constraint makes it resolve against those prefixed tags. See ailloy#263.
+		ref = refWithVersion(ref, declaredVersion)
+
 		// Check the smelted binary's embedded dep store first so offline casts
 		// can serve ore/ingot deps without any network access.
 		if parsed, perr := foundry.ParseReference(ref); perr == nil {
@@ -302,6 +311,26 @@ func resolveDepFS(ref, declaredVersion string, global bool) (fs.FS, string, stri
 		return nil, "", "", "", "", fmt.Errorf("%q is not a directory", path)
 	}
 	return os.DirFS(path), path, "", declaredVersion, "", nil
+}
+
+// refWithVersion embeds a dependency's declared version constraint into a
+// foundry reference string. ParseReference splits the //subpath before the
+// @version, so the version is inserted just before the //subpath (if any):
+// `<host>/<owner>/<repo>@<version>//<subpath>`. An empty version, or a ref
+// that already carries an @version, is returned unchanged.
+func refWithVersion(ref, version string) string {
+	if version == "" {
+		return ref
+	}
+	// Ignore a leading git@ SSH prefix when checking for an existing @version,
+	// so `git@github.com:owner/repo` isn't mistaken for an already-versioned ref.
+	if strings.Contains(strings.TrimPrefix(ref, "git@"), "@") {
+		return ref // already carries an @version
+	}
+	if i := strings.Index(ref, "//"); i != -1 {
+		return ref[:i] + "@" + version + ref[i:]
+	}
+	return ref + "@" + version
 }
 
 // depIdentity returns the (source, subpath) identity tuple for a dependency

--- a/pkg/foundry/fetcher.go
+++ b/pkg/foundry/fetcher.go
@@ -50,11 +50,17 @@ func (f *Fetcher) Fetch(ref *Reference, resolved *ResolvedVersion) (fs.FS, strin
 }
 
 // MoldVersionReaderFor returns a MoldVersionReader that reads the `version:`
-// field of the reference's mold.yaml at any given git tag. It ensures the
-// bare clone exists once, then serves each lookup with `git show <tag>:<path>`
+// field of the reference's package manifest at any given git tag. It ensures
+// the bare clone exists once, then serves each lookup with `git show <tag>:<path>`
 // against the local clone — cheap and offline. Results are memoised per tag.
 //
-// The reader reports found=false when no mold manifest exists at a tag (the
+// The package manifest may be a mold (`mold.yaml`), an ingot (`ingot.yaml`), or
+// an ore (`ore.yaml`) — all three declare a top-level `version:`. Ingot/ore
+// dependencies live at their own subpaths and must be ranked the same way as
+// mold deps; probing only `mold.yaml` would report found=false for every tag
+// of an ingot/ore subpath, excluding all candidates. See ailloy#263.
+//
+// The reader reports found=false when no package manifest exists at a tag (the
 // caller excludes that candidate), and found=true with an empty version when
 // the manifest exists but declares no version (the caller falls back to the
 // tag-embedded semver).
@@ -64,9 +70,16 @@ func (f *Fetcher) MoldVersionReaderFor(ref *Reference) (MoldVersionReader, error
 	}
 	bareDir := BareCloneDir(f.cacheDir, ref)
 
-	manifestPath := "mold.yaml"
-	if sp := strings.Trim(ref.Subpath, "/"); sp != "" {
-		manifestPath = sp + "/mold.yaml" // git object paths are always forward-slash
+	// Candidate manifest filenames, in precedence order. Git object paths are
+	// always forward-slash and prefixed with the subpath when present.
+	dir := strings.Trim(ref.Subpath, "/")
+	manifestPaths := make([]string, 0, 3)
+	for _, name := range []string{"mold.yaml", "ingot.yaml", "ore.yaml"} {
+		if dir != "" {
+			manifestPaths = append(manifestPaths, dir+"/"+name)
+		} else {
+			manifestPaths = append(manifestPaths, name)
+		}
 	}
 
 	type result struct {
@@ -82,15 +95,20 @@ func (f *Fetcher) MoldVersionReaderFor(ref *Reference) (MoldVersionReader, error
 		if r, ok := cache[tag]; ok {
 			return r.version, r.found
 		}
-		out, err := f.git("-C", bareDir, "show", tag+":"+manifestPath)
-		r := result{found: err == nil}
-		if r.found {
+		var r result
+		for _, manifestPath := range manifestPaths {
+			out, err := f.git("-C", bareDir, "show", tag+":"+manifestPath)
+			if err != nil {
+				continue
+			}
+			r.found = true
 			var m struct {
 				Version string `yaml:"version"`
 			}
 			if yaml.Unmarshal(out, &m) == nil {
 				r.version = m.Version
 			}
+			break
 		}
 		cache[tag] = r
 		return r.version, r.found

--- a/pkg/foundry/fetcher_test.go
+++ b/pkg/foundry/fetcher_test.go
@@ -289,3 +289,53 @@ func TestMoldVersionReaderFor(t *testing.T) {
 		t.Errorf("repeat lookup issued %d extra git show calls, want 0", shows-before)
 	}
 }
+
+// TestMoldVersionReaderFor_IngotAndOreManifests verifies the reader also finds
+// ingot.yaml and ore.yaml (not just mold.yaml). Ingot/ore deps live at their
+// own subpaths; before this the reader probed only mold.yaml, reported
+// found=false for every tag of an ingot/ore subpath, and the resolver then
+// excluded all candidates — surfacing as "no semver tags found". See ailloy#263.
+func TestMoldVersionReaderFor_IngotAndOreManifests(t *testing.T) {
+	cases := []struct {
+		name     string
+		subpath  string
+		manifest string // the git object path that exists
+		body     string
+		wantVer  string
+	}{
+		{"ingot", "ingots/pilot-facilitator-core", "ingots/pilot-facilitator-core/ingot.yaml", "kind: ingot\nname: pilot-facilitator-core\nversion: 0.1.0\n", "0.1.0"},
+		{"ore", "ores/pilot", "ores/pilot/ore.yaml", "kind: ore\nname: pilot\nversion: 0.3.0\n", "0.3.0"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cacheDir := t.TempDir()
+			ref := &Reference{Host: "github.com", Owner: "o", Repo: "foundry", Subpath: tc.subpath}
+			tag := tc.name + "-v" + tc.wantVer
+
+			git := func(args ...string) ([]byte, error) {
+				if len(args) >= 4 && args[0] == "clone" && args[1] == "--bare" {
+					if err := os.MkdirAll(args[3], 0750); err != nil {
+						return nil, err
+					}
+					return nil, os.WriteFile(filepath.Join(args[3], "HEAD"), []byte("ref: refs/heads/main"), 0644)
+				}
+				if len(args) == 4 && args[0] == "-C" && args[2] == "show" {
+					if args[3] == tag+":"+tc.manifest {
+						return []byte(tc.body), nil
+					}
+					// mold.yaml (probed first) is absent for an ingot/ore subpath.
+					return nil, fmt.Errorf("fatal: path does not exist")
+				}
+				return nil, fmt.Errorf("unexpected git call: %v", args)
+			}
+
+			reader, err := NewFetcherWithCacheDir(git, cacheDir).MoldVersionReaderFor(ref)
+			if err != nil {
+				t.Fatalf("MoldVersionReaderFor: %v", err)
+			}
+			if v, found := reader(tag); !found || v != tc.wantVer {
+				t.Errorf("%s = (%q, %v), want (%q, true)", tag, v, found, tc.wantVer)
+			}
+		})
+	}
+}

--- a/pkg/smelt/deps.go
+++ b/pkg/smelt/deps.go
@@ -183,9 +183,17 @@ func collectArtifactDeps(
 			continue
 		}
 
-		ref, err := foundry.ParseReference(raw)
+		// Fold the dependency's `version:` field into the reference. Unlike mold
+		// deps, an ore/ingot's source string carries no @version, so without this
+		// the reference resolves as Latest — and on a release-train monorepo that
+		// means "no semver tags found" whenever the subpath's component-prefixed
+		// tags don't happen to be the plain-tag latest. Embedding the constraint
+		// makes it resolve against the `<component>-vX.Y.Z` tags for the subpath.
+		refStr := withVersion(raw, dep.Version)
+
+		ref, err := foundry.ParseReference(refStr)
 		if err != nil {
-			return nil, fmt.Errorf("parsing %s ref %q: %w", kind, raw, err)
+			return nil, fmt.Errorf("parsing %s ref %q: %w", kind, refStr, err)
 		}
 		dedupeKey := ref.CacheKey() + "//" + ref.Subpath
 		if seen[dedupeKey] {
@@ -193,9 +201,9 @@ func collectArtifactDeps(
 		}
 		seen[dedupeKey] = true
 
-		fsys, result, err := resolveArtifact(raw, resolveOpts...)
+		fsys, result, err := resolveArtifact(refStr, resolveOpts...)
 		if err != nil {
-			return nil, fmt.Errorf("resolving %s %q: %w", kind, raw, err)
+			return nil, fmt.Errorf("resolving %s %q: %w", kind, refStr, err)
 		}
 
 		base := depFSPath(kind+"s", result.Ref.CacheKey(), result.Ref.Subpath)
@@ -232,6 +240,23 @@ func hasMoldDeps(m *mold.Mold) bool {
 		}
 	}
 	return false
+}
+
+// withVersion folds a dependency's `version:` field into a foundry reference
+// string. An ore/ingot source carries no @version (the constraint lives in a
+// separate YAML field), so it must be embedded before the reference is parsed.
+//
+// ParseReference splits the //subpath before the @version, so the version is
+// inserted just before the //subpath (if any): the result is
+// `<host>/<owner>/<repo>@<version>//<subpath>`. An empty version is a no-op.
+func withVersion(raw, version string) string {
+	if version == "" {
+		return raw
+	}
+	if i := strings.Index(raw, "//"); i != -1 {
+		return raw[:i] + "@" + version + raw[i:]
+	}
+	return raw + "@" + version
 }
 
 // depFSPath constructs the embedded FS path for a bundled dep artifact:


### PR DESCRIPTION
Fixes #263.

## Problem

An ore/ingot dependency declared in a `mold.yaml` fails to resolve on a monorepo whose subpaths are tagged with component-prefixed tags (`<component>-vX.Y.Z`), erroring:

```
resolving ingot github.com/replicated-collab/foundry//ingots/pilot-facilitator-core:
  resolving version: no semver tags found for github.com/replicated-collab/foundry
```

even though `pilot-facilitator-core-v0.2.0` exists.

## Root cause (two bugs)

1. **`MoldVersionReaderFor` probed only `mold.yaml`.** The release-train ranking reader reads a package's declared `version:` at each tag, but only ever looked for `<subpath>/mold.yaml`. An ore/ingot subpath has `ore.yaml` / `ingot.yaml` (both carry a top-level `version:`), so the reader reported `found=false` for *every* tag → `highestVersion` excluded all candidates → surfaced as the misleading `ErrNoSemverTags`.

2. **The ore/ingot paths never applied the dependency's `version:` field.** Mold deps fold `dep.Version` into the reference (`ref.Version` + `classifyConstraint`), but the ore/ingot paths passed the bare source string, so the ref resolved as `Latest` instead of the declared constraint. Fixed in both the cast/temper path (`resolveDepFS`) and the smelt packaging path (`collectArtifactDeps`) by embedding the version before resolving.

## What this does NOT change

Constraint-matching **semantics are unchanged**: a dependency constraint matches the dependency's **declared manifest version** (consistent with mold deps and the release-train `MoldVersionReader`), *not* the tag-embedded version. So a consumer must reference the ore/ingot by the version in its `ingot.yaml`/`ore.yaml`, exactly as for molds. (An earlier approach that made prefixed-tag versions authoritative was rejected because it broke the release-train case — `launch-v0.7.1` whose manifest is `0.2.1` must still satisfy `^0.2.0`.)

## Testing

- New regression test `TestMoldVersionReaderFor_IngotAndOreManifests` (ingot.yaml + ore.yaml probing).
- Full suite green (`go test ./...`, 25 packages), `go vet` clean.
- Verified end-to-end: a mold depending on `//ingots/pilot-facilitator-core@^0.1.0` (the ingot's declared version) now tempers cleanly; `@^0.2.0` correctly reports "no tag matching" (the ingot declares 0.1.0), rather than the misleading "no semver tags found".

🤖 Generated with [Claude Code](https://claude.com/claude-code)