### PR TITLE
fix: keep target-gated output files sharing a dest under different Set

### DIFF
--- a/pkg/mold/output_composite.go
+++ b/pkg/mold/output_composite.go
@@ -183,11 +183,15 @@ func ResolveFilesWithOreSources(output any, moldFS fs.FS, oreSources []OreSource
 		if resolved[i].DestPath != resolved[j].DestPath {
 			return resolved[i].DestPath < resolved[j].DestPath
 		}
+		if si, sj := setSignature(resolved[i].Set), setSignature(resolved[j].Set); si != sj {
+			return si < sj
+		}
 		return resolved[i].SrcPath < resolved[j].SrcPath
 	})
 
-	// Deduplicate by DestPath: consumer-origin (Origin == "") beats ore-origin;
-	// two ore-origin entries mapping to the same DestPath is a conflict error.
+	// Deduplicate by (DestPath, Set): consumer-origin (Origin == "") beats
+	// ore-origin; two ore-origin entries mapping to the same DestPath are a
+	// conflict error.
 	resolved, err = deduplicateByDestPath(resolved)
 	if err != nil {
 		return nil, err
@@ -196,9 +200,34 @@ func ResolveFilesWithOreSources(output any, moldFS fs.FS, oreSources []OreSource
 	return resolved, nil
 }
 
-// deduplicateByDestPath removes duplicate DestPath entries from a sorted slice.
-// Consumer-origin (Origin == "") beats ore-origin. Multiple ore-origin entries
-// with the same DestPath return an error naming the conflicting sources.
+// setSignature returns a deterministic signature of a render-context override
+// map. Two output entries that map the same source to the same DestPath but
+// under different Set contexts (e.g. agent.current_target=claude vs =opencode
+// for a target-gated file like mcp/.mcp.json) are NOT duplicates: each is a
+// distinct per-target render attempt, and the empty-render skip downstream
+// keeps whichever one produces content. Deduplication therefore keys on
+// (DestPath, Set) so those distinct contexts both survive.
+func setSignature(set map[string]any) string {
+	if len(set) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(set))
+	for k := range set {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for _, k := range keys {
+		fmt.Fprintf(&b, "%s=%v\x00", k, set[k])
+	}
+	return b.String()
+}
+
+// deduplicateByDestPath removes duplicate (DestPath, Set) entries from a slice
+// sorted by DestPath then Set signature. Consumer-origin (Origin == "") beats
+// ore-origin. Multiple ore-origin entries with the same DestPath and Set return
+// an error naming the conflicting sources. Entries sharing a DestPath but
+// carrying different Set contexts are kept as distinct render passes.
 func deduplicateByDestPath(resolved []ResolvedFile) ([]ResolvedFile, error) {
 	if len(resolved) <= 1 {
 		return resolved, nil
@@ -207,7 +236,8 @@ func deduplicateByDestPath(resolved []ResolvedFile) ([]ResolvedFile, error) {
 	i := 0
 	for i < len(resolved) {
 		j := i + 1
-		for j < len(resolved) && resolved[j].DestPath == resolved[i].DestPath {
+		for j < len(resolved) && resolved[j].DestPath == resolved[i].DestPath &&
+			setSignature(resolved[j].Set) == setSignature(resolved[i].Set) {
 			j++
 		}
 		group := resolved[i:j]

--- a/pkg/mold/output_composite_test.go
+++ b/pkg/mold/output_composite_test.go
@@ -1,6 +1,7 @@
 package mold
 
 import (
+	"fmt"
 	"io/fs"
 	"sort"
 	"strings"
@@ -242,6 +243,47 @@ func TestResolveFilesWithOreSources_DestPathDedup_ConsumerWins(t *testing.T) {
 	}
 	if resolved[0].SrcPath != "consumer.md" {
 		t.Errorf("expected consumer.md, got %q", resolved[0].SrcPath)
+	}
+}
+
+// Regression: a source mapped to the same DestPath under two different Set
+// contexts (e.g. a target-gated mcp/.mcp.json rendered once with
+// agent.current_target=claude and once =opencode) must NOT be deduplicated to
+// a single entry. Both render passes must survive; the empty-render skip
+// downstream keeps whichever produces content. Previously deduplicateByDestPath
+// keyed on DestPath alone and dropped one context, silently losing MCP configs.
+func TestResolveFilesWithOreSources_SameDestDifferentSetKeptDistinct(t *testing.T) {
+	moldFS := fstest.MapFS{
+		"mold.yaml":     &fstest.MapFile{Data: []byte("name: c\n")},
+		"mcp/.mcp.json": &fstest.MapFile{Data: []byte("{{ .agent.current_target }}\n")},
+	}
+	// Map the mcp dir to the repo root twice, once per target context.
+	output := map[string]any{
+		"mcp": []any{
+			map[string]any{"dest": ".", "set": map[string]any{"agent.current_target": "claude"}},
+			map[string]any{"dest": ".", "set": map[string]any{"agent.current_target": "opencode"}},
+		},
+	}
+	resolved, err := ResolveFilesWithOreSources(output, moldFS, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Both target contexts for .mcp.json must be present (2 entries), not 1.
+	var mcp []ResolvedFile
+	for _, r := range resolved {
+		if r.DestPath == ".mcp.json" {
+			mcp = append(mcp, r)
+		}
+	}
+	if len(mcp) != 2 {
+		t.Fatalf("expected 2 .mcp.json render passes (claude + opencode), got %d: %+v", len(mcp), mcp)
+	}
+	seen := map[string]bool{}
+	for _, r := range mcp {
+		seen[fmt.Sprintf("%v", r.Set["agent.current_target"])] = true
+	}
+	if !seen["claude"] || !seen["opencode"] {
+		t.Errorf("expected both claude and opencode current_target contexts, got %v", seen)
 	}
 }
 


### PR DESCRIPTION
## Problem

Casting a mold whose `output` maps a target-gated directory once per target — the common pattern:

```yaml
output:
  mcp:
    - dest: .
      set: { agent.current_target: claude }
    - dest: .
      set: { agent.current_target: opencode }
```

silently **drops** the rendered file (e.g. `.mcp.json`) for one target. It surfaces as `MCP config missing: .mcp.json` in cast validation.

## Root cause

`deduplicateByDestPath` (added when casts began routing through `ResolveFilesWithOreSources`) keyed dedup on **DestPath alone**. The two mappings above both resolve `mcp/.mcp.json → ./.mcp.json`, differing only by their `Set` (`agent.current_target`). Those aren't duplicates — they're two per-target render passes, and the empty-render skip is meant to keep whichever renders non-empty (`.mcp.json` renders under `claude`, empty under `opencode`). Dedup-ing on DestPath kept an arbitrary one; when it kept the `opencode` context, `.mcp.json` rendered empty and was skipped → file lost.

This is a regression vs the pre-`ResolveFilesWithOreSources` behavior (no such dedup), where both passes survived to the skip-empty stage.

## Fix

Deduplicate on **(DestPath, Set)**. Entries sharing a DestPath but carrying different `Set` contexts are distinct render passes and both survive; the empty-render skip downstream keeps the one that produces content. True duplicates (same DestPath **and** Set) still dedup with the existing consumer-wins / ore-ore-conflict semantics — those tests are unchanged.

## Testing

- New regression test `TestResolveFilesWithOreSources_SameDestDifferentSetKeptDistinct`.
- Existing dedup tests (backward-compat, ore-ore conflict, consumer-wins) still pass.
- Full suite green (`go test ./...`, 25 packages), `go vet` clean.
- Verified end-to-end: `ailloy cast <gtm mold> --set agent.targets=[claude]` now writes `.mcp.json` (was dropped at v0.6.41, present at v0.6.19).

> **Release note:** foundry's cast-integration CI and the pilot-gastown aggregator (replicated-collab/foundry#104) need this in a tagged release (v0.6.42) to cast tokenlessly with MCP intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)