### PR TITLE
feat: add native Codex skills and agents support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Find, create, and share reusable AI workflow packages — the way [Helm](https:/
 ## Why Ailloy
 
 - **Reproducible** — Versioned, configurable mold packages with Helm-style value precedence. Same mold, same flux values, same output every time.
-- **Tool-agnostic** — Works with any AI coding tool that reads file-based instructions: Claude Code, Cursor, Windsurf, GitHub Copilot, and [more](https://agents.md). The `output:` mapping in `flux.yaml` decides where blanks land.
+- **Tool-agnostic** — Works with any AI coding tool that reads file-based instructions: Codex, Claude Code, Cursor, Windsurf, GitHub Copilot, and [more](https://agents.md). The `output:` mapping in `flux.yaml` decides where blanks land.
 - **Helm-style ergonomics** — `cast`, `forge`, `smelt`, `temper`. If you know `helm install` and `helm template`, you already know the shape.
 
 ## What is Ailloy?
@@ -200,7 +200,7 @@ ailloy cast github.com/nimble-giant/nimble-mold -f flux-overrides.yaml
 
 **`ailloy assay [path]`** (alias: `lint`) — Lint rendered AI instruction files.
 
-- Auto-detects CLAUDE.md, AGENTS.md, Cursor rules, Copilot instructions, and more
+- Auto-detects CLAUDE.md, AGENTS.md, Codex skills and custom agents, Cursor rules, Copilot instructions, and more
 - `--format json|markdown` for CI · `--fail-on warning|suggestion` for exit control
 - Configure via `.ailloyrc.yaml` (`--init` for a starter)
 
@@ -335,6 +335,8 @@ Update the status field ({{ .ore.status.field_id }}) after each step.
 ```
 
 The [official mold](https://github.com/nimble-giant/nimble-mold) ships pre-built blanks for SDLC tasks (issue management, PR workflows, code review) and is a good reference. For the full guide, see [docs/blanks.md](docs/blanks.md). For packaging, see [docs/smelt.md](docs/smelt.md).
+
+Ailloy supports Codex Agent Skills at `.agents/skills/<name>/SKILL.md` and custom agents at `.codex/agents/<name>.toml`; see [Codex Skills and Agents](docs/codex.md).
 
 ## Configuration
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ These guides teach you how to create, package, and share your own AI workflow pa
 ## Getting Started
 
 - [Blanks](blanks.md) — What blanks are and how to create commands, skills, and workflows
+- [Codex Skills and Agents](codex.md) — Build and distribute native Codex skills and custom agents
 - [Coming from Helm?](helm-users.md) — Concept map, command equivalences, and what's new
 
 ## Authoring Guides

--- a/docs/assay.md
+++ b/docs/assay.md
@@ -40,6 +40,8 @@ ailloy lint
 | Rule | Severity | Description |
 |------|----------|-------------|
 | `agent-frontmatter` | Error/Warning | `.claude/agents/*.yml` (or plugin `agents/`) missing required `name` or recommended `description` |
+| `codex-agent-schema` | Error | `.codex/agents/*.toml` is invalid TOML or is missing non-empty `name`, `description`, or `developer_instructions` |
+| `codex-skill-frontmatter` | Error | `.agents/skills/<name>/SKILL.md` has invalid YAML frontmatter or is missing non-empty `name` or `description` |
 | `command-frontmatter` | Warning | `.claude/commands/*.md` (or plugin `commands/` / `skills/`) frontmatter contains unknown fields; auto-fixable via `ailloy lint --fix` or `ailloy config allow-fields` |
 | `settings-schema` | Error | `.claude/settings.json` has invalid JSON or unknown hook event types |
 | `plugin-manifest` | Error | `.claude-plugin/plugin.json` is invalid JSON or missing required fields (`name`, `version`, `description`) |
@@ -126,7 +128,7 @@ Assay auto-detects platforms by file presence:
 |----------|-------|
 | Claude | `CLAUDE.md`, `.claude/CLAUDE.md`, `.claude/rules/*.md`, `CLAUDE.local.md` |
 | Cursor | `.cursor/rules/*.md`, `.cursorrules` |
-| Codex | `AGENTS.md`, `codex.md` |
+| Codex | Root and nested `AGENTS.md`, `codex.md`, `**/.agents/skills/**/*.md`, `.codex/agents/*.toml` |
 | Copilot | `.github/copilot-instructions.md` |
 | Generic | `AGENTS.md` (root and nested directories) |
 
@@ -134,6 +136,7 @@ Use `--platform` to limit linting to a single platform:
 
 ```bash
 ailloy assay --platform claude
+ailloy assay --platform codex
 ```
 
 ## Severity Levels

--- a/docs/blanks.md
+++ b/docs/blanks.md
@@ -10,7 +10,7 @@ The only constraints are:
 
 - **Reserved root files** are mold metadata and are never installed: `mold.yaml`, `flux.yaml`, `flux.schema.yaml`, `ingot.yaml`, `README.md`, `PLUGIN_SUMMARY.md`, `LICENSE`, and `.ailloyignore`
 - **`ingots/`** is reserved for reusable template partials (see [Ingots](ingots.md))
-- **Hidden directories** (starting with `.`) are excluded from auto-discovery
+- **Hidden directories** (starting with `.`) are excluded from auto-discovery. When `output:` is omitted, the native Codex instruction directories `.agents/skills/` and `.codex/agents/` are preserved at the same paths
 - **Ignored files** specified via `.ailloyignore` or `mold.yaml` `ignore:` are excluded (see [Ignoring Files](#ignoring-files))
 
 Everything else — directory names, nesting, file types — is up to you. A mold with `prompts/` and `guidelines/` directories is just as valid as one with `commands/` and `skills/`:
@@ -62,6 +62,8 @@ my-mold/
 ```
 
 Skills are ideal for instructions that should always be available — coding standards, review guidelines, or domain-specific knowledge.
+
+For Codex and other tools that implement Agent Skills, use the `skills/<name>/SKILL.md` layout. See [Codex Skills and Agents](codex.md).
 
 #### Workflows
 
@@ -263,7 +265,7 @@ Blanks are automatically discovered from your mold's directory structure. The `o
 - **String output** — all top-level directories go under the specified parent
 - **No output key** — files are placed at their source paths (identity mapping)
 
-Non-reserved root-level files (e.g., `AGENTS.md`) are auto-discovered and installed to the project root. The `ingots/` directory, reserved root files, and hidden directories (starting with `.`) are always excluded from auto-discovery.
+Non-reserved root-level files (e.g., `AGENTS.md`) are auto-discovered and installed to the project root. The `ingots/` directory, reserved root files, and hidden directories (starting with `.`) are excluded from auto-discovery, apart from the two native Codex identity paths described above.
 
 ## Ignoring Files
 
@@ -359,6 +361,18 @@ output:
   commands: .claude/commands
   skills: .claude/skills
 ```
+
+### Codex
+
+Codex loads repository Agent Skills from `.agents/skills/<name>/SKILL.md` and project custom agents from `.codex/agents/<name>.toml`:
+
+```yaml
+output:
+  skills: .agents/skills
+  codex-agents: .codex/agents
+```
+
+Agent Skills can fan out unchanged to compatible tools. Provider-native custom agents use separate source templates; Codex custom agents are TOML configuration layers. See [Codex Skills and Agents](codex.md).
 
 ### Cursor
 

--- a/docs/clidocs.go
+++ b/docs/clidocs.go
@@ -62,6 +62,7 @@ var summaries = map[string]string{
 	"plugin":             "Generate plugins from molds (Claude Code)",
 	"ingots":             "Reusable template components",
 	"agents-md":          "Tool-agnostic agent instructions in molds",
+	"codex":              "Build and install Codex Agent Skills and custom agents",
 	"cast-claude-plugin": "Cast a mold as a Claude Code plugin",
 	"helm-users":         "Concept map for Helm users coming to Ailloy",
 	"cache":              "Clear ailloy's on-disk cache (mold artifacts and foundry indexes)",

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -1,0 +1,151 @@
+# Codex Skills and Agents
+
+Ailloy supports Codex's native repository and user-level instruction surfaces:
+
+| Capability | Project destination | User destination |
+|---|---|---|
+| Repository instructions | `AGENTS.md` | — |
+| Agent Skills | `.agents/skills/<name>/SKILL.md` | `~/.agents/skills/<name>/SKILL.md` |
+| Custom agents | `.codex/agents/<name>.toml` | `~/.codex/agents/<name>.toml` |
+
+These layouts follow OpenAI's current [skill](https://learn.chatgpt.com/docs/build-skills) and [custom agent](https://learn.chatgpt.com/docs/agent-configuration/subagents) documentation.
+
+## Package layout
+
+A Codex-focused mold can keep authoring paths descriptive and map them to Codex at cast time:
+
+```text
+codex-workflows/
+├── mold.yaml
+├── flux.yaml
+├── AGENTS.md
+├── skills/
+│   └── reviewing/
+│       ├── SKILL.md
+│       ├── references/
+│       │   └── checklist.md
+│       └── scripts/
+│           └── collect-diff.sh
+└── agents/
+    └── reviewer.toml
+```
+
+```yaml
+# flux.yaml
+output:
+  skills: .agents/skills
+  agents: .codex/agents
+  AGENTS.md: AGENTS.md
+```
+
+`ailloy cast` renders the files with the mold's flux values and preserves each source directory's relative structure.
+
+## Agent Skills
+
+Each skill is a directory containing a `SKILL.md` file and optional scripts, references, and assets. `SKILL.md` requires YAML frontmatter with `name` and `description`:
+
+```markdown
+---
+name: reviewing
+description: Reviews code changes for correctness, security, and missing tests.
+---
+
+# Reviewing
+
+Follow the review workflow in this skill.
+```
+
+With the output mapping above, `skills/reviewing/SKILL.md` is installed as `.agents/skills/reviewing/SKILL.md`.
+
+## Custom agents
+
+Each Codex custom agent is a TOML configuration layer. The required fields are `name`, `description`, and `developer_instructions`:
+
+```toml
+# agents/reviewer.toml
+name = "reviewer"
+description = "Reviews changes for correctness, security, and missing tests."
+sandbox_mode = "read-only"
+developer_instructions = """
+Review code like an owner.
+Lead with concrete findings and cite files and symbols.
+Do not edit application code.
+"""
+```
+
+Custom agents may also use other supported Codex configuration fields, such as `model`, `model_reasoning_effort`, `mcp_servers`, and `skills.config`.
+
+## Install and validate
+
+Install into the current repository:
+
+```bash
+ailloy cast ./codex-workflows
+```
+
+Install user-wide skills and agents under the current user's home directory:
+
+```bash
+ailloy cast ./codex-workflows --global
+```
+
+Lint rendered Codex instructions:
+
+```bash
+ailloy assay --platform codex
+```
+
+Assay discovers:
+
+- `AGENTS.md` and nested `AGENTS.md` files.
+- Agent Skill markdown under repository `.agents/skills/` directories.
+- Custom agents under `.codex/agents/*.toml`.
+
+It verifies required skill frontmatter and parses custom-agent TOML, including the three required agent fields.
+
+## Native-layout molds
+
+A mold may instead ship files already arranged at their final Codex paths:
+
+```text
+codex-workflows/
+├── mold.yaml
+├── .agents/
+│   └── skills/
+│       └── reviewing/
+│           └── SKILL.md
+└── .codex/
+    └── agents/
+        └── reviewer.toml
+```
+
+When `output:` is omitted, Ailloy preserves `.agents/skills/` and `.codex/agents/` at those exact destinations even though other dot-prefixed directories remain excluded.
+
+## Multi-platform packages
+
+Agent Skills use an open directory format, so one source can target multiple compatible tools:
+
+```yaml
+output:
+  skills:
+    - .agents/skills
+    - .claude/skills
+```
+
+Provider-native custom-agent formats should use separate outer templates. Shared behavioral instructions can live in an [ingot](ingots.md) and be included by each target's template:
+
+```text
+multi-platform-workflows/
+├── claude-agents/
+│   └── reviewer.md
+├── codex-agents/
+│   └── reviewer.toml
+└── ingots/
+    └── reviewer-body.md
+```
+
+```yaml
+output:
+  claude-agents: .claude/agents
+  codex-agents: .codex/agents
+```

--- a/docs/flux.md
+++ b/docs/flux.md
@@ -343,7 +343,7 @@ ailloy cast ./my-mold -f team-cursor.yaml
 
 For more multi-tool targeting patterns, see [Targeting Different AI Tools](blanks.md#targeting-different-ai-tools).
 
-The `ingots/` directory and hidden directories (starting with `.`) are always excluded from output resolution.
+The `ingots/` directory and hidden directories (starting with `.`) are excluded from automatic output resolution. When `output:` is omitted, `.agents/skills/` and `.codex/agents/` are preserved as native Codex identity paths. Explicit map output can target any destination.
 
 ## Validation
 

--- a/docs/ore.md
+++ b/docs/ore.md
@@ -273,7 +273,14 @@ output:
 
 #### Worked example: `agent_targets`
 
-A complete worked example lives in [`testdata/agent_targets/`](../testdata/agent_targets/). The ore ships an `output:` block that fans `blanks/agents/` out to both `.claude/agents` and `.opencode/agents` with per-target `set: { current_target: <name> }` context, plus `blanks/AGENTS.md → AGENTS.md`. A consumer can pick up the entire multi-target rendering with nothing but a one-line dependency:
+A complete worked example lives in [`testdata/agent_targets/`](../testdata/agent_targets/). The ore ships an `output:` block that:
+
+- Fans `blanks/agents/` out to `.claude/agents` and `.opencode/agents` with per-target `set: { current_target: <name> }` context.
+- Installs target-specific TOML from `blanks/codex-agents/` into `.codex/agents`.
+- Fans one portable Agent Skill from `blanks/skills/` into both `.claude/skills` and `.agents/skills`.
+- Installs `blanks/AGENTS.md` as the project-root `AGENTS.md`.
+
+A consumer can pick up the entire multi-target rendering with nothing but a one-line dependency:
 
 ```yaml
 # consumer/mold.yaml
@@ -286,7 +293,7 @@ dependencies:
     version: 0.1.0
 ```
 
-No `output:` block needed in the consumer. Cast renders `AGENTS.md`, `.claude/agents/...`, and `.opencode/agents/...` from the ore's blanks, each with its per-target context.
+No `output:` block is needed in the consumer. Cast renders `AGENTS.md`, Claude/OpenCode agent definitions, native Codex custom-agent TOML, and the shared Claude/Codex skill from the ore's blanks.
 
 #### Debug provenance
 
@@ -295,7 +302,10 @@ Run `ailloy forge --debug` to see which file came from which ore:
 ```
 [forge --debug] resolved output (dest ← src @ origin):
   AGENTS.md                                ← blanks/AGENTS.md                         @ ore:agent_targets
+  .agents/skills/example/SKILL.md          ← blanks/skills/example/SKILL.md           @ ore:agent_targets
   .claude/agents/example.md                ← blanks/agents/example.md                 @ ore:agent_targets
+  .claude/skills/example/SKILL.md          ← blanks/skills/example/SKILL.md           @ ore:agent_targets
+  .codex/agents/example.toml               ← blanks/codex-agents/example.toml         @ ore:agent_targets
   .opencode/agents/example.md              ← blanks/agents/example.md                 @ ore:agent_targets
 ```
 

--- a/features.md
+++ b/features.md
@@ -11,7 +11,7 @@ Every entry states behavior + expectation. Deeper docs: `docs/`. Do not duplicat
 | **mold** | A template package: `mold.yaml` manifest + auto-discovered blank templates + optional `ingots/`, `ores/`, `flux.yaml`/`flux.schema.yaml`, output mappings. | Cast into a target project. May declare mold/ingot/ore dependencies in `mold.yaml`. |
 | **ingot** | A reusable template fragment (partial), either a bare `ingots/name.md` or a manifest dir (`ingot.yaml` + `files:`). | Embedded into blanks via the `{{ingot "name"}}` template function; rendered with the same flux context; nested ingot calls allowed; circular refs error. |
 | **ore** | A versioned behavior package: flux-schema fragment + defaults + optional `output:` mappings + optional `blanks/`. | Overlays a consuming mold: schema/defaults are namespaced under `ore.<namespace>.*`; gated by `{{if .ore.<ns>.enabled}}` (default `enabled: false`). |
-| **blank** | A markdown template file inside a mold, auto-discovered from the mold tree (reserved dirs/files excluded). | Rendered by Go `text/template`; supports flux vars, conditionals, ranges, `{{ingot}}`. |
+| **blank** | A template file inside a mold, auto-discovered from the mold tree (reserved dirs/files excluded). | Rendered by Go `text/template`; supports flux vars, conditionals, ranges, `{{ingot}}`. |
 
 - Reserved files (never installed as blanks): `mold.yaml`, `flux.yaml`, `flux.schema.yaml`, `ingot.yaml`, `ore.yaml`, `README.md`, `LICENSE`, `.ailloyignore`, etc.
 - Dot-prefixed source directories are excluded from automatic discovery. When `output:` is omitted, the exact native Codex instruction directories `.agents/skills/` and `.codex/agents/` are preserved by identity mapping; explicit `output:` mappings can target any destination.
@@ -57,7 +57,7 @@ Renders a mold's blanks with resolved flux and writes them to destination paths 
 
 ## temper (`validate`)
 
-- Auto-detects `mold.yaml` / `ingot.yaml` / `ore.yaml` at root and validates: manifest parse, required fields, semver, `requires.ailloy` constraint, flux types/select options/discover, dependency shape (exactly one of ingot/ore/mold per dep), output dir existence, template syntax, ingot `files:` existence.
+- Auto-detects `mold.yaml` / `ingot.yaml` / `ore.yaml` at root and validates: manifest parse, required fields, semver, `requires.ailloy` constraint, flux types/select options/discover, dependency shape (exactly one of ingot/ore/mold per dep), output dir existence, template syntax for every output file rendered with `process: true` (including Codex TOML), ingot `files:` existence.
 - Ore checks: `kind: ore`, snake_case name, unprefixed schema/defaults, `enabled: bool` required. Ephemerally resolves ore deps and reports overlay collisions / shadowed keys / orphan defaults.
 - Non-zero exit on errors; exit 0 on warnings-only.
 - `--assay` (alias `--lint`): also renders blanks to a temp dir and runs the assay linter on output (molds only). Supports `--set`, `-f`, `--format`, `--fail-on`, `--max-lines`.
@@ -65,7 +65,7 @@ Renders a mold's blanks with resolved flux and writes them to destination paths 
 ## assay (`lint`)
 
 - Lints rendered AI-instruction output against best-practice rules (severity: error/warning/suggestion). Consumed by `temper --assay`.
-- Codex discovery includes `**/.agents/skills/**/*.md` and `.codex/agents/*.toml` in addition to root and nested `AGENTS.md` files and `codex.md`. Codex `SKILL.md` files require non-empty YAML `name` and `description`; custom-agent TOML requires non-empty `name`, `description`, and `developer_instructions`.
+- Codex discovery includes `**/.agents/skills/**/*.md` and `.codex/agents/*.toml` in addition to root and nested `AGENTS.md` files and `codex.md`. Contained symlinked skill directories are traversed; symlink targets outside the project root are excluded. Project-root discovery prefers an enclosing `.git` root over nested tool markers and does not treat global tool directories in the user's home as a project marker. Codex `SKILL.md` files require non-empty YAML `name` and `description`; custom-agent TOML requires non-empty `name`, `description`, and `developer_instructions`.
 
 ## smelt (`package`)
 

--- a/features.md
+++ b/features.md
@@ -14,6 +14,7 @@ Every entry states behavior + expectation. Deeper docs: `docs/`. Do not duplicat
 | **blank** | A markdown template file inside a mold, auto-discovered from the mold tree (reserved dirs/files excluded). | Rendered by Go `text/template`; supports flux vars, conditionals, ranges, `{{ingot}}`. |
 
 - Reserved files (never installed as blanks): `mold.yaml`, `flux.yaml`, `flux.schema.yaml`, `ingot.yaml`, `ore.yaml`, `README.md`, `LICENSE`, `.ailloyignore`, etc.
+- Dot-prefixed source directories are excluded from automatic discovery. When `output:` is omitted, the exact native Codex instruction directories `.agents/skills/` and `.codex/agents/` are preserved by identity mapping; explicit `output:` mappings can target any destination.
 - `.ailloyignore` (or `mold.yaml` `ignore:`) excludes files from `cast`/`forge` (not `smelt`).
 
 ## cast (`install`)
@@ -64,6 +65,7 @@ Renders a mold's blanks with resolved flux and writes them to destination paths 
 ## assay (`lint`)
 
 - Lints rendered AI-instruction output against best-practice rules (severity: error/warning/suggestion). Consumed by `temper --assay`.
+- Codex discovery includes `**/.agents/skills/**/*.md` and `.codex/agents/*.toml` in addition to root and nested `AGENTS.md` files and `codex.md`. Codex `SKILL.md` files require non-empty YAML `name` and `description`; custom-agent TOML requires non-empty `name`, `description`, and `developer_instructions`.
 
 ## smelt (`package`)
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/knadh/stuffbin v1.3.0
 	github.com/muesli/termenv v0.16.0
 	github.com/nimble-giant/ailloy-extensions-sdk v0.1.0
+	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/sahilm/fuzzy v0.1.1
 	github.com/spf13/cobra v1.9.1
 	golang.org/x/sync v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/nimble-giant/ailloy-extensions-sdk v0.1.0 h1:39yqOZyfO2lJ4JfQ3FWKIIHvaXiH2j4LhlYMmVaYlYM=
 github.com/nimble-giant/ailloy-extensions-sdk v0.1.0/go.mod h1:iJi32ErC+n2KrSO6npHtIWj6Jntu5Ed5x/Nip9Wu/N8=
+github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
+github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=

--- a/internal/commands/cast_core_test.go
+++ b/internal/commands/cast_core_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -11,6 +12,76 @@ import (
 	"github.com/nimble-giant/ailloy/pkg/foundry"
 	"github.com/nimble-giant/ailloy/pkg/mold"
 )
+
+func TestCastMold_InstallsNativeCodexLayoutWithoutOutputMapping(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		global bool
+	}{
+		{name: "project"},
+		{name: "global", global: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			projectDir := t.TempDir()
+			t.Chdir(projectDir)
+			homeDir := t.TempDir()
+			t.Setenv("HOME", homeDir)
+
+			moldDir := filepath.Join(projectDir, "mold")
+			skillPath := filepath.Join(moldDir, ".agents", "skills", "reviewing", "SKILL.md")
+			agentPath := filepath.Join(moldDir, ".codex", "agents", "reviewer.toml")
+			for _, path := range []string{skillPath, agentPath} {
+				if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := os.WriteFile(filepath.Join(moldDir, "mold.yaml"), []byte(`apiVersion: v1
+kind: mold
+name: codex-native
+version: 0.1.0
+`), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(skillPath, []byte(`---
+name: reviewing
+description: Reviews {{ .project_name }} changes.
+---
+`), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(agentPath, []byte(`name = "reviewer"
+description = "Reviews {{ .project_name }} changes."
+developer_instructions = "Return concrete findings."
+`), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(moldDir, "flux.yaml"), []byte("project_name: Ailloy\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err := CastMold(t.Context(), moldDir, CastOptions{Global: tc.global}); err != nil {
+				t.Fatalf("CastMold: %v", err)
+			}
+
+			installRoot := projectDir
+			if tc.global {
+				installRoot = homeDir
+			}
+			for _, rel := range []string{
+				filepath.Join(".agents", "skills", "reviewing", "SKILL.md"),
+				filepath.Join(".codex", "agents", "reviewer.toml"),
+			} {
+				content, err := os.ReadFile(filepath.Join(installRoot, rel))
+				if err != nil {
+					t.Fatalf("expected %s to be installed: %v", rel, err)
+				}
+				if !strings.Contains(string(content), "Ailloy") {
+					t.Errorf("%s was not rendered with flux: %s", rel, content)
+				}
+			}
+		})
+	}
+}
 
 // TestCastMold_CleansEmptyMultiDestDirs reproduces issue #195: when a
 // multi-destination output mapping has per-dest `set` context and the

--- a/internal/commands/cast_ore_overlay_test.go
+++ b/internal/commands/cast_ore_overlay_test.go
@@ -67,7 +67,10 @@ func TestAgentTargetsOreOverlay_EndToEndRendering(t *testing.T) {
 
 	gotDests := destPaths(resolved)
 	wantDests := []string{
+		".agents/skills/example/SKILL.md",
 		".claude/agents/example.md",
+		".claude/skills/example/SKILL.md",
+		".codex/agents/example.toml",
 		".opencode/agents/example.md",
 		"AGENTS.md",
 	}
@@ -90,6 +93,7 @@ func TestAgentTargetsOreOverlay_EndToEndRendering(t *testing.T) {
 	rendered := renderResolvedFiles(t, resolved)
 	claude := rendered[".claude/agents/example.md"]
 	opencode := rendered[".opencode/agents/example.md"]
+	codex := rendered[".codex/agents/example.toml"]
 	if !strings.Contains(claude, "target: claude") {
 		t.Errorf(".claude/agents/example.md missing claude target token; got:\n%s", claude)
 	}
@@ -99,6 +103,13 @@ func TestAgentTargetsOreOverlay_EndToEndRendering(t *testing.T) {
 	// Sanity: the two renders are NOT identical (different set: context).
 	if claude == opencode {
 		t.Errorf("per-target renders should differ but were identical:\n%s", claude)
+	}
+	if !strings.Contains(codex, `name = "example"`) ||
+		!strings.Contains(codex, "rendered for codex") {
+		t.Errorf(".codex/agents/example.toml is not valid target-specific output; got:\n%s", codex)
+	}
+	if rendered[".claude/skills/example/SKILL.md"] != rendered[".agents/skills/example/SKILL.md"] {
+		t.Error("portable Agent Skill should render identically for Claude and Codex")
 	}
 }
 

--- a/pkg/assay/config.go
+++ b/pkg/assay/config.go
@@ -185,6 +185,10 @@ assay:
       enabled: true
     agent-frontmatter:
       enabled: true
+    codex-agent-schema:
+      enabled: true
+    codex-skill-frontmatter:
+      enabled: true
     command-frontmatter:
       enabled: true
       # options:
@@ -253,6 +257,7 @@ assay:
     # - ".claude/rules/generated-*.md"
   # platforms:             # uncomment to limit to specific platforms
   #   - claude
+  #   - codex
   #   - cursor
 `
 }

--- a/pkg/assay/config_test.go
+++ b/pkg/assay/config_test.go
@@ -113,6 +113,12 @@ func TestGenerateStarterConfig(t *testing.T) {
 	if !contains(content, "plugin-hooks:") {
 		t.Error("expected 'plugin-hooks' rule in starter config")
 	}
+	if !contains(content, "codex-agent-schema:") {
+		t.Error("expected 'codex-agent-schema' rule in starter config")
+	}
+	if !contains(content, "codex-skill-frontmatter:") {
+		t.Error("expected 'codex-skill-frontmatter' rule in starter config")
+	}
 }
 
 func TestAddAllowedFrontmatterFields(t *testing.T) {

--- a/pkg/assay/detect.go
+++ b/pkg/assay/detect.go
@@ -70,31 +70,56 @@ func detectFS(fsys fs.FS, realRoot string, platforms []Platform) ([]DetectedFile
 	// level between the working directory and repository root. Walk the whole
 	// repository so scoped skills and their markdown references are linted.
 	if containsPlatform(targetPlatforms, PlatformCodex) {
-		err := fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
-			if err != nil {
-				return nil
+		activeSkillRoots := make(map[string]bool)
+		if realRoot != "" {
+			if resolvedRoot, ok := resolvedPathWithinRoot(realRoot, "."); ok {
+				activeSkillRoots[resolvedRoot] = true
 			}
-			if d.IsDir() {
-				if shouldSkipDir(d.Name()) {
-					return fs.SkipDir
+		}
+		var walkCodexSkills func(string) error
+		walkCodexSkills = func(root string) error {
+			return fs.WalkDir(fsys, root, func(path string, d fs.DirEntry, err error) error {
+				if err != nil {
+					return nil
 				}
+				if d.IsDir() {
+					if shouldSkipDir(d.Name()) {
+						return fs.SkipDir
+					}
+					return nil
+				}
+				// WalkDir does not follow symlinks it encounters below its root.
+				// Codex does follow symlinked skill folders, so recurse when the
+				// logical skill root resolves to a contained directory.
+				if d.Type()&fs.ModeSymlink != 0 && isCodexSkillDirectoryPath(path) {
+					if resolved, ok := resolvedSymlinkDirectoryWithinRoot(realRoot, path); ok {
+						if activeSkillRoots[resolved] {
+							return nil
+						}
+						activeSkillRoots[resolved] = true
+						walkErr := walkCodexSkills(path)
+						delete(activeSkillRoots, resolved)
+						return walkErr
+					}
+					return nil
+				}
+				if !isCodexSkillMarkdownPath(path) || seen[path] || !pathWithinRoot(realRoot, path) {
+					return nil
+				}
+				content, err := fs.ReadFile(fsys, path)
+				if err != nil {
+					return nil
+				}
+				seen[path] = true
+				files = append(files, DetectedFile{
+					Path:     path,
+					Platform: PlatformCodex,
+					Content:  content,
+				})
 				return nil
-			}
-			if !isCodexSkillMarkdownPath(path) || seen[path] || !pathWithinRoot(realRoot, path) {
-				return nil
-			}
-			content, err := fs.ReadFile(fsys, path)
-			if err != nil {
-				return nil
-			}
-			seen[path] = true
-			files = append(files, DetectedFile{
-				Path:     path,
-				Platform: PlatformCodex,
-				Content:  content,
 			})
-			return nil
-		})
+		}
+		err := walkCodexSkills(".")
 		if err != nil {
 			return files, err
 		}
@@ -141,34 +166,50 @@ func detectFS(fsys fs.FS, realRoot string, platforms []Platform) ([]DetectedFile
 	return files, nil
 }
 
-// FindProjectRoot walks up from startDir looking for .git or supported
-// tool-specific instruction-directory markers.
+// FindProjectRoot walks up from startDir looking for an enclosing .git root,
+// falling back to the nearest supported tool-specific instruction directory
+// when the path is not inside a git checkout.
 // Recognizes both .git directories (normal repos) and .git files (worktrees).
 // Returns startDir if no marker is found.
 func FindProjectRoot(startDir string) (string, error) {
-	dir, err := filepath.Abs(startDir)
+	start, err := filepath.Abs(startDir)
 	if err != nil {
 		return "", err
 	}
 
+	home, _ := os.UserHomeDir()
+	if home != "" {
+		home, _ = filepath.Abs(home)
+	}
+
+	dir := start
+	var toolRoot string
 	for {
 		// .git can be a directory (normal repo) or a file (worktree with
 		// "gitdir: ..." content). Both indicate a project root.
 		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
 			return dir, nil
 		}
-		// Tool-specific instruction directories are also valid project root
-		// markers when a project is not inside a git checkout.
-		for _, marker := range []string{".claude", ".agents", ".codex"} {
-			if info, err := os.Stat(filepath.Join(dir, marker)); err == nil && info.IsDir() {
-				return dir, nil
+
+		// Remember the nearest tool-specific marker while continuing upward in
+		// case this is a nested Codex scope inside a git repository. User-level
+		// ~/.claude, ~/.agents, and ~/.codex directories are global config, not
+		// evidence that the entire home directory is one project.
+		if toolRoot == "" && (home == "" || filepath.Clean(dir) != filepath.Clean(home)) {
+			for _, marker := range []string{".claude", ".agents", ".codex"} {
+				if info, err := os.Stat(filepath.Join(dir, marker)); err == nil && info.IsDir() {
+					toolRoot = dir
+					break
+				}
 			}
 		}
 
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			// Reached filesystem root, use the original startDir
-			return filepath.Abs(startDir)
+			if toolRoot != "" {
+				return toolRoot, nil
+			}
+			return start, nil
 		}
 		dir = parent
 	}
@@ -197,8 +238,33 @@ func isCodexSkillMarkdownPath(filePath string) bool {
 	return false
 }
 
+func isCodexSkillDirectoryPath(dirPath string) bool {
+	parts := strings.Split(filepath.ToSlash(dirPath), "/")
+	for i := 0; i+2 < len(parts); i++ {
+		if parts[i] == ".agents" && parts[i+1] == "skills" && i+3 == len(parts) {
+			return true
+		}
+	}
+	return false
+}
+
 func shouldSkipDir(name string) bool {
 	return name == "node_modules" || name == "vendor" || name == ".git"
+}
+
+func resolvedSymlinkDirectoryWithinRoot(realRoot, relativePath string) (string, bool) {
+	if realRoot == "" {
+		return "", false
+	}
+	resolved, ok := resolvedPathWithinRoot(realRoot, relativePath)
+	if !ok {
+		return "", false
+	}
+	info, err := os.Stat(resolved)
+	if err != nil || !info.IsDir() {
+		return "", false
+	}
+	return resolved, true
 }
 
 // pathWithinRoot rejects files whose symlinks escape the project root.
@@ -207,22 +273,29 @@ func pathWithinRoot(realRoot, relativePath string) bool {
 	if realRoot == "" {
 		return true
 	}
+	_, ok := resolvedPathWithinRoot(realRoot, relativePath)
+	return ok
+}
 
+func resolvedPathWithinRoot(realRoot, relativePath string) (string, bool) {
 	absRoot, err := filepath.Abs(realRoot)
 	if err != nil {
-		return false
+		return "", false
 	}
 	resolvedRoot, err := filepath.EvalSymlinks(absRoot)
 	if err != nil {
-		return false
+		return "", false
 	}
 	resolvedPath, err := filepath.EvalSymlinks(filepath.Join(resolvedRoot, relativePath))
 	if err != nil {
-		return false
+		return "", false
 	}
 	rel, err := filepath.Rel(resolvedRoot, resolvedPath)
 	if err != nil {
-		return false
+		return "", false
 	}
-	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return resolvedPath, true
 }

--- a/pkg/assay/detect.go
+++ b/pkg/assay/detect.go
@@ -11,7 +11,7 @@ import (
 var platformPatterns = map[Platform][]string{
 	PlatformClaude:  {"CLAUDE.md", ".claude/CLAUDE.md", ".claude/rules/*.md", "CLAUDE.local.md"},
 	PlatformCursor:  {".cursor/rules/*.md", ".cursorrules"},
-	PlatformCodex:   {"AGENTS.md", "codex.md"},
+	PlatformCodex:   {"AGENTS.md", "codex.md", ".codex/agents/*.toml"},
 	PlatformCopilot: {".github/copilot-instructions.md"},
 	PlatformGeneric: {"AGENTS.md"},
 }
@@ -23,7 +23,7 @@ func Detect(rootDir string, platforms []Platform) ([]DetectedFile, error) {
 }
 
 // detectFS performs file detection against an fs.FS for testability.
-// realRoot is used for reading file content via os when fsys is an os.DirFS.
+// realRoot enforces symlink containment when fsys is backed by an os.DirFS.
 func detectFS(fsys fs.FS, realRoot string, platforms []Platform) ([]DetectedFile, error) {
 	targetPlatforms := platforms
 	if len(targetPlatforms) == 0 {
@@ -47,27 +47,8 @@ func detectFS(fsys fs.FS, realRoot string, platforms []Platform) ([]DetectedFile
 				if seen[match] {
 					continue
 				}
-				seen[match] = true
-
-				// Validate symlinks stay within project root
-				if realRoot != "" {
-					fullPath := filepath.Join(realRoot, match)
-					resolved, err := filepath.EvalSymlinks(fullPath)
-					if err != nil {
-						continue
-					}
-					absRoot, err := filepath.Abs(realRoot)
-					if err != nil {
-						continue
-					}
-					// Resolve symlinks in the root path too (e.g. /var -> /private/var on macOS)
-					absRoot, err = filepath.EvalSymlinks(absRoot)
-					if err != nil {
-						continue
-					}
-					if !strings.HasPrefix(resolved, absRoot+string(filepath.Separator)) && resolved != absRoot {
-						continue
-					}
+				if !pathWithinRoot(realRoot, match) {
+					continue
 				}
 
 				content, err := fs.ReadFile(fsys, match)
@@ -75,6 +56,7 @@ func detectFS(fsys fs.FS, realRoot string, platforms []Platform) ([]DetectedFile
 					continue
 				}
 
+				seen[match] = true
 				files = append(files, DetectedFile{
 					Path:     match,
 					Platform: plat,
@@ -84,21 +66,60 @@ func detectFS(fsys fs.FS, realRoot string, platforms []Platform) ([]DetectedFile
 		}
 	}
 
+	// Codex discovers Agent Skills from .agents/skills directories at every
+	// level between the working directory and repository root. Walk the whole
+	// repository so scoped skills and their markdown references are linted.
+	if containsPlatform(targetPlatforms, PlatformCodex) {
+		err := fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return nil
+			}
+			if d.IsDir() {
+				if shouldSkipDir(d.Name()) {
+					return fs.SkipDir
+				}
+				return nil
+			}
+			if !isCodexSkillMarkdownPath(path) || seen[path] || !pathWithinRoot(realRoot, path) {
+				return nil
+			}
+			content, err := fs.ReadFile(fsys, path)
+			if err != nil {
+				return nil
+			}
+			seen[path] = true
+			files = append(files, DetectedFile{
+				Path:     path,
+				Platform: PlatformCodex,
+				Content:  content,
+			})
+			return nil
+		})
+		if err != nil {
+			return files, err
+		}
+	}
+
 	// Search for nested AGENTS.md files (per AGENTS.md spec)
-	if containsPlatform(targetPlatforms, PlatformGeneric) {
+	agentsPlatform := PlatformGeneric
+	searchNestedAgents := containsPlatform(targetPlatforms, PlatformGeneric)
+	if !searchNestedAgents && containsPlatform(targetPlatforms, PlatformCodex) {
+		agentsPlatform = PlatformCodex
+		searchNestedAgents = true
+	}
+	if searchNestedAgents {
 		err := fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return nil
 			}
 			// Skip common non-project directories
 			if d.IsDir() {
-				name := d.Name()
-				if name == "node_modules" || name == "vendor" || name == ".git" {
+				if shouldSkipDir(d.Name()) {
 					return fs.SkipDir
 				}
 				return nil
 			}
-			if d.Name() == "AGENTS.md" && path != "AGENTS.md" && !seen[path] {
+			if d.Name() == "AGENTS.md" && path != "AGENTS.md" && !seen[path] && pathWithinRoot(realRoot, path) {
 				seen[path] = true
 				content, err := fs.ReadFile(fsys, path)
 				if err != nil {
@@ -106,7 +127,7 @@ func detectFS(fsys fs.FS, realRoot string, platforms []Platform) ([]DetectedFile
 				}
 				files = append(files, DetectedFile{
 					Path:     path,
-					Platform: PlatformGeneric,
+					Platform: agentsPlatform,
 					Content:  content,
 				})
 			}
@@ -120,7 +141,8 @@ func detectFS(fsys fs.FS, realRoot string, platforms []Platform) ([]DetectedFile
 	return files, nil
 }
 
-// FindProjectRoot walks up from startDir looking for .git or .claude markers.
+// FindProjectRoot walks up from startDir looking for .git or supported
+// tool-specific instruction-directory markers.
 // Recognizes both .git directories (normal repos) and .git files (worktrees).
 // Returns startDir if no marker is found.
 func FindProjectRoot(startDir string) (string, error) {
@@ -135,9 +157,12 @@ func FindProjectRoot(startDir string) (string, error) {
 		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
 			return dir, nil
 		}
-		// .claude directory is also a valid project root marker.
-		if info, err := os.Stat(filepath.Join(dir, ".claude")); err == nil && info.IsDir() {
-			return dir, nil
+		// Tool-specific instruction directories are also valid project root
+		// markers when a project is not inside a git checkout.
+		for _, marker := range []string{".claude", ".agents", ".codex"} {
+			if info, err := os.Stat(filepath.Join(dir, marker)); err == nil && info.IsDir() {
+				return dir, nil
+			}
 		}
 
 		parent := filepath.Dir(dir)
@@ -156,4 +181,48 @@ func containsPlatform(platforms []Platform, target Platform) bool {
 		}
 	}
 	return false
+}
+
+func isCodexSkillMarkdownPath(filePath string) bool {
+	if filepath.Ext(filePath) != ".md" {
+		return false
+	}
+
+	parts := strings.Split(filepath.ToSlash(filePath), "/")
+	for i := 0; i+3 < len(parts); i++ {
+		if parts[i] == ".agents" && parts[i+1] == "skills" {
+			return true
+		}
+	}
+	return false
+}
+
+func shouldSkipDir(name string) bool {
+	return name == "node_modules" || name == "vendor" || name == ".git"
+}
+
+// pathWithinRoot rejects files whose symlinks escape the project root.
+// An empty realRoot denotes an abstract fs.FS, where paths are already scoped.
+func pathWithinRoot(realRoot, relativePath string) bool {
+	if realRoot == "" {
+		return true
+	}
+
+	absRoot, err := filepath.Abs(realRoot)
+	if err != nil {
+		return false
+	}
+	resolvedRoot, err := filepath.EvalSymlinks(absRoot)
+	if err != nil {
+		return false
+	}
+	resolvedPath, err := filepath.EvalSymlinks(filepath.Join(resolvedRoot, relativePath))
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(resolvedRoot, resolvedPath)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }

--- a/pkg/assay/detect_test.go
+++ b/pkg/assay/detect_test.go
@@ -151,6 +151,13 @@ func TestDetect_RejectsSymlinksOutsideProjectRoot(t *testing.T) {
 	if err := os.WriteFile(outsideSkill, []byte("---\nname: outside\ndescription: Outside.\n---\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	outsideSkillDir := filepath.Join(outside, "skill-dir")
+	if err := os.MkdirAll(outsideSkillDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outsideSkillDir, "SKILL.md"), []byte("---\nname: outside-dir\ndescription: Outside directory.\n---\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 
 	skillDir := filepath.Join(project, ".agents", "skills", "outside")
 	if err := os.MkdirAll(skillDir, 0o750); err != nil {
@@ -159,6 +166,9 @@ func TestDetect_RejectsSymlinksOutsideProjectRoot(t *testing.T) {
 	for target, link := range map[string]string{
 		outsideAgents: filepath.Join(project, "AGENTS.md"),
 		outsideSkill:  filepath.Join(skillDir, "SKILL.md"),
+		outsideSkillDir: filepath.Join(
+			project, ".agents", "skills", "outside-dir",
+		),
 	} {
 		if err := os.Symlink(target, link); err != nil {
 			t.Skipf("symlinks unavailable: %v", err)
@@ -171,6 +181,75 @@ func TestDetect_RejectsSymlinksOutsideProjectRoot(t *testing.T) {
 	}
 	if len(files) != 0 {
 		t.Errorf("detected files through symlinks outside project root: %v", files)
+	}
+}
+
+func TestDetect_FollowsSymlinkedSkillDirectoriesWithinProject(t *testing.T) {
+	project := t.TempDir()
+	actualSkill := filepath.Join(project, "shared", "reviewing")
+	if err := os.MkdirAll(filepath.Join(actualSkill, "references"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(actualSkill, "SKILL.md"),
+		[]byte("---\nname: reviewing\ndescription: Reviews code.\n---\n"),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(actualSkill, "references", "checks.md"), []byte("# Checks\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	skillsDir := filepath.Join(project, ".agents", "skills")
+	if err := os.MkdirAll(skillsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(
+		filepath.Join("..", "..", "shared", "reviewing"),
+		filepath.Join(skillsDir, "reviewing"),
+	); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	files, err := Detect(project, []Platform{PlatformCodex})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := make(map[string]bool, len(files))
+	for _, file := range files {
+		got[filepath.ToSlash(file.Path)] = true
+	}
+	for _, path := range []string{
+		".agents/skills/reviewing/SKILL.md",
+		".agents/skills/reviewing/references/checks.md",
+	} {
+		if !got[path] {
+			t.Errorf("expected symlinked skill file %s to be detected; got %v", path, got)
+		}
+	}
+}
+
+func TestDetect_DoesNotRecurseThroughSymlinkCycles(t *testing.T) {
+	project := t.TempDir()
+	skillsDir := filepath.Join(project, ".agents", "skills")
+	if err := os.MkdirAll(skillsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(
+		filepath.Join("..", ".."),
+		filepath.Join(skillsDir, "project-root"),
+	); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	files, err := Detect(project, []Platform{PlatformCodex})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 0 {
+		t.Errorf("expected cyclic skill symlink to be ignored; got %v", files)
 	}
 }
 
@@ -246,5 +325,63 @@ func TestFindProjectRoot_CodexMarkers(t *testing.T) {
 				t.Errorf("root = %q, want %q", root, project)
 			}
 		})
+	}
+}
+
+func TestFindProjectRoot_PrefersEnclosingGitRoot(t *testing.T) {
+	for _, marker := range []string{".claude", ".agents", ".codex"} {
+		t.Run(marker, func(t *testing.T) {
+			tmp := t.TempDir()
+			project := filepath.Join(tmp, "project")
+			scoped := filepath.Join(project, "services", "api")
+			nested := filepath.Join(scoped, "src")
+			if err := os.MkdirAll(filepath.Join(project, ".git"), 0o750); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.MkdirAll(filepath.Join(scoped, marker), 0o750); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.MkdirAll(nested, 0o750); err != nil {
+				t.Fatal(err)
+			}
+
+			root, err := FindProjectRoot(nested)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if root != project {
+				t.Errorf("root = %q, want enclosing git root %q", root, project)
+			}
+		})
+	}
+}
+
+func TestFindProjectRoot_DoesNotPromoteHomeToolDirectories(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	resolvedHome, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Clean(resolvedHome) != filepath.Clean(home) {
+		t.Skipf("os.UserHomeDir does not use HOME on this platform: got %q, set %q", resolvedHome, home)
+	}
+
+	for _, marker := range []string{".claude", ".agents", ".codex"} {
+		if err := os.MkdirAll(filepath.Join(home, marker), 0o750); err != nil {
+			t.Fatal(err)
+		}
+	}
+	start := filepath.Join(home, "work", "unmarked-project", "src")
+	if err := os.MkdirAll(start, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	root, err := FindProjectRoot(start)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if root != start {
+		t.Errorf("root = %q, want original start directory %q", root, start)
 	}
 }

--- a/pkg/assay/detect_test.go
+++ b/pkg/assay/detect_test.go
@@ -98,6 +98,82 @@ func TestDetectFS_ClaudeRules(t *testing.T) {
 	}
 }
 
+func TestDetectFS_CodexSkillsAndAgents(t *testing.T) {
+	fsys := fstest.MapFS{
+		".agents/skills/reviewing/SKILL.md":                          &fstest.MapFile{Data: []byte("---\nname: reviewing\ndescription: Reviews code.\n---\n")},
+		".agents/skills/reviewing/references/checks.md":              &fstest.MapFile{Data: []byte("# Checks")},
+		".agents/skills/reviewing/scripts/review.sh":                 &fstest.MapFile{Data: []byte("#!/bin/sh")},
+		".codex/agents/reviewer.toml":                                &fstest.MapFile{Data: []byte(`name = "reviewer"`)},
+		"services/api/.agents/skills/testing/SKILL.md":               &fstest.MapFile{Data: []byte("---\nname: testing\ndescription: Tests APIs.\n---\n")},
+		"services/api/.agents/skills/testing/references/fixtures.md": &fstest.MapFile{Data: []byte("# Fixtures")},
+		"services/api/.agents/skills/testing/scripts/test.sh":        &fstest.MapFile{Data: []byte("#!/bin/sh")},
+		"services/api/AGENTS.md":                                     &fstest.MapFile{Data: []byte("# API instructions")},
+	}
+
+	files, err := detectFS(fsys, "", []Platform{PlatformCodex})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := make(map[string]Platform, len(files))
+	for _, f := range files {
+		got[f.Path] = f.Platform
+	}
+	for _, path := range []string{
+		".agents/skills/reviewing/SKILL.md",
+		".agents/skills/reviewing/references/checks.md",
+		".codex/agents/reviewer.toml",
+		"services/api/.agents/skills/testing/SKILL.md",
+		"services/api/.agents/skills/testing/references/fixtures.md",
+		"services/api/AGENTS.md",
+	} {
+		if got[path] != PlatformCodex {
+			t.Errorf("%s: platform = %q, want %q", path, got[path], PlatformCodex)
+		}
+	}
+	if _, ok := got[".agents/skills/reviewing/scripts/review.sh"]; ok {
+		t.Error("non-markdown skill support files should not be linted")
+	}
+	if _, ok := got["services/api/.agents/skills/testing/scripts/test.sh"]; ok {
+		t.Error("non-markdown scoped skill support files should not be linted")
+	}
+}
+
+func TestDetect_RejectsSymlinksOutsideProjectRoot(t *testing.T) {
+	project := t.TempDir()
+	outside := t.TempDir()
+
+	outsideAgents := filepath.Join(outside, "AGENTS.md")
+	if err := os.WriteFile(outsideAgents, []byte("# Outside"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	outsideSkill := filepath.Join(outside, "SKILL.md")
+	if err := os.WriteFile(outsideSkill, []byte("---\nname: outside\ndescription: Outside.\n---\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	skillDir := filepath.Join(project, ".agents", "skills", "outside")
+	if err := os.MkdirAll(skillDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	for target, link := range map[string]string{
+		outsideAgents: filepath.Join(project, "AGENTS.md"),
+		outsideSkill:  filepath.Join(skillDir, "SKILL.md"),
+	} {
+		if err := os.Symlink(target, link); err != nil {
+			t.Skipf("symlinks unavailable: %v", err)
+		}
+	}
+
+	files, err := Detect(project, []Platform{PlatformCodex})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 0 {
+		t.Errorf("detected files through symlinks outside project root: %v", files)
+	}
+}
+
 func TestFindProjectRoot(t *testing.T) {
 	// Test with a directory that has .git (our own repo)
 	root, err := FindProjectRoot(".")
@@ -146,5 +222,29 @@ func TestFindProjectRoot_NoMarker(t *testing.T) {
 	// Should either return sub itself or find a parent .git — either way, not empty
 	if root == "" {
 		t.Error("expected non-empty root")
+	}
+}
+
+func TestFindProjectRoot_CodexMarkers(t *testing.T) {
+	for _, marker := range []string{".agents", ".codex"} {
+		t.Run(marker, func(t *testing.T) {
+			tmp := t.TempDir()
+			project := filepath.Join(tmp, "project")
+			nested := filepath.Join(project, "src", "pkg")
+			if err := os.MkdirAll(filepath.Join(project, marker), 0755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.MkdirAll(nested, 0755); err != nil {
+				t.Fatal(err)
+			}
+
+			root, err := FindProjectRoot(nested)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if root != project {
+				t.Errorf("root = %q, want %q", root, project)
+			}
+		})
 	}
 }

--- a/pkg/assay/rationales.go
+++ b/pkg/assay/rationales.go
@@ -12,6 +12,8 @@ var ruleRationales = map[string]string{
 	"duplicate-topics":   "Duplicated content creates maintenance burden and risks instructions drifting out of sync, leading to conflicting guidance across files.",
 
 	"agent-frontmatter":           "Agent runtimes use the name and description fields to discover and invoke agents. Missing or malformed fields prevent the agent from being registered.",
+	"codex-agent-schema":          "Codex loads project custom agents from TOML configuration layers. Invalid TOML or missing identity and instruction fields prevent Codex from loading the intended agent. See: https://learn.chatgpt.com/docs/agent-configuration/subagents",
+	"codex-skill-frontmatter":     "Codex uses each Agent Skill's name and description for discovery before loading the full SKILL.md body. Missing metadata prevents reliable registration and selection. See: https://learn.chatgpt.com/docs/build-skills",
 	"command-frontmatter":         "Agent runtimes only recognize specific frontmatter keys. Unrecognized fields are silently ignored — tool restrictions, model overrides, and hints you set may never take effect.",
 	"settings-schema":             "Unrecognized hook event types are silently skipped. A typo in an event name means your hook never fires, with no error to diagnose.",
 	"plugin-manifest":             "The plugin manifest is how agent runtimes identify, load, and display your plugin. Missing required fields prevent installation or cause silent failures.",

--- a/pkg/assay/rules_codex.go
+++ b/pkg/assay/rules_codex.go
@@ -1,0 +1,138 @@
+package assay
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/goccy/go-yaml"
+	"github.com/nimble-giant/ailloy/pkg/mold"
+	"github.com/pelletier/go-toml/v2"
+)
+
+func init() {
+	Register(&codexSkillFrontmatterRule{})
+	Register(&codexAgentSchemaRule{})
+}
+
+// codexSkillFrontmatterRule validates the required Agent Skills fields for
+// repository skills loaded by Codex from .agents/skills/<name>/SKILL.md.
+type codexSkillFrontmatterRule struct{}
+
+func (r *codexSkillFrontmatterRule) Name() string { return "codex-skill-frontmatter" }
+func (r *codexSkillFrontmatterRule) DefaultSeverity() mold.DiagSeverity {
+	return mold.SeverityError
+}
+func (r *codexSkillFrontmatterRule) Platforms() []Platform {
+	return []Platform{PlatformCodex}
+}
+
+func (r *codexSkillFrontmatterRule) Check(ctx *RuleContext) []mold.Diagnostic {
+	var diags []mold.Diagnostic
+	for _, f := range ctx.Files {
+		if f.Platform != PlatformCodex || filepath.Base(f.Path) != "SKILL.md" || !isSkillPath(f) {
+			continue
+		}
+
+		frontmatter := extractFrontmatter(f.Content)
+		if frontmatter == nil {
+			diags = append(diags, mold.Diagnostic{
+				Severity: r.DefaultSeverity(),
+				Message:  "Codex skill is missing YAML frontmatter",
+				Tip:      "start SKILL.md with frontmatter containing non-empty `name` and `description` fields",
+				File:     f.Path,
+				Rule:     r.Name(),
+			})
+			continue
+		}
+
+		var metadata map[string]any
+		if err := yaml.Unmarshal(frontmatter, &metadata); err != nil {
+			diags = append(diags, mold.Diagnostic{
+				Severity: r.DefaultSeverity(),
+				Message:  fmt.Sprintf("invalid skill frontmatter YAML: %v", err),
+				File:     f.Path,
+				Rule:     r.Name(),
+			})
+			continue
+		}
+
+		for _, field := range []string{"name", "description"} {
+			value, ok := metadata[field]
+			text, isString := value.(string)
+			switch {
+			case !ok:
+				diags = append(diags, mold.Diagnostic{
+					Severity: r.DefaultSeverity(),
+					Message:  fmt.Sprintf("Codex skill missing required frontmatter field: %s", field),
+					File:     f.Path,
+					Rule:     r.Name(),
+				})
+			case !isString || strings.TrimSpace(text) == "":
+				diags = append(diags, mold.Diagnostic{
+					Severity: r.DefaultSeverity(),
+					Message:  fmt.Sprintf("Codex skill frontmatter field %q must be a non-empty string", field),
+					File:     f.Path,
+					Rule:     r.Name(),
+				})
+			}
+		}
+	}
+	return diags
+}
+
+// codexAgentSchemaRule validates project-scoped Codex custom agents at
+// .codex/agents/<name>.toml.
+type codexAgentSchemaRule struct{}
+
+func (r *codexAgentSchemaRule) Name() string { return "codex-agent-schema" }
+func (r *codexAgentSchemaRule) DefaultSeverity() mold.DiagSeverity {
+	return mold.SeverityError
+}
+func (r *codexAgentSchemaRule) Platforms() []Platform {
+	return []Platform{PlatformCodex}
+}
+
+func (r *codexAgentSchemaRule) Check(ctx *RuleContext) []mold.Diagnostic {
+	var diags []mold.Diagnostic
+	for _, f := range ctx.Files {
+		if f.Platform != PlatformCodex ||
+			filepath.Dir(f.Path) != filepath.Join(".codex", "agents") ||
+			filepath.Ext(f.Path) != ".toml" {
+			continue
+		}
+
+		var agent map[string]any
+		if err := toml.Unmarshal(f.Content, &agent); err != nil {
+			diags = append(diags, mold.Diagnostic{
+				Severity: r.DefaultSeverity(),
+				Message:  fmt.Sprintf("invalid Codex agent TOML: %v", err),
+				File:     f.Path,
+				Rule:     r.Name(),
+			})
+			continue
+		}
+
+		for _, field := range []string{"name", "description", "developer_instructions"} {
+			value, ok := agent[field]
+			text, isString := value.(string)
+			switch {
+			case !ok:
+				diags = append(diags, mold.Diagnostic{
+					Severity: r.DefaultSeverity(),
+					Message:  fmt.Sprintf("Codex agent missing required field: %s", field),
+					File:     f.Path,
+					Rule:     r.Name(),
+				})
+			case !isString || strings.TrimSpace(text) == "":
+				diags = append(diags, mold.Diagnostic{
+					Severity: r.DefaultSeverity(),
+					Message:  fmt.Sprintf("Codex agent field %q must be a non-empty string", field),
+					File:     f.Path,
+					Rule:     r.Name(),
+				})
+			}
+		}
+	}
+	return diags
+}

--- a/pkg/assay/rules_codex_test.go
+++ b/pkg/assay/rules_codex_test.go
@@ -1,0 +1,129 @@
+package assay
+
+import "testing"
+
+func TestCodexSkillFrontmatterRule(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    int
+	}{
+		{
+			name:    "valid",
+			content: "---\nname: reviewing\ndescription: Reviews pull requests.\n---\n# Reviewing\n",
+		},
+		{
+			name:    "missing frontmatter",
+			content: "# Reviewing\n",
+			want:    1,
+		},
+		{
+			name:    "missing required fields",
+			content: "---\nlicense: Apache-2.0\n---\n# Reviewing\n",
+			want:    2,
+		},
+		{
+			name:    "invalid YAML",
+			content: "---\nname: [reviewing\ndescription: Reviews pull requests.\n---\n",
+			want:    1,
+		},
+		{
+			name:    "empty required fields",
+			content: "---\nname: ''\ndescription: ''\n---\n# Reviewing\n",
+			want:    2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &RuleContext{
+				Files: []DetectedFile{{
+					Path:     ".agents/skills/reviewing/SKILL.md",
+					Platform: PlatformCodex,
+					Content:  []byte(tt.content),
+				}},
+				Config: DefaultConfig(),
+			}
+			got := (&codexSkillFrontmatterRule{}).Check(ctx)
+			if len(got) != tt.want {
+				t.Errorf("diagnostics = %v, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCodexAgentSchemaRule(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    int
+	}{
+		{
+			name: "valid",
+			content: `name = "reviewer"
+description = "Reviews changes for correctness."
+developer_instructions = """
+Review the requested changes and cite concrete evidence.
+"""
+sandbox_mode = "read-only"
+`,
+		},
+		{
+			name:    "invalid TOML",
+			content: `name = "reviewer`,
+			want:    1,
+		},
+		{
+			name:    "missing required fields",
+			content: `name = "reviewer"`,
+			want:    2,
+		},
+		{
+			name: "empty required field",
+			content: `name = ""
+description = "Reviews changes."
+developer_instructions = "Review."
+`,
+			want: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &RuleContext{
+				Files: []DetectedFile{{
+					Path:     ".codex/agents/reviewer.toml",
+					Platform: PlatformCodex,
+					Content:  []byte(tt.content),
+				}},
+				Config: DefaultConfig(),
+			}
+			got := (&codexAgentSchemaRule{}).Check(ctx)
+			if len(got) != tt.want {
+				t.Errorf("diagnostics = %v, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAssayCodexSkillsAndAgents(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, ".agents/skills/reviewing/SKILL.md", "# missing frontmatter\n")
+	writeFile(t, dir, ".codex/agents/reviewer.toml", `name = "reviewer"`)
+
+	result, err := Assay(dir, &Config{Platforms: []string{"codex"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rules := make(map[string]bool)
+	for _, d := range result.Diagnostics {
+		rules[d.Rule] = true
+	}
+	if !rules["codex-skill-frontmatter"] {
+		t.Error("expected codex-skill-frontmatter diagnostic")
+	}
+	if !rules["codex-agent-schema"] {
+		t.Error("expected codex-agent-schema diagnostic")
+	}
+}

--- a/pkg/mold/output.go
+++ b/pkg/mold/output.go
@@ -1,6 +1,7 @@
 package mold
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"path"
@@ -13,6 +14,15 @@ import (
 var reservedDirs = map[string]bool{
 	"ingots": true,
 	"deps":   true, // smelt-embedded dep tree; internal to the binary, not mold content
+}
+
+// nativeIdentityDirs are well-known, dot-prefixed instruction directories
+// preserved when a mold omits output and therefore uses identity mapping.
+// Keeping these paths exact avoids treating unrelated hidden configuration as
+// installable content.
+var nativeIdentityDirs = []string{
+	".agents/skills",
+	".codex/agents",
 }
 
 // reservedRootFiles are root-level files excluded from auto-discovery
@@ -75,9 +85,10 @@ func WithIgnorePatterns(patterns []string) ResolveOption {
 // ResolveFiles walks the mold filesystem and resolves all files according
 // to the output mapping.
 //
-// If output is nil, all top-level directories (excluding reserved names
-// like "ingots") and root-level files (excluding metadata like mold.yaml)
-// are walked with identity mapping (src path = dest path).
+// If output is nil, non-hidden top-level directories (excluding reserved names
+// like "ingots"), native identity directories, and root-level files (excluding
+// metadata like mold.yaml) are walked with identity mapping (src path = dest
+// path).
 //
 // If output is a string, it's treated as a parent directory — all top-level
 // directories are mapped under it. Root-level files are mapped to the
@@ -138,6 +149,16 @@ func resolveIdentity(moldFS fs.FS) ([]ResolvedFile, error) {
 			target: OutputTarget{Dest: d},
 		})
 	}
+	nativeDirs, err := discoverNativeIdentityDirs(moldFS)
+	if err != nil {
+		return nil, err
+	}
+	for _, d := range nativeDirs {
+		dirs = append(dirs, dirMapping{
+			src:    d,
+			target: OutputTarget{Dest: d},
+		})
+	}
 
 	rootFiles, err := discoverRootFiles(moldFS)
 	if err != nil {
@@ -172,6 +193,23 @@ func discoverTopLevelDirs(moldFS fs.FS) ([]string, error) {
 			continue
 		}
 		dirs = append(dirs, name)
+	}
+	return dirs, nil
+}
+
+func discoverNativeIdentityDirs(moldFS fs.FS) ([]string, error) {
+	var dirs []string
+	for _, name := range nativeIdentityDirs {
+		info, err := fs.Stat(moldFS, name)
+		if errors.Is(err, fs.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("inspecting native instruction directory %s: %w", name, err)
+		}
+		if info.IsDir() {
+			dirs = append(dirs, name)
+		}
 	}
 	return dirs, nil
 }

--- a/pkg/mold/output_test.go
+++ b/pkg/mold/output_test.go
@@ -40,6 +40,58 @@ func TestResolveFiles_StringOutput(t *testing.T) {
 	}
 }
 
+func TestResolveFiles_IdentityAutoDiscoversCodexDirectories(t *testing.T) {
+	moldFS := fstest.MapFS{
+		".agents/skills/reviewing/SKILL.md": &fstest.MapFile{Data: []byte("# Reviewing")},
+		".codex/agents/reviewer.toml":       &fstest.MapFile{Data: []byte(`name = "reviewer"`)},
+		".codex/config.toml":                &fstest.MapFile{Data: []byte(`model = "gpt-5"`)},
+		".git/config":                       &fstest.MapFile{Data: []byte("[core]")},
+		".idea/workspace.xml":               &fstest.MapFile{Data: []byte("<project/>")},
+	}
+
+	resolved, err := ResolveFiles(nil, moldFS)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := make(map[string]string, len(resolved))
+	for _, rf := range resolved {
+		got[rf.SrcPath] = rf.DestPath
+	}
+
+	want := map[string]string{
+		".agents/skills/reviewing/SKILL.md": ".agents/skills/reviewing/SKILL.md",
+		".codex/agents/reviewer.toml":       ".codex/agents/reviewer.toml",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("resolved files = %v, want %v", got, want)
+	}
+	for src, dest := range want {
+		if got[src] != dest {
+			t.Errorf("%s: destination = %q, want %q", src, got[src], dest)
+		}
+	}
+}
+
+func TestResolveFiles_StringOutputExcludesNativeCodexDirectories(t *testing.T) {
+	moldFS := fstest.MapFS{
+		"skills/reviewing/SKILL.md":         &fstest.MapFile{Data: []byte("# Reviewing")},
+		".agents/skills/reviewing/SKILL.md": &fstest.MapFile{Data: []byte("# Native reviewing")},
+		".codex/agents/reviewer.toml":       &fstest.MapFile{Data: []byte(`name = "reviewer"`)},
+	}
+
+	resolved, err := ResolveFiles(".claude", moldFS)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resolved) != 1 {
+		t.Fatalf("resolved files = %v, want only the non-hidden skills directory", resolved)
+	}
+	if resolved[0].DestPath != ".claude/skills/reviewing/SKILL.md" {
+		t.Errorf("destination = %q, want .claude/skills/reviewing/SKILL.md", resolved[0].DestPath)
+	}
+}
+
 func TestResolveFiles_MapOutput(t *testing.T) {
 	moldFS := fstest.MapFS{
 		"commands/hello.md": &fstest.MapFile{Data: []byte("hello")},

--- a/pkg/mold/temper_test.go
+++ b/pkg/mold/temper_test.go
@@ -410,12 +410,18 @@ output:
 		"skills/kots-skill/SKILL.md": &fstest.MapFile{Data: []byte(
 			"# KOTS\nUse `{{repl ConfigOption \"x\"}}` for KOTS config.\n",
 		)},
+		"skills/custom-agent.toml": &fstest.MapFile{Data: []byte(
+			`developer_instructions = "{{if}}"`,
+		)},
 	}
 
 	result := Temper(fsys)
 
 	for _, d := range result.Errors() {
 		if d.File == "skills/helm-skill/SKILL.md" || d.File == "skills/kots-skill/SKILL.md" {
+			t.Errorf("should not validate template syntax on process:false file %s: %s", d.File, d.Message)
+		}
+		if d.File == "skills/custom-agent.toml" {
 			t.Errorf("should not validate template syntax on process:false file %s: %s", d.File, d.Message)
 		}
 	}
@@ -458,6 +464,37 @@ output:
 	}
 	if !found {
 		t.Error("expected error referencing commands/broken.md")
+	}
+}
+
+func TestTemper_ValidatesNativeCodexAgentTemplates(t *testing.T) {
+	fsys := fstest.MapFS{
+		"mold.yaml": &fstest.MapFile{Data: []byte(`
+apiVersion: v1
+kind: mold
+name: codex-agents
+version: 1.0.0
+`)},
+		".codex/agents/reviewer.toml": &fstest.MapFile{Data: []byte(`
+name = "reviewer"
+description = "Reviews changes."
+developer_instructions = "{{if}}missing condition{{end}}"
+`)},
+	}
+
+	result := Temper(fsys)
+
+	if !result.HasErrors() {
+		t.Fatal("expected template syntax error for native Codex custom agent")
+	}
+	found := false
+	for _, d := range result.Errors() {
+		if d.File == ".codex/agents/reviewer.toml" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected error referencing .codex/agents/reviewer.toml; got %v", result.Errors())
 	}
 }
 

--- a/pkg/mold/validate.go
+++ b/pkg/mold/validate.go
@@ -632,7 +632,7 @@ func temperMold(fsys fs.FS, result *TemperResult) {
 	// Validate flux schema consistency
 	temperFluxSchema(fsys, m.Flux, result)
 
-	// Validate template syntax only for output-manifest files
+	// Validate template syntax for files cast will process.
 	outputFiles := resolveOutputPaths(flux["output"], fsys)
 	validateTemplates(fsys, outputFiles, result)
 }
@@ -763,17 +763,19 @@ func temperFluxSchema(fsys fs.FS, manifestFlux []FluxVar, result *TemperResult) 
 	}
 }
 
-// validateTemplates parses .md files through Go text/template to catch syntax errors.
-// When allowedPaths is non-nil, only files in that set are validated.
+// validateTemplates parses files that cast will process through Go
+// text/template to catch syntax errors. When allowedPaths is non-nil, only
+// files in that set are validated, regardless of extension.
 // resolveOutputPaths returns the set of source paths from the output manifest
 // that will be template-processed at cast time. Files in `process: false`
 // mappings are copied as-is and therefore must not be subject to Go template
 // syntax validation (they may legitimately contain `{{` from Helm/KOTS/Jinja).
-// If output is nil (identity mode), all .md files are considered in scope.
+// If output resolution fails and allowedPaths is nil, validation falls back to
+// markdown files to preserve the legacy best-effort behavior.
 func resolveOutputPaths(output any, fsys fs.FS) map[string]bool {
 	resolved, err := ResolveFiles(output, fsys)
 	if err != nil {
-		return nil // nil means "validate all" as fallback
+		return nil // nil selects the legacy markdown-only fallback
 	}
 	paths := make(map[string]bool, len(resolved))
 	for _, rf := range resolved {
@@ -793,15 +795,15 @@ func validateTemplates(fsys fs.FS, allowedPaths map[string]bool, result *TemperR
 		if d.IsDir() {
 			return nil
 		}
-		if filepath.Ext(path) != ".md" {
-			return nil
-		}
 		// Skip manifest files
 		if path == "mold.yaml" || path == "ingot.yaml" {
 			return nil
 		}
-		// If allowedPaths is set, only validate files in scope
-		if allowedPaths != nil && !allowedPaths[path] {
+		if allowedPaths == nil {
+			if filepath.Ext(path) != ".md" {
+				return nil
+			}
+		} else if !allowedPaths[path] {
 			return nil
 		}
 

--- a/testdata/agent_targets/ore/blanks/codex-agents/example.toml
+++ b/testdata/agent_targets/ore/blanks/codex-agents/example.toml
@@ -1,0 +1,7 @@
+name = "example"
+description = "Example custom agent rendered for {{ .current_target }}."
+developer_instructions = """
+Work only on the bounded task delegated by the parent agent.
+Return concise findings with concrete file references.
+"""
+sandbox_mode = "read-only"

--- a/testdata/agent_targets/ore/blanks/skills/example/SKILL.md
+++ b/testdata/agent_targets/ore/blanks/skills/example/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: example
+description: Demonstrates one Agent Skill rendered for Claude and Codex.
+---
+
+# Example skill
+
+Follow the consuming project's instructions and return a concise result.

--- a/testdata/agent_targets/ore/flux.schema.yaml
+++ b/testdata/agent_targets/ore/flux.schema.yaml
@@ -6,4 +6,4 @@
 - name: targets
   type: list
   description: "Which agent surfaces to render for"
-  default: '["claude", "opencode"]'
+  default: '["claude", "opencode", "codex"]'

--- a/testdata/agent_targets/ore/flux.yaml
+++ b/testdata/agent_targets/ore/flux.yaml
@@ -2,6 +2,7 @@ enabled: true
 targets:
   - claude
   - opencode
+  - codex
 
 output:
   blanks/AGENTS.md: AGENTS.md
@@ -12,3 +13,10 @@ output:
     - dest: .opencode/agents
       set:
         current_target: opencode
+  blanks/codex-agents:
+    dest: .codex/agents
+    set:
+      current_target: codex
+  blanks/skills:
+    - .claude/skills
+    - .agents/skills

--- a/testdata/agent_targets/ore/ore.yaml
+++ b/testdata/agent_targets/ore/ore.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ore
 name: agent_targets
 version: 0.1.0
-description: "Multi-target rendering for Claude and OpenCode agent surfaces"
+description: "Multi-target rendering for Claude, OpenCode, and Codex agent surfaces"


### PR DESCRIPTION
## Summary

Add first-class support for packaging, installing, and validating Codex Agent Skills and custom agents. Ailloy now recognizes Codex's native project and user layouts while preserving its tool-agnostic output mapping model.

## Changes

- Preserve `.agents/skills/` and `.codex/agents/` when casting native-layout molds without an `output:` mapping.
- Support both project-local and `--global` installation into Codex's native destinations.
- Discover repository-scoped `.agents/skills` directories, nested `AGENTS.md` files, and project custom agents during `assay --platform codex`.
- Validate required Agent Skill YAML frontmatter and Codex custom-agent TOML fields.
- Reject instruction-file symlinks that escape the project root.
- Extend the multi-target ore fixture with Codex agents and portable Agent Skills.
- Document Codex authoring, installation, validation, native layouts, and multi-platform packages as first-class Ailloy workflows.
- Update `features.md` with the new user-facing behavior.

## Related Issue

The feature issue will be filed separately.

## Testing

- `go test -race ./...`
- `go vet ./...`
- `go build ./...`
- `golangci-lint run`
- `gofmt -l .`
- `git diff --check`

## UAT

1. Create a mold containing `.agents/skills/reviewing/SKILL.md` and `.codex/agents/reviewer.toml` with no `output:` mapping.
2. Run `ailloy cast <mold>` and verify both files are rendered into the current project's native Codex paths.
3. Run `ailloy cast <mold> --global` and verify they are rendered under `~/.agents/skills/` and `~/.codex/agents/`.
4. Run `ailloy assay --platform codex` and verify valid skills and agents pass.
5. Remove a required skill or agent field and verify assay reports an error.

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project style
- [x] I have added tests
- [x] I have updated documentation
- [x] My commits have DCO sign-off (`git commit -s`)
