### PR TITLE
fix(smelt): make aggregator molds castable from a smelted binary

### DIFF
--- a/internal/commands/cast.go
+++ b/internal/commands/cast.go
@@ -863,8 +863,10 @@ func copyResolvedFilesWithSchema(reader *blanks.MoldReader, manifest *mold.Mold,
 		logger.Printf("warning: %v", err)
 	}
 
-	// Build ingot resolver
+	// Build ingot resolver. Also search the mold's own FS (the embedded
+	// filesystem for stuffed-binary casts, where the mold's ingots live off-disk).
 	resolver := buildIngotResolver(flux, reader.Root())
+	resolver.FS = reader.FS()
 	tplOpts := []mold.TemplateOption{
 		mold.WithIngotResolver(resolver),
 		mold.WithLogger(logger),

--- a/internal/commands/cast_plugin.go
+++ b/internal/commands/cast_plugin.go
@@ -157,6 +157,7 @@ func renderMoldFiles(reader *blanks.MoldReader, manifest *mold.Mold, flux map[st
 	}
 
 	resolver := buildIngotResolver(flux, reader.Root())
+	resolver.FS = reader.FS()
 	tplOpts := []mold.TemplateOption{
 		mold.WithIngotResolver(resolver),
 		mold.WithLogger(logger),
@@ -212,6 +213,7 @@ func readMoldReadme(reader *blanks.MoldReader, flux map[string]any) ([]byte, err
 		return nil, fmt.Errorf("reading mold README.md: %w", err)
 	}
 	resolver := buildIngotResolver(flux, reader.Root())
+	resolver.FS = reader.FS()
 	processed, perr := mold.ProcessTemplate(string(raw), flux, mold.WithIngotResolver(resolver))
 	if perr != nil {
 		return nil, fmt.Errorf("processing mold README.md: %w", perr)

--- a/internal/commands/forge.go
+++ b/internal/commands/forge.go
@@ -160,6 +160,7 @@ func runForge(_ *cobra.Command, args []string) error {
 
 	// Build ingot resolver
 	ingotResolver := buildIngotResolver(flux, reader.Root())
+	ingotResolver.FS = reader.FS()
 	opts := []mold.TemplateOption{mold.WithIngotResolver(ingotResolver)}
 
 	// Load ignore patterns from .ailloyignore and mold.yaml.

--- a/internal/commands/temper.go
+++ b/internal/commands/temper.go
@@ -164,6 +164,7 @@ func runTemperLint(moldDir string) error {
 
 	// Build ingot resolver and render files
 	resolver := buildIngotResolver(flux, reader.Root())
+	resolver.FS = reader.FS()
 	opts := []mold.TemplateOption{mold.WithIngotResolver(resolver)}
 
 	resolved, err := mold.ResolveFiles(flux["output"], reader.FS())

--- a/pkg/mold/ingot_resolver.go
+++ b/pkg/mold/ingot_resolver.go
@@ -2,7 +2,9 @@ package mold
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -12,7 +14,13 @@ import (
 // IngotResolver resolves {{ingot "name"}} template function calls by searching
 // for ingot content across a list of directories. It supports both manifest-based
 // ingots (directory with ingot.yaml) and bare file ingots (name.md).
+//
+// FS, when non-nil, is searched (at "ingots/<name>") before the disk SearchPaths.
+// This is how a stuffed-binary cast resolves the mold's own ingots: the mold
+// lives in an embedded fs.FS, not on disk, so a purely path-based search would
+// miss them.
 type IngotResolver struct {
+	FS          fs.FS
 	SearchPaths []string
 	Flux        map[string]any
 	resolving   map[string]bool
@@ -27,6 +35,14 @@ func NewIngotResolver(searchPaths []string, flux map[string]any) *IngotResolver 
 	}
 }
 
+// NewIngotResolverWithFS is NewIngotResolver plus an fs.FS (e.g. the mold's
+// embedded filesystem) searched before the disk SearchPaths.
+func NewIngotResolverWithFS(fsys fs.FS, searchPaths []string, flux map[string]any) *IngotResolver {
+	r := NewIngotResolver(searchPaths, flux)
+	r.FS = fsys
+	return r
+}
+
 // Resolve finds and renders an ingot by name. It searches each path for a
 // directory with an ingot.yaml manifest first, then falls back to a bare .md file.
 // The ingot content is rendered through the same template engine with the same
@@ -37,6 +53,17 @@ func (r *IngotResolver) Resolve(name string) (string, error) {
 	}
 	r.resolving[name] = true
 	defer delete(r.resolving, name)
+
+	// Search the embedded/mold fs.FS first (stuffed-binary casts: the mold and
+	// its ingots live in this FS, not on disk).
+	if r.FS != nil {
+		if content, err := r.resolveManifestFS(path.Join("ingots", name, "ingot.yaml"), name); err == nil {
+			return r.render(content)
+		}
+		if content, err := fs.ReadFile(r.FS, path.Join("ingots", name+".md")); err == nil {
+			return r.render(string(content))
+		}
+	}
 
 	for _, base := range r.SearchPaths {
 		// Try directory with manifest first
@@ -90,6 +117,33 @@ func (r *IngotResolver) resolveManifest(manifestPath, name string) (string, erro
 		combined.Write(content)
 	}
 
+	return combined.String(), nil
+}
+
+// resolveManifestFS loads an ingot.yaml manifest from r.FS and concatenates all
+// listed files. The fs.FS analogue of resolveManifest for stuffed-binary casts.
+func (r *IngotResolver) resolveManifestFS(manifestPath, name string) (string, error) {
+	data, err := fs.ReadFile(r.FS, manifestPath)
+	if err != nil {
+		return "", err
+	}
+	ingot, err := ParseIngot(data)
+	if err != nil {
+		return "", fmt.Errorf("parsing ingot %q manifest: %w", name, err)
+	}
+	ingotDir := path.Dir(manifestPath)
+	var combined strings.Builder
+	for _, f := range ingot.Files {
+		fp := path.Join(ingotDir, f)
+		if !fs.ValidPath(fp) {
+			return "", fmt.Errorf("ingot %q file %q: invalid path", name, f)
+		}
+		content, err := fs.ReadFile(r.FS, fp)
+		if err != nil {
+			return "", fmt.Errorf("reading ingot %q file %q: %w", name, f, err)
+		}
+		combined.Write(content)
+	}
 	return combined.String(), nil
 }
 

--- a/pkg/mold/ingot_resolver_test.go
+++ b/pkg/mold/ingot_resolver_test.go
@@ -5,7 +5,36 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"testing/fstest"
 )
+
+// TestIngotResolver_FS covers the stuffed-binary cast path: the mold (and its
+// ingots) live in an embedded fs.FS, not on disk, so the resolver must search
+// r.FS. Regression test for embedded ingots resolving to "not found".
+func TestIngotResolver_FS(t *testing.T) {
+	fsys := fstest.MapFS{
+		"ingots/footer.md":       {Data: []byte("-- footer --")},
+		"ingots/head/ingot.yaml": {Data: []byte("files:\n  - head.md\n")},
+		"ingots/head/head.md":    {Data: []byte("== head ==")},
+	}
+	r := NewIngotResolverWithFS(fsys, nil, nil)
+
+	got, err := r.Resolve("footer")
+	if err != nil {
+		t.Fatalf("bare-file ingot from FS: unexpected error: %v", err)
+	}
+	if got != "-- footer --" {
+		t.Errorf("bare-file ingot: got %q, want %q", got, "-- footer --")
+	}
+
+	got, err = r.Resolve("head")
+	if err != nil {
+		t.Fatalf("manifest ingot from FS: unexpected error: %v", err)
+	}
+	if got != "== head ==" {
+		t.Errorf("manifest ingot: got %q, want %q", got, "== head ==")
+	}
+}
 
 func TestIngotResolver_BareFile(t *testing.T) {
 	dir := t.TempDir()

--- a/pkg/smelt/tarball.go
+++ b/pkg/smelt/tarball.go
@@ -105,7 +105,19 @@ func collectMoldFiles(moldFS fs.FS, moldDir string) ([]archiveFile, bool, error)
 	if err != nil {
 		return nil, false, fmt.Errorf("resolving output files: %w", err)
 	}
+	// Archive each source file once, even when the output maps it to multiple
+	// destinations (e.g. AGENTS.md -> {AGENTS.md, CLAUDE.md} via strategy:append,
+	// or one source rendered per target). archiveFiles are keyed by source path,
+	// so adding the same SrcPath twice produces a duplicate entry — which stuffbin
+	// records as two files at the same path, and the resulting binary then fails
+	// to open its embedded mold ("file already exists"). Cast re-reads the single
+	// embedded source for every destination, so one copy is sufficient.
+	seenSrc := make(map[string]bool)
 	for _, rf := range resolved {
+		if seenSrc[rf.SrcPath] {
+			continue
+		}
+		seenSrc[rf.SrcPath] = true
 		data, err := fs.ReadFile(moldFS, rf.SrcPath)
 		if err != nil {
 			return nil, false, fmt.Errorf("reading %s: %w", rf.SrcPath, err)

--- a/pkg/smelt/tarball_test.go
+++ b/pkg/smelt/tarball_test.go
@@ -8,9 +8,44 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"testing/fstest"
 
 	"github.com/nimble-giant/ailloy/pkg/mold"
 )
+
+// TestCollectMoldFiles_DedupsMultiDestSource guards against a source file being
+// archived once per output destination. A mold that maps one source to two
+// destinations (e.g. AGENTS.md -> {AGENTS.md, CLAUDE.md}) must still embed the
+// source exactly once — otherwise stuffbin records two files at the same path
+// and the smelted binary fails to open its embedded mold ("file already exists").
+func TestCollectMoldFiles_DedupsMultiDestSource(t *testing.T) {
+	moldFS := fstest.MapFS{
+		"mold.yaml": {Data: []byte("name: m\nversion: 0.1.0\n")},
+		"flux.yaml": {Data: []byte(
+			"output:\n" +
+				"  AGENTS.md:\n" +
+				"    - dest: AGENTS.md\n" +
+				"      strategy: append\n" +
+				"    - dest: CLAUDE.md\n" +
+				"      strategy: append\n")},
+		"AGENTS.md": {Data: []byte("shared instructions")},
+	}
+
+	files, _, err := collectMoldFiles(moldFS, t.TempDir())
+	if err != nil {
+		t.Fatalf("collectMoldFiles: %v", err)
+	}
+
+	count := 0
+	for _, f := range files {
+		if f.path == "AGENTS.md" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("AGENTS.md archived %d times, want 1", count)
+	}
+}
 
 // writeMoldFixture creates a minimal valid mold directory structure in dir.
 func writeMoldFixture(t *testing.T, dir string) {


### PR DESCRIPTION
## Problem

Smelting an aggregator mold to a self-contained binary (`smelt -o binary`) and then casting it offline failed in two independent ways. Both surfaced while smelting `pilot-gastown` (an aggregator that layers a facilitator + pathway skills over `replicated-vendor`) for the factory long-lived-assistant VM, which casts skills offline from a committed binary.

### Bug 1 — duplicate embedded source (`file already exists: /AGENTS.md`)

When a mold maps **one source to multiple destinations** — e.g. `pilot-gastown`'s
```yaml
AGENTS.md:
  - dest: AGENTS.md
    strategy: append
  - dest: CLAUDE.md
    strategy: append
```
`collectMoldFiles` archived the source **once per destination**. stuffbin then recorded two files at the same embedded path, and the resulting binary failed to open its own embedded mold:

```
Error: opening embedded mold: file already exists: /AGENTS.md
```

**Fix:** deduplicate embedded sources by source path. Cast re-reads the single embedded source for each destination, so one copy is correct.

### Bug 2 — embedded ingots not found during cast

After Bug 1, the cast failed rendering an agent that uses `{{ingot "..."}}`:

```
ingot "helm-lint-agent-frontmatter-claude" not found
  (searched: ingots, .ailloy/ingots, /Users/.../.ailloy/ingots)
```

The ingot **is** embedded (`/ingots/helm-lint-agent-frontmatter-claude.md`), but `IngotResolver` only searched **disk** paths. A stuffed-binary cast's mold lives in an embedded `fs.FS`, not on disk, so its own ingots were unreachable.

**Fix:** make `IngotResolver` FS-aware — it searches an optional `fs.FS` (the mold's embedded filesystem) before the disk paths — and wire `reader.FS()` into every cast site.

## Verification

Re-smelt + offline cast of `pilot-gastown` now renders the **complete** mold: 68 skills, 6 agents, `AGENTS.md` + `CLAUDE.md`, and the facilitator agent with its ingot fully expanded (zero `{{ingot}}` leftovers). No workaround/pre-rendered archive — these are root-cause fixes in the smelt/cast path.

## Tests

- `pkg/smelt`: `TestCollectMoldFiles_DedupsMultiDestSource` — one source → two dests embeds the source once.
- `pkg/mold`: `TestIngotResolver_FS` — bare-file and manifest ingots resolve from an `fs.FS`.

Full suite passes; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)